### PR TITLE
Add leadership-layer playbooks for Director, CoS, and TPM roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,114 @@
 # Engineering Playbooks
 
-Operational frameworks from production engineering work across payments, platform, and compliance contexts. Each document reflects decisions made in real systems, not hypothetical best practices.
+Operational and leadership frameworks from production engineering work across payments, platform, and compliance contexts. Each document reflects decisions made in real systems, not hypothetical best practices. Organized by the leadership domain each framework addresses.
 
-## Contents
+## Org Design & Strategy
 
-### Disaster Recovery
-**[fire-drill-template.md](disaster-recovery/fire-drill-template.md)**
-Tabletop exercise format for stress-testing DR posture and incident management protocols. Covers scenario sequencing (catastrophic failure first), participant structure, pre/post checklists, and what to watch for. Built from exercises run at ActBlue to validate payment continuity under failure scenarios.
+Frameworks for how a Director or Head of Engineering structures the organization, sets technical direction, and makes investment decisions.
 
-### Incident Management
-**[on-call-restructuring-framework.md](incident-management/on-call-restructuring-framework.md)**
+**[org-design/team-topology-framework.md](org-design/team-topology-framework.md)**
+How to design and evolve engineering org structure using the four team types (stream-aligned, platform, enabling, complicated-subsystem). Covers cognitive load thresholds, the Inverse Conway Maneuver, reorg execution, and post-reorg metrics. Grounded in real reorg patterns from high-growth platforms.
+
+**[metrics/engineering-health-scorecard.md](metrics/engineering-health-scorecard.md)**
+How to build a leadership-facing engineering health dashboard across four domains: delivery (DORA), quality (SLO attainment, defect escape rate), reliability (MTTR, incident frequency), and team health (on-call load, lead time). Covers instrumentation, target-setting, QBR narrative, and what not to put in front of executives.
+
+**[strategy/technical-strategy-template.md](strategy/technical-strategy-template.md)**
+Full skeleton and guidance for a 1–3 year technical strategy document: current state assessment, target state vision, gap analysis, investment roadmap (3-horizon), and success metrics. Includes communication format guidance for engineers, executives, and board audiences.
+
+**[strategy/build-vs-buy-framework.md](strategy/build-vs-buy-framework.md)**
+Three-way decision framework (build / buy / partner) across five scored dimensions: strategic differentiation, 5-year TCO, integration complexity, velocity impact, and vendor risk. Includes weighted scoring matrices by org type, a bias inventory, and three worked examples (feature flags, data pipeline, auth provider).
+
+**[strategy/ma-technical-due-diligence.md](strategy/ma-technical-due-diligence.md)**
+Engineering assessment framework for acquisitions. Covers 8 domains (architecture, technical debt, security, team, operational maturity, data practices, IP/licensing, integration complexity) with artifacts to request, interview questions, and red/yellow flags per domain. Includes a 2-week diligence sprint structure and executive report format.
+
+---
+
+## People Systems
+
+Frameworks for managing engineering talent: defining expectations clearly, running promotions fairly, and planning the headcount required to deliver on commitments.
+
+**[people/career-ladder-calibration.md](people/career-ladder-calibration.md)**
+How to build or inherit a career ladder and run calibration. Covers IC vs. manager track design, a four-axis level definition format (impact scope, decision autonomy, execution, collaboration), full L3–Staff worked definitions, calibration session structure, the three failure modes (grade inflation, recency bias, proximity bias), and a documented appeals process.
+
+**[people/headcount-capacity-planning.md](people/headcount-capacity-planning.md)**
+How to model HC needs, build the finance ask, and sequence hiring against roadmap risk. Covers the four capacity inputs, initiative-level modeling with worked examples, the one-page HC request format, backfill vs. new headcount criteria, common planning errors, and a 12-month rolling model template.
+
+---
+
+## Operating Cadence
+
+Frameworks for the Chief of Staff, Engineering function: how information flows, how decisions are made, how leadership time is spent, and how engineering communicates upward.
+
+**[operating-cadence/engineering-rhythm-of-business.md](operating-cadence/engineering-rhythm-of-business.md)**
+The weekly/monthly/quarterly/annual meeting cadence for a 50-engineer org. Covers agenda templates, decision authority (DACI), meeting health audit methodology, CoS responsibilities, and a sample weekly and monthly calendar.
+
+**[operating-cadence/engineering-okr-framework.md](operating-cadence/engineering-okr-framework.md)**
+How to set, cascade, and report engineering OKRs without the common failure modes (activity OKRs, unmeasurable aspirations). Covers the org → team cascade, grading, quarterly review format, and anti-patterns.
+
+**[operating-cadence/executive-communication-templates.md](operating-cadence/executive-communication-templates.md)**
+Five ready-to-use templates for written artifacts engineering leaders produce for executive and board audiences: engineering QBR, board engineering update, incident executive summary, major initiative status memo, and headcount request memo.
+
+**[operating-cadence/cross-functional-alignment-playbook.md](operating-cadence/cross-functional-alignment-playbook.md)**
+How engineering works with product, design, legal, finance, and sales. Covers decision authority models, SLAs, intake processes, and a RACI template for cross-functional program decisions. Opens with the three partnership failure modes.
+
+**[operating-cadence/escalation-framework.md](operating-cadence/escalation-framework.md)**
+When and how to escalate issues at the leadership layer (distinct from on-call escalation). Covers the three trigger categories (delivery risk, people risk, reputational/external risk), four escalation levels with response SLAs, the 5-sentence escalation memo format, and anti-patterns.
+
+---
+
+## Program Management
+
+Frameworks for TPMs and engineering leads running programs that span multiple teams or exceed a single team's ownership.
+
+**[program-management/program-planning-playbook.md](program-management/program-planning-playbook.md)**
+How to scope, launch, and run a multi-team technical program. Covers the program brief format, kickoff structure, milestone tracking (leading vs. lagging indicators), the weekly sync format, closure criteria, and common failure modes including the coordinator tax.
+
+**[program-management/raid-dependency-tracking.md](program-management/raid-dependency-tracking.md)**
+How to run a RAID log and dependency matrix. Covers risk register, assumption log, issue tracker, and dependency matrix formats with worked team-by-team examples. Includes the weekly RAID review ritual and health signals distinguishing live maintenance from theater.
+
+**[program-management/launch-readiness-checklist.md](program-management/launch-readiness-checklist.md)**
+Go/no-go gate framework for major releases. Eight readiness domains with owner-per-domain accountability, blocker vs. waiver decision process, launch day runbook (T-24h through T+24h), and post-launch review cadence.
+
+**[program-management/stakeholder-communication-templates.md](program-management/stakeholder-communication-templates.md)**
+Templates for weekly status reports, escalation memos, kickoff emails, milestone announcements, and stakeholder tier maps. Includes frequency calibration guidance and the three writing principles for upward communication.
+
+**[program-management/change-management-framework.md](program-management/change-management-framework.md)**
+How to manage technical, process, and organizational transitions. Covers a 5-phase change model, a resistance root cause framework, communication plan template, rollback criteria, and success metrics including a one-question pulse survey format.
+
+---
+
+## Operations
+
+Frameworks for running reliable engineering operations: on-call structure, incident readiness, CI/CD governance, and release management.
+
+**[incident-management/on-call-restructuring-framework.md](incident-management/on-call-restructuring-framework.md)**
 Framework for restructuring an on-call program that has outgrown its original design. Covers the IC/responder split, rotation structure, Wed-Wed cadence, metrics instrumentation via Jeli and Jira, and the rollout approach. Based on a restructuring that expanded the on-call program from a 5-person SRE team absorbing everything to per-team responder rotations backed by a 12-person incident commander rotation.
 
-### Compliance
-**[pci-dss-gap-analysis-checklist.md](compliance/pci-dss-gap-analysis-checklist.md)**
-Engineering-focused checklist for a PCI-DSS v4.0 gap analysis. Organized by all 12 requirement domains, with emphasis on the controls engineering teams are most likely to own or partially own. Includes a section on common gaps found in first assessments.
+**[disaster-recovery/fire-drill-template.md](disaster-recovery/fire-drill-template.md)**
+Tabletop exercise format for stress-testing DR posture and incident management protocols. Covers scenario sequencing (catastrophic failure first), participant structure, pre/post checklists, and what to watch for. Built from exercises run at ActBlue to validate payment continuity under failure scenarios.
 
-### CI/CD
-**[pipeline-governance-guide.md](ci-cd/pipeline-governance-guide.md)**
+**[ci-cd/pipeline-governance-guide.md](ci-cd/pipeline-governance-guide.md)**
 Governance model for CI/CD pipelines at scale: ownership, required gates, secret management, audit requirements, and change control. Covers the shared template model, DORA metric instrumentation, and the most common governance failures.
 
-### Experimentation
-**[launchdarkly-rollout-governance.md](experimentation/launchdarkly-rollout-governance.md)**
+**[experimentation/launchdarkly-rollout-governance.md](experimentation/launchdarkly-rollout-governance.md)**
 Flag lifecycle management for LaunchDarkly at scale. Covers flag taxonomy, naming conventions, rollout sequencing, targeting rules, experiment guardrails, and the cleanup policy that prevents flag debt from accumulating.
 
-### AI Adoption
-**[ai-adoption-readiness-framework.md](ai-adoption/ai-adoption-readiness-framework.md)**
+---
+
+## Compliance & Security
+
+**[compliance/pci-dss-gap-analysis-checklist.md](compliance/pci-dss-gap-analysis-checklist.md)**
+Engineering-focused checklist for a PCI-DSS v4.0 gap analysis. Organized by all 12 requirement domains, with emphasis on the controls engineering teams are most likely to own or partially own. Includes a section on common gaps found in first assessments.
+
+---
+
+## Technology Adoption
+
+**[ai-adoption/ai-adoption-readiness-framework.md](ai-adoption/ai-adoption-readiness-framework.md)**
 Framework for rolling out AI-assisted development tools (GitHub Copilot, Claude, Claude Code, Cursor) across engineering organizations. Covers a four-stage IC fluency rubric, role-differentiated use cases (IC vs. manager), task classification by risk level, a three-tier observability model, and a phased gate model that sequences access to higher-risk workflows on demonstrated readiness. Developed across two production rollouts (ActBlue 2024–2025, CTA 2025–2026). Includes a worked example and rollback triggers.
+
+---
 
 ## Context
 
-These frameworks were developed and applied across high-volume, regulated platforms including a payments processor handling 1M+ transactions/day under PCI-DSS. They are written to be adapted, not followed verbatim. The right answer for your system depends on your scale, team structure, and constraints.
+These frameworks were developed and applied across high-volume, regulated platforms including a payments processor handling 1M+ transactions/day under PCI-DSS. They span the full scope of engineering leadership: from org design and technical strategy at the director level, to operating cadence and executive communication at the chief-of-staff level, to cross-team program delivery at the TPM level. They are written to be adapted, not followed verbatim. The right answer for your system depends on your scale, team structure, and constraints.

--- a/ai-adoption/ai-adoption-readiness-framework.md
+++ b/ai-adoption/ai-adoption-readiness-framework.md
@@ -1,5 +1,7 @@
 # AI Adoption Readiness Framework (AARF)
 
+> **Leadership context:** AI tooling adoption is a capability investment with a measurable ROI — and a risk surface if left ungoverned. The engineering leader's job is not to decide whether to adopt AI tools (that decision is effectively made), but to structure the rollout so that productivity gains are captured, quality does not regress, and the org does not develop a dependency on a tool no one fully understands. This framework treats adoption as a phased program with gates, not a one-time rollout.
+
 > A practitioner's guide to rolling out AI-assisted development tools in engineering organizations — designed to accelerate leverage while preventing engineers from outsourcing judgment to the tool.
 
 **Author:** Mike Brown  

--- a/ci-cd/pipeline-governance-guide.md
+++ b/ci-cd/pipeline-governance-guide.md
@@ -1,5 +1,7 @@
 # CI/CD Pipeline Governance Guide
 
+> **Leadership context:** Pipeline governance is a delivery confidence problem, not a DevOps tooling problem. Without it, the org cannot answer basic questions that engineering leadership needs answered: what changed, who approved it, and could it have caused this incident? DORA metrics — the primary lens for executive-level delivery reporting — are only credible when the pipeline enforces the gates that make them meaningful.
+
 ## Purpose
 
 This guide covers the decisions and controls that determine whether a CI/CD pipeline is trustworthy at scale. It is written for engineering orgs that have pipelines running but have not formalized the rules around who can change them, what gates are required, and how to audit what ran.

--- a/compliance/pci-dss-gap-analysis-checklist.md
+++ b/compliance/pci-dss-gap-analysis-checklist.md
@@ -1,5 +1,7 @@
 # PCI-DSS Gap Analysis Checklist
 
+> **Leadership context:** PCI-DSS compliance is not a legal checkbox — it is a trust prerequisite for any business that processes payments. For engineering leadership, the gap analysis is the artifact that translates compliance requirements into a prioritized engineering workplan. Arriving at a QSA assessment without having done this work first is expensive: remediation timelines measured in months, potential assessment failure, and the reputational cost of delayed card-brand certifications.
+
 ## Purpose
 
 This checklist supports an initial gap analysis against PCI-DSS v4.0 requirements for engineering teams operating in or adjacent to the cardholder data environment (CDE). It is not a substitute for a formal QSA assessment, but it is the right starting point before one: it surfaces the gaps that are fixable before the auditor arrives and identifies the ones that require longer remediation timelines.

--- a/disaster-recovery/fire-drill-template.md
+++ b/disaster-recovery/fire-drill-template.md
@@ -1,5 +1,7 @@
 # Disaster Recovery Fire Drill Template
 
+> **Leadership context:** Untested DR plans are a liability, not an asset. Boards and enterprise customers increasingly ask for evidence of DR validation — a tabletop exercise log is the minimum viable answer. More importantly, fire drills surface the assumptions baked into recovery plans before an actual incident reveals them at cost: undocumented steps, single-person knowledge, and RTO commitments that no one has ever actually validated.
+
 ## Purpose
 
 This template formalizes the tabletop exercise format used to stress-test disaster recovery posture and incident management protocols before a real event forces the issue. The goal is to surface gaps in failover readiness, standardization debt, and coordination assumptions while the cost of finding them is low.

--- a/experimentation/launchdarkly-rollout-governance.md
+++ b/experimentation/launchdarkly-rollout-governance.md
@@ -1,5 +1,7 @@
 # LaunchDarkly Rollout Governance
 
+> **Leadership context:** Feature flags are the primary mechanism for decoupling deployment from release — which is what allows an engineering org to ship continuously without betting the business on each deploy. The governance question is not whether to use flags, but whether they remain a controlled instrument or become hidden complexity that slows delivery, obscures system behavior, and accumulates technical debt no one is willing to clean up.
+
 ## Purpose
 
 Feature flags without governance become permanent conditionals that no one understands and no one removes. This guide covers the policies and practices that keep a LaunchDarkly implementation useful over time: flag naming, lifecycle management, targeting rules, rollout sequencing, and the cleanup process that prevents flag debt from accumulating.

--- a/incident-management/on-call-restructuring-framework.md
+++ b/incident-management/on-call-restructuring-framework.md
@@ -1,5 +1,7 @@
 # On-Call Restructuring Framework
 
+> **Leadership context:** On-call structure is a talent and delivery risk, not just an ops concern. Unsustainable rotation load drives attrition among your most experienced engineers, increases incident duration, and degrades the reliability signal that leadership depends on for investment decisions. A well-designed on-call program is an argument for trust — it demonstrates that the org can absorb failure without heroics.
+
 ## Problem Statement
 
 A common failure mode in on-call programs: a small team gets paged for everything, regardless of who actually owns the problem or can fix it. Alerts are not standardized, so some issues surface only when an engineer notices something is wrong, not when a monitor fires. There is no mechanism for recording incident start and end times, so the org has no data on frequency, duration, or trend.

--- a/metrics/engineering-health-scorecard.md
+++ b/metrics/engineering-health-scorecard.md
@@ -1,0 +1,312 @@
+# Engineering Health Scorecard
+
+## Leadership Context
+
+A Director or Head of Engineering who cannot quantify the health of the engineering org is dependent on narratives that are impossible to validate and easy to challenge. In a QBR, a board meeting, or an M&A diligence session, "the team is shipping fast and quality is high" without supporting data is not a credible claim — it is an assertion. The engineering health scorecard converts that assertion into a structured, defensible position: here are the four domains we measure, here are our targets, here is where we are, here is the trend, and here is who owns each number.
+
+This is not a dashboard for engineers. Engineers need granular telemetry. The health scorecard is a leadership communication artifact: 8–12 metrics, organized by domain, that answer the questions a non-technical executive will ask about engineering capability, reliability, and sustainability.
+
+---
+
+## When to Use This
+
+| Trigger | What the scorecard provides |
+|---------|-----------------------------|
+| New Director/Head of Engineering taking over | Establishes a baseline and surfaces the highest-leverage problems in the first 90 days |
+| QBR or board update on engineering | Structured narrative that connects engineering activity to business outcomes |
+| Headcount justification | Quantified evidence that the team is at capacity or that a specific domain is under-resourced |
+| M&A technical diligence | Engineering maturity signal for acquirers or investors; shows the org has instrumented itself |
+| Engineering leadership performance review | Gives the business a shared language for evaluating the engineering function |
+
+Do not build a scorecard reactively — after a major incident, a missed launch, or a performance conversation with the CTO. Built reactively, the scorecard looks like a cover story. Built proactively and maintained consistently, it is a credibility asset.
+
+---
+
+## The Four Domains
+
+### Domain 1: Delivery (DORA Metrics)
+
+Delivery metrics measure how fast and reliably the team ships. They come from the DORA research program (Accelerate State of DevOps Report) and have been validated across thousands of engineering organizations as predictors of organizational performance.
+
+**Deployment Frequency**
+
+How often the team deploys to production. Not "how often the team commits code" or "how often a release branch is cut." Production deploys, per team, per week.
+
+- Elite: Multiple per day
+- High: Once per day to once per week
+- Medium: Once per week to once per month
+- Low: Less than once per month
+
+*How to instrument:* Tag production deployment events in your CI/CD platform. GitHub Actions: filter workflow runs by environment = production. CircleCI: filter by context. Datadog CI Visibility can aggregate this across pipelines. For Jira-tracked releases: create a release event type and query by closed date.
+
+**Lead Time for Change**
+
+Time from first commit on a branch to that commit running in production. Measures the efficiency of the full delivery pipeline.
+
+- Elite: Less than 1 hour
+- High: 1 day to 1 week
+- Medium: 1 week to 1 month
+- Low: More than 1 month
+
+*How to instrument:* Git commit timestamp → production deploy timestamp. LinearB, Jellyfish, and Swarmia automate this by connecting your Git provider to your deployment events. Manual proxy: Jira issue creation date to production deploy date (less precise but works without additional tooling).
+
+**Change Failure Rate**
+
+Percentage of production deployments that require a hotfix, rollback, or immediate remediation. This is the quality gate on delivery speed — high deployment frequency with high change failure rate is not elite performance.
+
+- Elite: 0–5%
+- High: 5–10%
+- Medium: 10–15%
+- Low: More than 15%
+
+*How to instrument:* Tag incidents or hotfixes that are causally linked to a deployment event. PagerDuty and Jeli both support incident tagging; the tag needs to connect to a deploy event. This is the hardest DORA metric to instrument cleanly — it requires discipline about incident classification.
+
+**Time to Restore Service (MTTR)**
+
+How long it takes to restore normal service after a production failure. Measures incident response effectiveness.
+
+- Elite: Less than 1 hour
+- High: Less than 1 day
+- Medium: 1 day to 1 week
+- Low: More than 1 week
+
+*How to instrument:* Jeli tracks incident open time and resolution time. PagerDuty incident duration is a proxy but conflates acknowledgment with resolution. For a clean MTTR, define resolution as "service restored to SLO" not "incident acknowledged."
+
+---
+
+### Domain 2: Quality
+
+Quality metrics measure the rate at which defects escape into production and the org's ability to maintain the reliability contracts it has made with users.
+
+**SLO Attainment**
+
+Percentage of rolling 30-day windows where each published SLO is met. This is the most customer-facing quality signal.
+
+*Target:* Depends on what you have committed to. If you have not set SLOs yet, start there before building this scorecard. A reasonable starting target for a B2B SaaS platform: 99.5% availability SLO, measured per service tier.
+
+*How to instrument:* Datadog SLO tracking, New Relic SLAs, or Honeycomb. Define SLOs in code (Terraform for Datadog SLOs is ideal for audit purposes). Report: number of SLOs in breach + trending direction, not just a pass/fail.
+
+**Defect Escape Rate**
+
+Percentage of bugs found in production versus bugs found in pre-production. A high defect escape rate means the test suite and staging environment are not catching what they should.
+
+- Target: <20% of reported defects first detected in production
+- Warning threshold: >35%
+
+*How to instrument:* Jira bug label + environment field at time of creation. Requires discipline about where bugs are logged. If your team logs all bugs as customer-reported issues after the fact, the data will be noisy — establish a classification convention first.
+
+**P0/P1 Incident Count (Quality-Attributed)**
+
+Count of severity 0 and severity 1 incidents where root cause is attributable to a code defect (as opposed to infrastructure failure, dependency failure, or capacity). This separates engineering quality failures from operational failures.
+
+*Target:* Set based on your 90-day baseline; target 20% reduction quarter-over-quarter until you reach a stable floor.
+
+*How to instrument:* Jeli or PagerDuty incident classification + root cause tag. Requires the postmortem process to consistently classify root cause.
+
+---
+
+### Domain 3: Reliability
+
+Reliability metrics measure how the system behaves under failure conditions and whether operational load is sustainable for the team carrying it.
+
+**Incident Frequency**
+
+Total number of incidents per time period, segmented by severity tier. Frequency trending up is a leading indicator of systemic debt accumulating faster than it is being addressed.
+
+*Segment by:* P0/P1 (customer-impacting), P2 (degraded service, users affected), P3 (internal/latent).
+
+*How to instrument:* PagerDuty incident count by severity. Requires consistent severity classification at incident open time — not after the fact.
+
+**MTTR (see also Delivery domain)**
+
+MTTR appears in both delivery and reliability because it measures different things depending on the context. In delivery, it measures response to deployment-caused failures. In reliability, it measures response to all production failures. Track both separately.
+
+**On-Call Incident Load Per Engineer**
+
+Average number of pages per on-call engineer per week, by severity tier. This is the most direct measure of on-call sustainability and a leading indicator of engineer burnout and attrition risk.
+
+- Target: <3 P2+ pages per engineer per week on average
+- Warning threshold: >6 P2+ pages per engineer per week (sustained over 4+ weeks)
+
+*How to instrument:* PagerDuty on-call report → divide total pages by number of engineers in the rotation. Report the distribution, not just the average — one engineer absorbing 80% of pages while others see none is a structural problem the average hides.
+
+**Mean Time Between Failures (MTBF) for Critical Services**
+
+How long your most critical services run without a customer-impacting incident. For services with SLAs, MTBF is an input to the reliability covenant.
+
+*How to instrument:* Calculated from PagerDuty or Jeli incident history. For each critical service, time between consecutive P0/P1 incidents. Track trend, not absolute value.
+
+---
+
+### Domain 4: Team Health
+
+Team health metrics are the leading indicators for the lagging indicators in the other three domains. Delivery and reliability degrade when teams are overloaded, undersupported, or operating with unclear ownership.
+
+**Lead-to-Cycle Time Ratio**
+
+Cycle time is time spent actively working on a ticket. Lead time is end-to-end time from creation to done. A high ratio (lead time >> cycle time) indicates that work is spending most of its time waiting: waiting for review, waiting for dependencies, waiting in a queue, waiting for a decision.
+
+- Healthy ratio: Lead time < 3× cycle time
+- Warning: Lead time > 5× cycle time
+
+*How to instrument:* Jira time-in-status reports. LinearB and Jellyfish calculate this automatically from Jira + Git data. Cycle time = time in "In Progress"; lead time = time from "To Do" to "Done."
+
+**Sprint Capacity on Unplanned Work**
+
+Percentage of sprint capacity consumed by work that was not planned at sprint start: reactive incidents, urgent requests, context switches from leadership.
+
+- Target: <25%
+- Warning threshold: >40% (sustained over two or more sprints)
+
+*How to instrument:* Jira sprint report — tickets added after sprint start versus at sprint start. Requires consistent sprint planning discipline. If your team does not use sprints, use a weekly capacity tracking mechanism instead.
+
+**On-Call Load** (see Reliability domain — the same metric appears here as a team health signal)
+
+**Voluntary Attrition (Engineering)**
+
+Rolling 12-month voluntary attrition rate for engineering roles. Engineering attrition is expensive: recruiting, onboarding, and knowledge transfer costs are typically 0.5–1.5× annual salary per departure. High attrition correlates with on-call overload, poor manager effectiveness, and unclear career growth.
+
+- Target: <12% annually
+- Warning: >20% annually
+
+*How to instrument:* HRIS data. Distinguish voluntary from involuntary; include contractors if they are a significant share of engineering capacity.
+
+---
+
+## Sample Scorecard Table Format
+
+Use this format for QBR slides, board decks, and leadership reports. One table per domain. Color-coding (green/yellow/red) should be applied to the Trend column, not the Current column — a metric that is below target but improving is a better story than one that is at target but declining.
+
+**Delivery**
+
+| Metric | Target | Current | Trend | Owner |
+|--------|--------|---------|-------|-------|
+| Deployment frequency (prod) | ≥1/day | 3.2/week | ↑ | VP Eng |
+| Lead time for change | <3 days | 4.1 days | ↓ | Eng Mgr, Platform |
+| Change failure rate | <8% | 6.2% | ↔ | Eng Mgr, QA |
+| MTTR (all incidents) | <2 hours | 1.8 hours | ↑ | SRE Lead |
+
+**Quality**
+
+| Metric | Target | Current | Trend | Owner |
+|--------|--------|---------|-------|-------|
+| SLO attainment (avg, all services) | ≥99.5% | 99.3% | ↓ | SRE Lead |
+| Defect escape rate | <20% | 28% | ↔ | Eng Mgr, QA |
+| P0/P1 incidents (code-attributed) | ≤2/month | 3/month | ↑ | VP Eng |
+
+**Reliability**
+
+| Metric | Target | Current | Trend | Owner |
+|--------|--------|---------|-------|-------|
+| P0/P1 incident count | ≤2/month | 3/month | ↑ | SRE Lead |
+| On-call pages/engineer/week (P2+) | <3 | 4.8 | ↓ | Eng Mgr, on-call rotation |
+| MTBF (critical services, days) | ≥30 days | 18 days | ↓ | SRE Lead |
+
+**Team Health**
+
+| Metric | Target | Current | Trend | Owner |
+|--------|--------|---------|-------|-------|
+| Lead-to-cycle time ratio | <3× | 4.1× | ↔ | Eng Mgr |
+| Sprint capacity on unplanned work | <25% | 38% | ↓ | Eng Mgr |
+| Engineering attrition (12-month) | <12% | 9% | ↑ | Director Eng |
+
+---
+
+## How to Set Targets
+
+The most common mistake in scorecard setup is adopting DORA industry benchmarks as targets before you have a baseline. "Elite performer" thresholds are aspirational; using them as Q1 targets for an org that has never measured itself sets up the scorecard as a failure narrative from day one.
+
+**The right sequence:**
+
+1. **Instrument first.** Get 90 days of data before you set targets. You cannot set a credible target for deployment frequency if you do not know what your current deployment frequency is.
+
+2. **Set 90-day improvement targets, not industry benchmarks.** "We will improve deployment frequency from 3/week to 5/week" is a credible target. "We will be an elite performer by Q3" is a slogan.
+
+3. **Anchor on the trajectory, not the absolute value.** A metric that is below benchmark but improving every quarter is a better leadership story than one that hit benchmark once and is now flat.
+
+4. **Re-baseline annually.** As the org matures, benchmarks should tighten. Do not leave targets unchanged for more than 12 months — they become wallpaper.
+
+5. **Define the instrumentation for each metric before the scorecard goes to leadership.** A metric with an undefined data source is a liability; the first time someone asks "how did you calculate that" and the answer is "we estimated," the scorecard loses credibility.
+
+---
+
+## Leadership Dashboard Narrative
+
+Metrics without narrative are data. At a QBR or board meeting, you need to be able to explain each metric in two sentences: what it measures and what it means for the business.
+
+**Deployment Frequency:**
+"We ship to production an average of 3.2 times per week, up from 1.8 times per week six months ago. This means we can respond to user feedback and fix production issues faster — it also means our deployment process has become reliable enough to run more frequently without increasing risk."
+
+**SLO Attainment:**
+"Our average SLO attainment across services is 99.3%, slightly below our 99.5% target. The underperformance is concentrated in two services — our search API and our notification pipeline — and we have a roadmap item in H2 to address the root cause for each."
+
+**On-Call Load:**
+"Our engineers are averaging 4.8 pages per on-call week at P2 and above, above our 3-page target. Sustained above 6, this becomes a retention risk. We are investing in alert rationalization and service reliability work in Q3 specifically to bring this number down — it is one of the primary quality-of-life signals we track."
+
+**Defect Escape Rate:**
+"28% of bugs are first detected in production, above our 20% target. This is a test coverage and staging fidelity problem. We are adding contract testing between two high-failure service pairs and expanding staging data representativeness as a Q3 priority."
+
+---
+
+## What NOT to Include
+
+A leadership scorecard that includes too many metrics is harder to act on than one with too few. Every metric on the scorecard should be actionable — if it drops, there is a known owner and a known response.
+
+**Metrics to exclude:**
+
+- **Lines of code / commit count:** Measures activity, not output. A team that refactors 10,000 lines of complex code into 1,000 clean lines has done more valuable work, by this metric, than the team that did.
+- **Story points completed:** Velocity is a sprint planning tool, not a performance metric. Story point inflation, scope change, and estimation variance make cross-team and cross-quarter comparisons meaningless.
+- **PR count:** Same problem as commit count. Optimizes for small PRs, not for impactful work.
+- **Test coverage percentage (as a standalone metric):** 80% coverage with tests that assert nothing meaningful is worse than 60% coverage with tests that catch real regressions. Track defect escape rate instead.
+- **Uptime percentage (without SLO context):** 99.9% uptime sounds good but tells you nothing about whether you met your commitments or whether the 0.1% downtime happened at peak user traffic.
+- **"Team happiness" survey scores as a primary metric:** Engagement surveys are useful inputs to a Director's understanding of team health, but they belong in manager-level conversations, not leadership scorecards where the audience does not have the context to interpret them.
+
+---
+
+## Cadence
+
+Different metrics belong at different review cadences. Reviewing everything weekly creates noise; reviewing everything quarterly means you miss slow degradation.
+
+**Weekly (engineering leadership)**
+
+- On-call incident count and severity distribution (PagerDuty weekly digest)
+- Active SLO breaches
+- Deployment frequency (trailing 7 days)
+- Sprint capacity on unplanned work (at sprint review)
+
+**Monthly (Director/VP-level review)**
+
+- Full scorecard review: all four domains
+- Trend analysis: is each metric improving, stable, or declining?
+- Owner check-in: every metric has an owner accountable for the trend
+- Update targets if a metric has been consistently above/below target for 60+ days
+
+**Quarterly (QBR / exec / board)**
+
+- Scorecard summary: current vs. target vs. prior quarter
+- Narrative for each domain: what happened, what we did about it, what comes next
+- Investment asks that are supported by scorecard data (e.g., "on-call load is at 4.8 pages/week; to get to target we need 2 additional SRE headcount in H2")
+- Rolling 12-month trend on attrition and team health
+
+**Annual (engineering planning)**
+
+- Re-baseline all targets
+- Review instrumentation: is each metric still measuring what it should?
+- Identify new metrics if the org has matured into a domain that was not previously measured
+- Archive metrics that are no longer decision-relevant
+
+---
+
+## Tooling Reference
+
+| Domain | Recommended Tool | Alternative | What to instrument |
+|--------|-----------------|-------------|--------------------|
+| Deployment frequency | LinearB, Jellyfish, Datadog CI | GitHub Actions workflow analytics | Production deploy events by team |
+| Lead time | LinearB, Jellyfish | Jira time-in-status | First commit to production deploy |
+| Change failure rate | PagerDuty + Jeli | Manual Jira classification | Incidents tagged to causative deploy |
+| MTTR | Jeli | PagerDuty incident duration | Incident open to service restored |
+| SLO attainment | Datadog SLOs | New Relic | SLO burn rate, rolling 30d |
+| Defect escape rate | Jira bug fields | Linear | Bug environment at first detection |
+| On-call load | PagerDuty | OpsGenie | Pages per engineer per week |
+| Cycle/lead time ratio | LinearB, Jira | Swarmia | Time in status per ticket type |
+| Attrition | HRIS (Workday, BambooHR) | HR reporting | Voluntary departure by role |

--- a/operating-cadence/cross-functional-alignment-playbook.md
+++ b/operating-cadence/cross-functional-alignment-playbook.md
@@ -1,0 +1,289 @@
+# Cross-Functional Alignment Playbook
+
+## Leadership Context
+
+Engineering organizations that cannot align effectively with product, design, legal, finance, and sales do not just deliver slower — they deliver the wrong things, at the wrong time, with last-minute surprises that erode trust with every function they depend on. Cross-functional alignment is not a soft skill; it is an operational capability that determines whether engineering can make and keep commitments. The cost of misalignment compounds: a legal review that starts three weeks too late delays a launch by a quarter; a sales commitment made without engineering input creates a customer expectation no one can meet; a finance model built on the wrong headcount assumptions generates budget fights mid-year. This playbook establishes the decision authorities, rituals, and interfaces that keep engineering in alignment with every function it touches.
+
+## When to Use This
+
+- A new engineering leader is onboarding and needs to understand how engineering relates to its cross-functional partners
+- A post-mortem on a missed launch or failed project reveals that coordination failure — not technical failure — was the root cause
+- Rapid organizational growth (above ~30 engineers or after a significant acquisition) is creating coordination failures that did not exist when the org was smaller
+- An engineering Chief of Staff or TPM is being asked to design or repair the org's cross-functional operating model
+
+---
+
+## The Three Partnership Failure Modes
+
+Most cross-functional coordination problems trace to one of three root causes. Diagnosing the right one before attempting a fix matters — the solutions are different.
+
+### Failure Mode 1: Too Much Gate-Keeping
+
+Engineering has installed reviews, approval processes, and technical requirements gates that slow down cross-functional partners without providing proportionate value. Legal cannot get a privacy review without a 10-page technical spec. Product cannot start design without engineering sign-off on whether something is feasible. Finance cannot get headcount cost estimates without a formal request.
+
+**Signal:** Cross-functional partners route around engineering, go directly to ICs without manager awareness, or stop including engineering in early planning because it creates more work than value.
+
+**Fix:** Audit every approval process engineering owns. For each one, ask: who benefits from this gate, what problem does it prevent, and is the prevention worth the delay it adds? Remove any gate that fails this test.
+
+### Failure Mode 2: Too Little Early Warning
+
+Engineering is not included in decisions until after they are made — product roadmap commitments made without capacity input, legal requirements surfaced in the final week of a project, sales deals closed on features that do not exist. Engineering is then asked to react to a fait accompli.
+
+**Signal:** Engineering leaders consistently describe being "surprised" by commitments, requirements, or decisions that were made without them.
+
+**Fix:** Define the earliest point at which engineering needs to be in the room for each type of decision. Build that into cross-functional processes, not as a gate, but as a standing invitation.
+
+### Failure Mode 3: No Shared Language for Priority
+
+Engineering and its partners are operating with different mental models of what is urgent, what is important, and what can wait. Product thinks "high priority" means this quarter. Engineering thinks it means this sprint. Legal thinks it means before signature. Finance thinks it means before end of fiscal year.
+
+**Signal:** Cross-functional escalations are frequent. Every stakeholder believes their request is the highest priority. Engineering feels constantly in triage mode.
+
+**Fix:** Establish a shared priority taxonomy (see RACI section) and enforce it consistently. When a cross-functional request arrives without a priority label, return it for classification before accepting it into the queue.
+
+---
+
+## Engineering × Product
+
+### Decision Authority Model
+
+The most durable source of engineering-product friction is ambiguity about who decides what. The following model, adapted from product management practice, has worked at companies ranging from ActBlue (mission-driven, low margin for error) to Capital One (regulated, compliance-heavy):
+
+| Decision type | Who decides | Who must be consulted | Who is informed |
+|---|---|---|---|
+| What problem to solve | Product | Engineering, Data | Design, Legal |
+| Whether to ship a feature | Product | Engineering (feasibility), Design (UX) | Engineering team |
+| How to build it (architecture) | Engineering | Product (constraints), Staff engineer | Product manager |
+| When it will ship | Engineering | Product (priority), Manager | Product, Stakeholders |
+| Whether to change scope mid-flight | Product + Engineering jointly | Design | Stakeholders |
+| Whether to accept technical debt to meet a deadline | Engineering manager | Product manager | Director |
+| Whether to deprecate a product capability | Product | Engineering (migration cost) | Legal, Support |
+
+"Engineering owns the when" is the principle with the highest leverage and the most friction. Product managers who believe they own the timeline, or who make external commitments about ship dates without engineering input, create the conditions for the delivery surprises that damage trust across the org. The fix is not to remove product's ability to advocate for dates — it is to establish that no date is a commitment until engineering has confirmed it.
+
+### Escalation Path
+
+When engineering and product cannot agree on priority, scope, or timeline:
+
+1. Manager-level conversation between engineering manager and product manager — most disagreements should resolve here
+2. If unresolved within 48 hours: Director-level conversation between engineering director and product director
+3. If unresolved within 48 hours: VP-level tiebreaker (VP Eng and CPO jointly, or escalated to CEO if both VPs cannot align)
+
+The escalation path should be explicitly known to both engineering managers and product managers. The failure mode is when disagreements fester for weeks without escalation because neither party wants to "make it a thing." Unresolved disagreements are always a thing; they just become a worse thing later.
+
+### The 3-Amigos Ritual
+
+For any feature that requires coordination between product, engineering, and design, the 3-amigos ritual establishes shared understanding before implementation begins.
+
+**What it is:** A 60-minute meeting between the product manager, engineering lead, and design lead, held after the design is far enough along to review but before engineering has started implementation.
+
+**What it covers:**
+- Product: What is the user problem this solves? What does success look like in measurable terms?
+- Engineering: What are the technical constraints? Are there edge cases the design does not account for? Is the implementation plan roughly correct?
+- Design: Are there UX implications of the technical approach? Are there design dependencies (component library, accessibility) that need to be in scope?
+
+**What it produces:** A shared written summary (one page or less) with: the agreed problem statement, the agreed success metric, any scope items that were explicitly excluded, and any open questions with owners.
+
+A 3-amigos session that produces no written artifact did not happen.
+
+---
+
+## Engineering × Design
+
+### Design Handoff SLA
+
+Unclear handoff between design and engineering is one of the highest-friction points in product development. The following handoff SLA defines what engineering needs from design before implementation begins, and what the timeline for receiving it is.
+
+**Engineering needs from design, 5 business days before implementation sprint:**
+- Final mockups in Figma (or equivalent) for all states: default, loading, error, empty, responsive breakpoints
+- Annotation of any behavior that is not visually obvious (hover states, animation timing, validation logic)
+- Confirmation from product that the design is approved for implementation
+- Component specification: which existing design system components are used; which new components need to be built
+
+**Engineering needs from design, 1 business day before handoff:**
+- Confirmation that all feedback from the last design review is incorporated
+- Written answer to: "Is there anything in this design that engineering should know but cannot see in the mockup?"
+
+**What engineering does not need from design before starting:**
+- Perfect pixel fidelity on every edge case — this is resolved in implementation review
+- Animations that are "nice to have" but not in scope for the initial release
+
+### Component Library Ownership
+
+A component library is owned jointly by design and engineering but with clear individual accountabilities:
+
+- **Design owns:** visual specification, accessibility requirements, usage guidelines, when to use which component
+- **Engineering owns:** implementation, test coverage, documentation in the component catalog, deprecation process for old components
+- **Joint ownership:** decisions about adding new components (both parties must agree that a new component is warranted vs. extending an existing one)
+
+When a product team wants to ship a feature that requires a new component the design system does not have, the process is: design proposes the component, engineering estimates the implementation cost, the component team reviews for fit, and a decision is made before the implementation sprint begins. Not during it.
+
+### When to Ship Without Perfect Design
+
+There are legitimate situations where the product needs to ship before the design is final. The criteria for this to be acceptable:
+
+- The product manager and engineering manager have both agreed, in writing, that the current state is acceptable for launch
+- The design gap is documented with a specific plan to address it (not "backlog") — ideally in the next sprint
+- The design gap does not create an accessibility issue or a material UX degradation for users
+- Legal and compliance are not impacted by the design gap
+
+"We'll fix it after launch" is only acceptable if the fix has a date attached and an owner named.
+
+---
+
+## Engineering × Legal
+
+### Standard Review Tracks
+
+Engineering works with legal on three categories of issues. Each has a different review lead time expectation.
+
+**Track 1: Privacy and data handling**
+Applicable when: a new feature collects, processes, or stores personal data; a new vendor will have access to personal data; a data retention policy is being changed; a new data-sharing arrangement is being established with a partner.
+
+Lead time needed: 10–15 business days for a standard privacy review.
+
+What legal needs from engineering to start: a data flow diagram showing what data is collected, where it is stored, who can access it, and how long it is retained.
+
+**Track 2: Intellectual property**
+Applicable when: engineering is incorporating open-source software with a new license type; engineering is creating code or models that the company intends to claim as IP; engineering is building on top of a third-party API in a way that the API terms of service may restrict.
+
+Lead time needed: 5–10 business days for a standard IP review.
+
+What legal needs from engineering to start: a description of the third-party software or API, the license or terms of service, and the proposed use.
+
+**Track 3: Compliance and regulatory**
+Applicable when: a feature touches a regulated domain (payments, healthcare, financial data, children's data); a new geographic market is being entered; an enterprise customer contract requires specific compliance certifications.
+
+Lead time needed: 15–30 business days for a standard compliance review. This is not negotiable — regulatory review has external dependencies.
+
+What legal needs from engineering to start: a product brief from the product manager, the relevant regulatory framework (GDPR, HIPAA, PCI DSS, etc.), and a technical description of the implementation approach.
+
+### Expedited Path Criteria
+
+Legal can provide an expedited review (5–7 business days) for standard track items if all of the following are true:
+- Engineering has provided a complete intake packet (not a verbal summary)
+- The feature is substantially similar to a previously reviewed feature
+- The legal question is bounded (not "is this compliant with GDPR?" but "does this retention policy comply with GDPR Article 17?")
+
+**What legal cannot review in 48 hours:**
+- Novel privacy architectures
+- Cross-border data transfer questions
+- Any contract that requires negotiation with a third party
+- Regulatory opinions in jurisdictions where outside counsel is required
+
+If engineering surfaces a legal requirement 48 hours before a launch date, the launch date moves, not the legal review. The escalation path is engineering director → CPO/CEO → legal leadership to confirm whether a risk acceptance decision is available. It sometimes is. But the default is: legal review that is not complete means the feature does not ship.
+
+---
+
+## Engineering × Finance
+
+### Headcount Model Handoff
+
+Finance operates on an annual headcount plan and often a quarterly re-forecast. Engineering's role in this process:
+
+**Annual plan (typically Q4 for the following year):**
+Engineering director and engineering managers submit a headcount plan by role, level, and team — not by name. Finance converts this to a budget number using their compensation models. The plan should include: current headcount, proposed adds by quarter, and the initiative or business outcome each role supports.
+
+**Quarterly re-forecast:**
+Finance will ask engineering to confirm or revise the headcount plan based on what has actually been hired, what roles are being added to the plan, and what roles are being removed. Engineering should treat this as an opportunity to surface capacity constraints that affect delivery commitments.
+
+**Headcount requests outside the plan:**
+Use the headcount request memo format in the [Executive Communication Templates](executive-communication-templates.md). These requests require: business case, cost, and risk of not hiring. They are reviewed by the VP Eng (or Director in smaller orgs) and typically require CFO or CEO approval if above a threshold.
+
+### Capitalized vs. Expensed Work (R&D Capitalization)
+
+This matters to finance and to the audit committee. Engineering leaders who understand the basics avoid surprises during audit cycles.
+
+**The rule (simplified from ASC 350-40):** Software development costs can be capitalized (treated as an asset on the balance sheet rather than an operating expense) once the project has reached the "application development stage" — after the preliminary project stage is complete and management has authorized funding. Costs in the planning phase are expensed.
+
+**In practice for engineering:** Work on new features and products that meet the capitalization criteria can be tracked as a capitalized asset. This affects gross margin and EBITDA. Finance will ask engineering to classify projects as capitalized or expensed and to track engineering time allocation accordingly.
+
+**What engineering needs to do:**
+- Work with finance to understand which projects are classified as capitalized development
+- Ensure engineering managers are tracking time allocation for capitalized projects (even a rough percentage split by engineer is usually sufficient for smaller orgs)
+- Surface project completions to finance — a capitalized project that has shipped should stop accruing capitalized costs
+
+Most engineering leaders never need to present this to a board. But engineering leaders who are involved in investor due diligence, who are building the financial model for a fundraise, or who work at a public company will encounter it. Understanding enough to ask the right questions is the goal.
+
+### Cost Center Reporting
+
+Engineering is typically a cost center — it does not generate revenue directly but supports the product that does. Finance will report engineering costs against budget on a monthly and quarterly basis. Engineering leaders should:
+
+- Know their run-rate cost (headcount loaded + tools + infrastructure), updated monthly
+- Know which costs are variable (cloud infrastructure scales with product usage) vs. fixed (headcount, tooling subscriptions)
+- Flag cost overruns before they appear in the finance report — finance should never surface a cost overrun to the CFO that engineering did not already know about and communicate
+
+---
+
+## Engineering × Sales
+
+### Feature Request Intake
+
+Sales will bring customer feature requests to engineering. Without a defined intake process, these requests land informally (in Slack, in a hallway conversation, in a customer call), are routed inconsistently, and create commitments that engineering did not agree to.
+
+**The intake process:**
+1. Sales logs feature requests in a shared system (Productboard, Jira, or equivalent) with: customer name, ARR of that customer, what the customer asked for, and what problem the customer is trying to solve.
+2. Product triages the request against the roadmap within 5 business days: is this on the roadmap, adjacent to something on the roadmap, or not in current plans?
+3. Product communicates the triage outcome to sales with a timeline expectation or a "not in plan" response.
+4. Engineering is not in the intake loop until product has triaged the request. Engineering does not receive feature requests directly from sales.
+
+The reason for this: engineering receiving feature requests directly from sales creates pressure on ICs that bypasses product prioritization. It also creates inconsistent commitments when ICs give informal timeline estimates to customer-facing teams.
+
+### Customer Commitment Process
+
+**Who can promise what:**
+- Sales can promise: features that are on the current quarter's roadmap, with "expected in Q[X]" framing (not an exact date)
+- Sales cannot promise: features that are not on the roadmap, specific release dates, or custom implementation timelines
+- Customer success can promise: standard SLA commitments defined by the product, existing feature roadmap items with product approval
+- Engineering leadership can promise to a customer: technical architecture decisions, security and compliance posture, escalation path for critical issues
+
+When a customer is asking for a commitment that sales cannot make, the escalation path is: sales → product (for roadmap commitments) or sales → engineering director (for technical or security commitments). This conversation happens before the customer is given any response.
+
+**The danger of informal commitments:**
+A sales engineer telling a customer "I think we can have that in 6 months" is a commitment in the customer's mind even if it is not in any contract. Engineering leaders who inherit customer expectation mismatches discover them at the worst time — when the customer is renewing, escalating, or churning. The fix is clear rules about who can say what to customers about engineering timelines.
+
+---
+
+## RACI Template: Cross-Functional Program Decisions
+
+Use this template when a cross-functional program involves decisions that need clarity on authority.
+
+**Instructions:** For each decision row, assign one person as Accountable (A) and one as Responsible (R). Multiple people can be Consulted (C) or Informed (I). If a cell is blank, that function is not involved in that decision.
+
+| Decision | Engineering | Product | Design | Legal | Finance | Sales | CEO/Exec |
+|---|---|---|---|---|---|---|---|
+| Launch date for a major feature | A/R | C | C | C | I | I | I |
+| Scope reduction to meet launch date | A (eng mgr) | A (PM) — joint | C | I | I | I | I |
+| New enterprise customer compliance requirement | R | C | I | A | I | C | I |
+| Price of new product tier | I | C | I | C | A | C | R |
+| External API contract with a vendor | R | C | I | A | C | I | I |
+| Headcount increase outside annual plan | R | I | I | I | C | I | A |
+| Emergency patch to a customer-facing bug | R | C | I | I | I | I | I |
+| Deprecating a product feature | C | A | C | C | I | R (customer impact) | I |
+
+**A (Accountable):** The buck stops here. This person makes the final call.
+**R (Responsible):** Does the work or drives the process.
+**C (Consulted):** Must be consulted before the decision is made.
+**I (Informed):** Told about the decision after it is made.
+
+When two functions are listed as A/R jointly, both must agree before the decision is finalized. Use this sparingly — shared accountability often means no accountability. Joint ownership only makes sense when both parties have a genuinely equal stake in the outcome and no tiebreaker mechanism exists.
+
+---
+
+## Alignment Health Check
+
+Run this check quarterly, either in the engineering leadership retrospective or as a standalone 30-minute conversation with the engineering director and cross-functional leads.
+
+**Five questions:**
+
+1. **Are there any cross-functional commitments engineering made in the last quarter that the other function was surprised by (positively or negatively)?** Surprises in either direction indicate that communication expectations are not calibrated.
+
+2. **Did any cross-functional request arrive too late for engineering to respond without a quality tradeoff?** If yes, trace back to where in the process the request should have arrived and fix the entry point.
+
+3. **Is there any function that engineering does not have a consistent 1:1 relationship with at the director level?** Informal alignment between ICs is not a substitute for leadership-level relationship-building.
+
+4. **Are there any decisions that were made in the last quarter that engineering should have been consulted on but was not?** This surfaces gate-keeping vs. exclusion failure modes.
+
+5. **Is there any decision that engineering is currently delaying because the accountability is unclear?** Name it and assign it before leaving the room.
+
+If the answer to all five questions is "no, nothing notable," either alignment is working well or the check-in is not surfacing real information. The tie-breaker is to ask each function's leader separately whether they have any friction with engineering. If the answers differ from what engineering leadership reported, the problem is information flow, not alignment.

--- a/operating-cadence/engineering-okr-framework.md
+++ b/operating-cadence/engineering-okr-framework.md
@@ -1,0 +1,304 @@
+# Engineering OKR Framework
+
+## Leadership Context
+
+OKRs are one of the most frequently adopted and most frequently broken planning tools in engineering organizations. When they work, they create a direct line from an IC's quarterly work to a company-level outcome, make accountability legible at every level of the org, and give engineering leaders a credible answer when executives ask "what is engineering doing and why does it matter?" When they fail — which is most of the time — they become a performance theater exercise that consumes three weeks of Q1 planning and is forgotten by April. This playbook covers the mechanics and judgment calls that determine which outcome you get.
+
+## When to Use This
+
+- Annual or quarterly planning cycle is underway and OKRs need to be set, refined, or re-anchored to company priorities
+- A new engineering leader is inheriting OKRs that no one owns, no one checks, and no one grades
+- Post-Q1 check-in reveals that OKRs were set but not reviewed — the "set and forget" failure mode is active
+- An executive or board member asks engineering leadership to explain how engineering work connects to company strategy
+
+---
+
+## The Two OKR Failure Modes
+
+Before writing a single OKR, name the two failure modes and check for them explicitly.
+
+### Failure Mode 1: Activity OKRs (We Will Ship X)
+
+Activity OKRs describe what the team will do, not what will change as a result. They are the most common failure mode because they are easy to write and easy to grade — if the thing shipped, it is a 1.0.
+
+**Example (broken):**
+> Objective: Improve our infrastructure
+> KR1: Migrate 12 services to Kubernetes by March 31
+> KR2: Complete the database upgrade project
+> KR3: Document all runbooks
+
+These are project milestones. They belong in a project plan. They are not OKRs.
+
+**Why they are dangerous:** A team can score 1.0 on every activity OKR and still have made no progress on the business problem that motivated the work. The Kubernetes migration is complete, but page load time did not improve. The database upgrade is done, but checkout error rate is unchanged. Activity OKRs measure effort, not impact.
+
+**How to fix them:** For every "we will ship X," ask: "What will be true after X ships that is not true now, and how will we measure it?" The answer to that question is the Key Result.
+
+---
+
+### Failure Mode 2: Aspiration Without Measurement
+
+The opposite failure: the KR sounds impactful but has no measurement mechanism.
+
+**Example (broken):**
+> KR: Significantly improve platform reliability
+
+"Significantly" is not a number. Without a baseline and a target, this KR cannot be graded, which means it cannot hold anyone accountable, which means it will be ignored.
+
+**How to fix it:** Define the baseline metric, the target value, and the measurement method. "Reduce P0 incident frequency from 4/month to 1/month, measured by the incident log, by March 31."
+
+---
+
+## OKR Hierarchy: What Lives at Each Level
+
+### Company Level
+
+Company OKRs are set by the CEO and exec team. They describe the most important outcomes for the business in the next quarter or year. Engineering may inform them but does not own them.
+
+Examples of well-formed company-level objectives:
+- Grow net revenue retention from 105% to 115%
+- Expand into two new enterprise verticals with at least three design partners each
+- Achieve SOC 2 Type II certification
+
+Engineering's job with company OKRs: understand them well enough to connect team-level work to them, and to push back when a company-level commitment requires engineering work that is not in the plan.
+
+---
+
+### Engineering Org Level
+
+Engineering org OKRs are owned by the VP or Director of Engineering. They describe what the engineering organization will accomplish — not just ship — in the quarter, and they connect directly to company-level outcomes.
+
+A well-formed engineering org OKR:
+- Connects to a company OKR (explicitly — name it)
+- Is measurable at the end of the quarter
+- Is at a level of abstraction that makes sense for the org, not for a single team
+
+**Example:**
+
+> Company OKR: Achieve SOC 2 Type II certification
+>
+> Engineering Org Objective: Build the infrastructure and evidence trail required for SOC 2 Type II certification
+>
+> KR1: 100% of production systems have audit logging enabled, confirmed by a third-party audit firm pre-scan by March 15
+> KR2: Mean time to revoke access for a departed employee reduced from 72 hours to 4 hours, measured in the IAM system
+> KR3: Zero critical findings in the third-party penetration test scheduled for February
+
+Each KR has a number, a measurement method, and a deadline. None of them describe activities; all describe the state of the world at the end of the period.
+
+---
+
+### Team Level
+
+Team OKRs are owned by the engineering manager, with input from the team. They connect to org-level OKRs and to the specific work that team is best positioned to do.
+
+**The connection test:** For every team KR, the manager should be able to name which org-level KR it supports, in one sentence, without hedging. If they cannot, the team KR is probably a project milestone in disguise.
+
+Team-level KRs should be specific enough that a new team member reading them would know exactly what the team considers success.
+
+---
+
+## How to Write a Good Key Result
+
+A Key Result that cannot answer all five questions below is not ready to commit to:
+
+1. **What changes?** Not "we complete X" but "X moves from A to B."
+2. **Who measures it?** There is a named person responsible for tracking this number.
+3. **Where does the data come from?** The measurement system exists today or will exist before the measurement period begins.
+4. **By when?** Quarter end is the default, but interim checkpoints should be defined for KRs with long lead times.
+5. **Who owns it?** One person's name. Not "the team." Not "engineering."
+
+**SMART test:**
+- **Specific:** The KR describes a single outcome, not a cluster of activities
+- **Measurable:** There is a number
+- **Achievable:** A score of 1.0 is possible but not guaranteed — if it is guaranteed, the KR is not ambitious enough
+- **Relevant:** The KR connects to an objective that connects to a company priority
+- **Time-bound:** The deadline is explicit
+
+---
+
+## Cascade Mechanics
+
+Cascading OKRs is not about translating objectives down line-by-line. It is about alignment — ensuring that what each team is working on connects to what the org is trying to accomplish, without requiring every team KR to be a direct copy of an org KR.
+
+**How to cascade without micromanaging:**
+
+Step 1: Engineering Director shares org-level OKRs with all managers, with the context for why each one was chosen and which company OKR it connects to.
+
+Step 2: Each manager drafts team OKRs independently and writes one sentence next to each KR explaining which org OKR it supports.
+
+Step 3: Director reviews for coverage (are all org OKRs supported by at least one team?) and for conflicts (are any two teams pulling in opposite directions on the same system?).
+
+Step 4: Director does not rewrite team KRs. If a KR is unclear or disconnected, the conversation is: "Help me understand how this KR supports [org OKR]. Can you explain the connection?" That conversation often reveals either a gap in the team's understanding of priorities, or a gap in the director's understanding of what the team actually does.
+
+**Coverage gap vs. conflict:**
+- A coverage gap means an org OKR has no team-level work supporting it. Either the org OKR needs a team assigned to it, or it needs to be removed.
+- A conflict means two teams are making incompatible assumptions about how a shared system will work. Surface this during cascade, not mid-quarter.
+
+---
+
+## Grading
+
+### The 0.7 Target
+
+Google popularized the idea that a 1.0 score on an OKR means the target was too easy. The engineering interpretation: if every KR scores 1.0 every quarter, the organization is not setting ambitious enough targets. The right calibration is that hitting 0.7 across the board is considered strong performance.
+
+This only works if the grading is honest. A team that inflates its scores to look good destroys the information value of OKRs. The engineering director's job during scoring is to press on scores that look inflated, not to accept them in the name of positivity.
+
+### What to Do With a 1.0
+
+Two questions to ask:
+1. Was this a legitimate stretch that we executed exceptionally well? If yes, celebrate it and use it to recalibrate ambition upward next quarter.
+2. Was the target set too conservatively? If yes, that is planning feedback, not a performance win. Recalibrate the target for next quarter.
+
+If a team consistently scores 1.0 on every KR every quarter, the targets are too conservative and the planning process needs fixing.
+
+### What to Do With a 0.3
+
+A 0.3 means something significant did not happen. Before attributing this to execution failure, ask:
+
+1. Was the KR still valid at the end of the quarter? Company priorities shift; a KR that was right in January may have been explicitly deprioritized by March. If so, grade it N/A or "deprioritized" rather than 0.3 — penalizing a team for acting on changed priorities is wrong.
+2. Was there a blocker that should have been escalated? A 0.3 that was visible in week 4 and not surfaced until scoring is a leadership failure, not just an execution failure.
+3. Was the KR unrealistic to begin with? If so, that is a planning failure. Fix the planning process.
+
+A 0.3 that represents genuine execution failure — the team committed, had the capacity, was not blocked, and still did not deliver — warrants a direct conversation about what happened and what changes next quarter.
+
+---
+
+## Quarterly OKR Review Format
+
+**Cadence:** Monthly check-in (30–45 min), with a formal score at quarter end
+**Audience:** Engineering director with all managers; managers run an equivalent with their teams
+**Owner:** Engineering director drives the check-in; each manager is accountable for their KRs
+
+**Monthly check-in template:**
+
+| KR | Owner | Target | Current | Score (0–1) | Status | Next 30-day action |
+|---|---|---|---|---|---|---|
+| P0 incident frequency: 4/mo → 1/mo | Platform lead | 1/mo | 2.5/mo | 0.4 | At risk | Root cause the two November incidents; fix alert sensitivity by Dec 15 |
+| Checkout error rate: 2.3% → 0.8% | Payments team TL | 0.8% | 1.1% | 0.7 | On track | Ship the payment retry logic fix in sprint 3 |
+| Access revocation time: 72h → 4h | Security eng | 4h | 4h | 1.0 | Complete | Maintain; document the process for audit evidence |
+
+**Status definitions:**
+- **On track:** Current score and trajectory suggest 0.7+ by quarter end
+- **At risk:** Current score and trajectory suggest 0.4–0.7 by quarter end without intervention
+- **Off track:** Current score suggests <0.4 by quarter end even with intervention
+- **Complete:** KR is at 1.0 and the work is done
+- **Deprioritized:** KR was explicitly deprioritized during the quarter due to changed company direction
+
+The monthly check-in is not about explaining why scores are what they are. It is about the "Next 30-day action" column — what will actually change before the next check-in?
+
+---
+
+## Retrospective: What to Learn From OKRs
+
+At the end of each quarter, before setting next quarter's OKRs, run a 30-minute retrospective focused on the OKRs themselves:
+
+**Questions to answer:**
+1. Which KRs scored below 0.5? Was this an execution problem, a planning problem, or a changed-priorities problem? Each has a different fix.
+2. Which KRs scored 1.0? Were they too easy, or were they genuine stretch achievements?
+3. Were there things the team did in the quarter that were not in any KR? If yes, why? Was it unplanned work that should have been anticipated? Was it reactive work that should have been prevented? Was it valuable work that should be in next quarter's OKRs?
+4. Were the measurement systems in place? If a KR was hard to grade because the data did not exist or was not trustworthy, that is a setup failure.
+
+**What to celebrate:**
+- KRs that scored 0.7–0.9 on a genuinely ambitious target — this is the system working
+- KRs where the team surfaced a blocker in week 4 and escalated it, even if the score was low — this is the behavior the system is supposed to incentivize
+- KRs that were deprioritized cleanly and transparently when company priorities changed — this is organizational adaptability, not failure
+
+**What not to celebrate:**
+- 1.0s on targets that were conservative
+- Completing activities that were listed as KRs but did not move any outcome metric
+
+---
+
+## Anti-Patterns
+
+### Too Many OKRs
+
+The optimal number of OKRs for a team is 1–2 objectives with 2–4 key results each. A team with 5 objectives and 15 key results does not have priorities — it has a wish list.
+
+A useful forcing function: every new KR proposed must displace an existing one, or the manager must explain in one sentence why the team has capacity for more than the cap.
+
+### OKRs Set by Committee
+
+OKRs set by a committee of stakeholders with no clear owner produce KRs that are acceptable to everyone and owned by no one. The manager who owns the objective needs to write the first draft. Stakeholders refine. The director approves or asks questions. One name at the end.
+
+### KRs That Measure Output, Not Outcome
+
+"Deploy the new checkout flow" is an output. "Increase mobile checkout conversion from 62% to 70%" is an outcome. The fact that something was deployed is meaningless if it did not change anything in the world.
+
+This distinction matters especially for infrastructure and platform work, where the temptation is to use deployment milestones as KRs. The question is always: what will be better for someone — a user, an engineer, an operator — after this work ships?
+
+### OKRs That Cannot Fail
+
+If every KR is structured as "complete X initiative" and the team controls whether X is complete, the KR cannot fail. It can slip, but slipping is reported as "in progress" not as "failed," which means the accountability mechanism never engages.
+
+OKRs need to be structured so that the world can tell you whether you succeeded, not just your internal retrospective.
+
+### Grading Season Theater
+
+Teams that spend hours debating whether a KR deserves a 0.6 or a 0.7 are wasting the mechanism. Scoring should take 15 minutes per KR. The value is not in the number; it is in the honest conversation that producing the number requires. If grading is taking more than two hours for a full team's OKRs, the KRs are probably not measurable enough.
+
+---
+
+## Templates
+
+### OKR Draft Template (Team Level)
+
+```
+**Objective:** [One sentence describing the outcome, not the activity. Should be inspiring 
+               but grounded in something real.]
+
+**Connects to:** [Org-level objective name]
+
+**KR1:** [Metric] moves from [baseline] to [target] by [date]
+  Owner: [Name]
+  Measurement: [How and where this is tracked]
+  Confidence: [High / Medium / Low — and one sentence on the primary uncertainty]
+
+**KR2:** [Metric] moves from [baseline] to [target] by [date]
+  Owner: [Name]
+  Measurement: [How and where this is tracked]
+  Confidence: [High / Medium / Low — and one sentence on the primary uncertainty]
+```
+
+### Monthly Check-In Prompt (Manager to Director)
+
+A one-paragraph written update submitted 24 hours before the monthly OKR check-in:
+
+```
+This month: [What moved, by how much]
+At risk: [Which KR is most at risk and why]
+What I need: [Any unblock, decision, or resource needed from leadership]
+My call: [Whether I expect to be on track, at risk, or off track at quarter end, in one sentence]
+```
+
+---
+
+## Implementation Sequence
+
+**Week 1 of a new quarter (OKR setting):**
+- Director shares company and org OKRs with managers, with written context
+- Managers draft team OKRs independently, due end of week
+- Director reviews for coverage, conflicts, and measurement quality
+
+**Week 2:**
+- Director holds 30-minute 1:1s with each manager to review their draft OKRs
+- Managers refine and finalize team OKRs
+- All OKRs published to a shared, accessible location (Notion, Confluence, or equivalent)
+
+**Month 2 check-in:**
+- Managers submit one-paragraph written update
+- 30-minute group check-in with director and all managers
+- At-risk KRs get an explicit recovery action assigned
+
+**Quarter end (grading):**
+- Managers submit scores with one-sentence explanation per KR
+- 30-minute retrospective on the OKR process itself
+- Planning for next quarter begins the following week
+
+---
+
+## A Note on Trust
+
+The OKR system only works if people believe that honest low scores will be treated as information, not as performance failures. An engineering director who responds to a 0.3 with criticism rather than curiosity will get inflated scores next quarter. The question when a KR scores low is: what does this tell us about what we planned vs. what was actually possible? That is a planning question, not a performance question — unless the pattern of low scores persists across multiple quarters with the same owner and the same explanations.
+
+Building that distinction into how you respond to scores is more important than any template in this document.

--- a/operating-cadence/engineering-rhythm-of-business.md
+++ b/operating-cadence/engineering-rhythm-of-business.md
@@ -1,0 +1,431 @@
+# Engineering Rhythm of Business
+
+## Leadership Context
+
+An engineering org without a defined operating cadence makes decisions at the wrong level, at the wrong time, or not at all. The result is predictable: strategy set in Q1 is invisible by Q2, engineering managers spend their 1:1s on status updates instead of development, and the VP learns about a critical platform risk in the same meeting where the CTO does. This playbook defines the meeting and ritual structure that reduces decision latency, keeps leadership bandwidth focused on the right problems, and creates the coordination surface that cross-functional partners can depend on. When the cadence is working, surprises shrink and trust grows — both inside the engineering org and with the business.
+
+## When to Use This
+
+- A new VP or Director is stepping into an existing org and needs to understand what cadence is already in place (and what is broken)
+- Post-acquisition integration: two engineering orgs are merging and need a unified operating model
+- The org has crossed 30 engineers and ad hoc coordination is no longer working — meetings are proliferating without structure, decisions are being made in Slack threads and forgotten
+- An engineering Chief of Staff or TPM is being asked to own the operating cadence and needs a reference model
+
+---
+
+## The Three Failure Modes This Cadence Prevents
+
+**Failure mode 1: Decision latency.** Decisions that should take 48 hours take two weeks because there is no standing forum at the right level with the right people. The weekly eng staff meeting exists to fix this.
+
+**Failure mode 2: Altitude mismatch.** Senior leaders are pulled into execution details; team leads are excluded from decisions they need context on. The tiered meeting structure keeps problems at the level where they belong.
+
+**Failure mode 3: Strategy decay.** Quarterly and annual direction-setting happens but there is no mechanism to check whether it is still alive mid-quarter. The monthly metrics review and quarterly retrospective exist to surface decay before it compounds.
+
+---
+
+## Weekly Tier
+
+### Engineering Staff Meeting
+
+**Attendees:** Engineering Director/VP, engineering managers, staff-level tech leads (optional)
+**Frequency:** Weekly, 60 minutes
+**Owner:** Engineering Director/VP or Chief of Staff
+
+This is the primary decision-making forum for the engineering leadership layer. It is not a status meeting — status is async. If a topic belongs in this meeting, it requires a decision, a cross-team alignment, or an escalation.
+
+**Agenda template:**
+
+```
+[5 min]  Pulse check — what happened last week that leadership needs to know
+[10 min] Blocking items — anything stalled that requires a decision in this room
+[15 min] Rotating deep-dive — one team or topic per week (delivery health, architecture concern, 
+         incident debrief, etc.)
+[15 min] Cross-functional updates — product, design, legal, finance items that affect eng
+[10 min] Upcoming — what is shipping or going live in the next two weeks
+[5 min]  Actions review — close out last week's actions; confirm owners
+```
+
+What does not belong in this meeting:
+- Individual sprint status — this belongs in team standups
+- Technical implementation debates — these belong in architecture review or async RFCs
+- Performance conversations — these belong in 1:1s with HR follow-up as needed
+
+**How to know this meeting is broken:**
+- More than 40% of the time is updates with no decision point
+- The same topics recur week over week without resolution
+- Engineering managers dread attending and send delegates
+- Actions are assigned but not tracked or closed
+
+**How to fix it:**
+Start by auditing the last four weeks of meeting notes. Categorize each agenda item: decision, alignment, update, or bloat. Move update items to a written pre-read. Eliminate bloat. If more than two items recur across weeks without closing, they represent a broken process somewhere upstream — surface that explicitly rather than letting the meeting absorb the dysfunction.
+
+---
+
+### On-Call Sync
+
+**Attendees:** Current on-call IC, engineering manager on call, platform/SRE lead
+**Frequency:** Weekly, 30 minutes (Monday or Wednesday, depending on rotation handoff day)
+**Owner:** Platform lead or on-call IC
+
+See also: [On-Call Restructuring Framework](../incident-management/on-call-restructuring-framework.md)
+
+Purpose: handoff the rotation, review any open incidents from the prior week, confirm alert health and runbook coverage.
+
+**Standing agenda:**
+```
+[5 min]  Rotation handoff — who is IC, who are the responders, how to reach them
+[10 min] Prior week incidents — severity, TTR, postmortem status (complete / scheduled / not yet)
+[10 min] Alert health — any alerts that fired and should not have; runbook gaps surfaced
+[5 min]  Upcoming risk — planned releases, infrastructure changes, or external dependencies in the next week
+```
+
+If there are no incidents from the prior week and no upcoming risk, this meeting can be shortened to 15 minutes or replaced with a written update to a shared channel. Do not run a 30-minute meeting to confirm that nothing happened.
+
+---
+
+### 1:1 Cadence Guidance
+
+The 1:1 is the most important leadership tool for engineering managers. It is also the most commonly wasted.
+
+**Recommended structure for manager-to-direct-report 1:1s (30–45 min, weekly):**
+
+Do not start with status. Status should be async. The 1:1 is for:
+- Development and growth: what is the person working toward; what is getting in the way
+- Concerns the person would not raise in a group: org friction, morale signals, interpersonal issues
+- Feedback in both directions: manager to report and report to manager
+- Strategic context: things the report should know about the direction of the org or team
+
+**Manager-to-manager 1:1s (30 min, biweekly):**
+Engineering directors should hold biweekly 1:1s with each of their managers. The agenda is:
+- What is one thing that is going well that I should amplify?
+- What is one thing that is stuck that you need me to unblock?
+- What is one person on your team I should know more about (in either direction)?
+
+**Engineering leader to cross-functional peer 1:1s (30 min, monthly):**
+Engineering VP or Director should hold monthly 1:1s with product, design, and data leads. These are relationship meetings, not status meetings. The goal is early warning and trust, not coordination — that happens in cross-functional forums.
+
+---
+
+## Monthly Tier
+
+### Engineering All-Hands
+
+**Attendees:** All engineers, engineering managers, invited cross-functional guests
+**Frequency:** Monthly, 60–75 minutes
+**Owner:** Engineering Director/VP with CoS support on logistics
+
+The all-hands serves two functions: creating shared context on direction and health, and maintaining connection between individual contributors and the decisions being made above them.
+
+**Format:**
+
+```
+[10 min] Opening — what is true about the org right now (not what we wish were true)
+[15 min] Metrics — 3–5 key health metrics, trend direction, what we are doing about the ones moving wrong
+[15 min] Featured team — one team presents what they shipped, what they learned, and what is next
+[10 min] Cross-functional update — one partner (product, design, data) gives a 5-minute view from their seat
+[10 min] Asks and offers — what leadership needs from the IC layer; what ICs should know leadership is working on
+[10 min] Q&A — live and async (Slido or equivalent)
+```
+
+What does not belong in the all-hands:
+- Long roadmap recaps — these belong in written updates or team-level planning sessions
+- Performance callouts (positive or negative) — recognition is valuable but should not consume all-hands time
+- Vendor pitches or tooling demos — unless the org is actively deciding on adoption
+
+**Common failure:** The all-hands becomes a leadership broadcast. Engineers stop attending because nothing they care about is discussed. Fix by reserving the featured team slot for ICs presenting their own work, making Q&A genuinely open (pre-submitted and live), and asking "what do you want to know that you're not being told?" every three months in a skip-level or anonymous channel.
+
+---
+
+### Architecture Review
+
+**Attendees:** Staff engineers, architects, engineering managers of affected teams, relevant product leads
+**Frequency:** Monthly, 90 minutes (or as-needed for major changes)
+**Owner:** Principal/Staff engineer or architecture working group
+
+Purpose: review proposed system changes above a defined threshold of scope or risk before they are committed to. This is not a rubber stamp; it is a quality gate.
+
+**Threshold criteria for requiring architecture review:**
+- New service or major service decomposition
+- Changes to data model that affect more than one team's systems
+- Third-party integrations that carry compliance or security implications
+- Any change with estimated implementation effort >4 engineer-weeks
+
+**Meeting structure:**
+```
+[15 min] Proposing team presents: problem, proposed solution, alternatives considered, tradeoffs
+[30 min] Questions and feedback from reviewers — structured around: correctness, scalability, operability, security, team burden
+[15 min] Decision: approve / approve with conditions / defer for revision
+[30 min] Open slot for async RFC reviews or carry-over items
+```
+
+Decisions are written and stored (Confluence, Notion, or equivalent). An architecture decision that lives only in a meeting recording is not a decision.
+
+---
+
+### Metrics Review
+
+**Attendees:** Engineering Director/VP, engineering managers, data or analytics partner
+**Frequency:** Monthly, 45–60 minutes
+**Owner:** Engineering Director/VP or CoS
+
+The metrics review is not a status meeting. The question is not "what are the numbers?" — those should be visible in a dashboard. The question is "what do these trends tell us about the health of the system, and what are we going to do about it?"
+
+**Metric categories to cover:**
+
+| Category | Example metrics |
+|---|---|
+| Delivery health | Cycle time, deployment frequency, change failure rate, MTTR |
+| Platform reliability | Error rate by service, p99 latency, uptime vs. SLA |
+| Team health | On-call incident load, incident-per-engineer rate, sprint completion rate |
+| Technical debt | Open critical/high severity bugs, dependency freshness, test coverage trend |
+| People metrics | Attrition rate, open headcount, time-to-fill |
+
+**Structure:**
+- Each manager submits a 3-sentence metric summary before the meeting: what moved, which direction, and what is being done
+- Meeting focuses on items that are below threshold or trending the wrong way
+- For each problem metric: what is the hypothesis, who owns the recovery, what is the target date
+
+Do not spend time discussing metrics that are healthy and stable unless they are about to be stressed by an upcoming change.
+
+---
+
+## Quarterly Tier
+
+### Engineering QBR
+
+**Attendees:** Engineering Director/VP, engineering managers, product VP or CPO, CTO if present
+**Frequency:** Quarterly, 120 minutes
+**Owner:** Engineering Director/VP with CoS managing prep and logistics
+
+The engineering QBR is a leadership-layer forcing function: a structured look at what the org committed to, what it delivered, and what it is committing to next. It is the venue for surfacing structural problems — not for celebrating wins that could be communicated in an email.
+
+**What goes in the QBR:**
+
+1. **Delivery recap** — commitments vs. actuals for the quarter. Not a polished slide; an honest accounting. What shipped, what did not ship, and why.
+2. **Health metrics** — 90-day trend on delivery, reliability, and team health metrics. Red/yellow/green with commentary.
+3. **Capacity and risk** — headcount vs. plan; open roles; technical debt load; risks entering the next quarter.
+4. **OKR grade** — score on each key result (0.0–1.0), one-sentence explanation, what was learned.
+5. **Next quarter commitments** — what the org is committing to, at what confidence level, with what dependencies.
+6. **Asks** — what the engineering org needs from the company to deliver on next quarter's commitments (headcount approvals, cross-functional prioritization, tooling budget, executive decision needed).
+
+**What stays out of the QBR:**
+- Sprint-level delivery detail — too granular for this audience
+- Technical architecture debates — these belong in architecture review
+- Individual performance — this belongs in talent reviews
+
+**Pre-read requirement:** A written pre-read covering sections 1–4 is distributed at least 48 hours before the QBR. The meeting is for discussion, not for reading slides aloud.
+
+---
+
+### Planning Kickoff
+
+**Attendees:** Engineering managers, product managers, design leads, data leads
+**Frequency:** Quarterly (8 weeks before end of quarter), 2-hour working session
+**Owner:** Engineering Director/VP with product VP as co-owner
+
+The planning kickoff is the start of the next quarter's planning cycle, not a final commitment meeting. The goal is shared context: what is the company trying to accomplish, what is engineering's capacity, and what are the largest bets under consideration.
+
+**Working session structure:**
+```
+[20 min] Company context: product VP presents top company priorities for next quarter
+[20 min] Capacity baseline: engineering director presents headcount, known constraints, carry-over commitments
+[60 min] Initiative mapping: cross-functional teams map proposed initiatives to capacity in rough T-shirt sizing
+[20 min] Dependency identification: what requires legal review, infrastructure work, data availability, or vendor contracts
+```
+
+Output: a draft list of initiatives, rough relative priority, and a list of questions to resolve before planning is finalized.
+
+---
+
+### Quarterly Retrospective
+
+**Attendees:** Engineering managers and interested ICs (opt-in)
+**Frequency:** Quarterly, 90 minutes
+**Owner:** Rotating facilitation; engineering director is a participant, not the facilitator
+
+The quarterly retrospective is distinct from sprint retrospectives. It surfaces patterns across teams and quarters, not sprint-level friction.
+
+**Format:**
+
+Async pre-work (24 hours before): each team submits three inputs on a shared board:
+- One thing that worked and should be preserved
+- One thing that did not work and should be changed
+- One thing that was unclear and should be defined
+
+Meeting:
+```
+[15 min] Read the board — silent review of all submissions
+[40 min] Theme discussion — facilitator groups submissions into 3–5 themes; group discusses root causes
+[20 min] Action selection — group picks 2–3 actions to carry into next quarter; assigns owners and success criteria
+[15 min] Feedback on the retrospective itself — was it useful? What should change?
+```
+
+**A retrospective without assigned actions is a venting session.** If the 2–3 actions from last quarter are not reviewed at the start of this one, the process has no credibility.
+
+---
+
+## Annual Tier
+
+### Technology Strategy Review
+
+**Attendees:** Engineering leadership (VP, directors, principal engineers), product leadership, CTO
+**Frequency:** Annual (Q4, in parallel with business planning)
+**Owner:** CTO or VP Engineering with principal engineer input
+
+This is the forcing function to answer: given where the business is going in the next 12–18 months, is our technology platform equipped to support it? This is not a roadmap review; it is a structural question about the architecture and the org.
+
+**Agenda:**
+```
+[30 min] Business direction brief — product or strategy team presents where the company is going
+[45 min] Platform assessment — where is the system strong; where is it a risk to future business objectives
+[30 min] Team capability assessment — where are the skills we have vs. the skills we need
+[30 min] Strategic bets — what are 2–3 technology investments we need to make in the next year that are not currently planned
+[15 min] Outputs and owners — who writes the strategy memo; who presents it to the executive team
+```
+
+Output: a 2–3 page strategy memo that feeds into the annual planning process. Not a 40-slide deck.
+
+---
+
+### Roadmap Reset
+
+**Attendees:** Engineering and product leadership
+**Frequency:** Annual (concurrent with strategy review)
+**Owner:** Product VP with engineering VP as co-owner
+
+The roadmap reset is not planning — planning produces sprint-level commitments. The roadmap reset produces a 12-month view of bets with honest confidence levels.
+
+Each initiative in the roadmap should have:
+- A one-sentence problem statement (not a feature name)
+- The business metric it is expected to move
+- A confidence level (high / medium / low) and the primary uncertainty driving that confidence level
+- An owning team and an engineering lead
+- A rough quarter when work is expected to begin
+
+The roadmap is not a contract. It is a forecast. The reset acknowledges that the prior year's roadmap was partially correct and that this one will be too.
+
+---
+
+### Org Health Survey
+
+**Frequency:** Annual (or biannual for orgs with high change velocity)
+**Owner:** Engineering Director/VP with HR partnership
+
+An annual survey covering: clarity of direction, psychological safety, manager effectiveness, career growth, cross-functional collaboration, and on-call/operational load. Not optional; participation should be the norm, not the exception.
+
+Outputs from the survey go into the next quarter's planning cycle as engineering-org inputs. If the survey results do not influence any decision, engineers will correctly conclude that their feedback is performative, and participation will drop.
+
+---
+
+## Decision Accountability Model
+
+Use a DACI (Driver, Approver, Consulted, Informed) framework to define which decisions belong where. The following table maps common engineering-org decisions to the right level.
+
+| Decision type | Driver | Approver | Consulted | Informed |
+|---|---|---|---|---|
+| Adopt a new primary programming language or framework | Staff engineer | VP Eng | Engineering managers, architects | All engineers |
+| Add a service to the production topology | Owning team tech lead | Engineering manager | Platform lead | On-call rotation |
+| Change on-call rotation structure | Platform lead | Engineering Director | Engineering managers | All on-call participants |
+| Deprecate a service | Owning team tech lead | Engineering manager | Dependent teams | All engineers |
+| Approve a headcount request | Engineering Director | VP Eng or CFO | HR, Finance | Hiring managers |
+| Commit engineering capacity to a product initiative | Engineering manager | Engineering Director | Product manager | Team |
+| Select a vendor for a production system | Lead engineer evaluating | Engineering Director | Security, Finance, Legal | Engineering managers |
+| Promote an engineer to staff level | Engineering manager | Engineering Director | Peer staff engineers | Engineering org |
+
+**How to use this table:** When a decision is stuck — either no one is moving it, or everyone is arguing about who should move it — the first question to ask is: who is the Driver? If there is no named Driver, the decision will not move. Assign one before doing anything else.
+
+---
+
+## Meeting Health Principles
+
+**A meeting is broken when:**
+- It recurs on the calendar but no one can articulate what decision it produces or what would happen if it were canceled
+- The same person speaks more than 60% of the time
+- Action items from the previous meeting were not reviewed
+- Attendees are present but not engaged (camera off, no contributions, clearly doing other work)
+- The meeting could have been a well-written document
+
+**How to audit a meeting:**
+At the end of a quarter, pull the last 8 meeting notes for any standing meeting. Ask:
+1. What decisions were made in this meeting that could not have been made another way?
+2. Which agenda items were updates vs. discussion vs. decisions?
+3. Were actions assigned and closed?
+
+If you cannot answer question 1 with at least two concrete decisions, the meeting is a candidate for elimination or restructuring.
+
+**The one-meeting-per-quarter cancellation rule:**
+Once a quarter, cancel one standing meeting as an experiment. If someone needs it back, the burden of proof is on them to explain what decision would be lost without it.
+
+---
+
+## CoS Role in Running This Cadence
+
+A Chief of Staff or senior TPM who owns the operating cadence is one of the highest-leverage roles in an engineering org. The specific responsibilities:
+
+**Preparation:**
+- Owns the agenda for the weekly staff meeting: collects inputs from managers 24 hours in advance, sequences items by urgency and decision-type, circulates the agenda the evening before
+- Manages the all-hands run-of-show: confirms speakers, collects slides, seeds the Q&A queue
+- Drives QBR prep: distributes the pre-read template, chases submissions from managers, assembles the consolidated deck, flags where commitments vs. actuals need an explanation
+
+**During meetings:**
+- Takes notes in the staff meeting, capturing decisions and owners in a consistent format
+- Time-keeps and cuts discussion that is going past its slot
+- Names when a discussion has become circular and surfaces what decision is missing
+
+**After meetings:**
+- Publishes action items within 24 hours to a shared channel or doc
+- Owns the action register: tracks open items week over week, flags overdue items to the engineering director
+- Escalation flags: if an item has been in the action register for more than two weeks without movement, it goes to the director with a recommendation for whether to close, reassign, or escalate
+
+**Escalation judgment:** The CoS is often the first person to see that something is wrong before the director does. This is only valuable if the CoS develops a calibrated view of what needs to surface immediately vs. what can wait for the next staff meeting. The calibration question is: "If this is not resolved in 48 hours, does it cost money, create a compliance risk, or surprise an executive?" If yes, surface it immediately.
+
+---
+
+## Sample Weekly Calendar: 50-Engineer Org
+
+```
+Monday
+  9:00 AM   On-call sync (IC, on-call manager, platform lead) — 30 min
+  10:00 AM  Engineering staff meeting (managers + staff leads) — 60 min
+  
+Wednesday  
+  10:00 AM  Product × Engineering sync (product + eng managers) — 45 min
+  
+Thursday
+  Various   Engineering manager 1:1s with reports
+  
+Friday
+  2:00 PM   Weekly written update published to #eng-leadership Slack:
+            - Top 3 things that shipped
+            - Top 3 things that are at risk
+            - One metric to watch
+```
+
+## Sample Monthly Calendar: 50-Engineer Org
+
+```
+Week 1
+  Wednesday: Architecture review (staff engineers, affected team leads) — 90 min
+
+Week 2
+  Monday:    Metrics review (engineering managers + data lead) — 60 min
+
+Week 3
+  All-hands (all engineers, open Q&A) — 75 min
+
+Week 4
+  Cross-functional 1:1s (VP Eng with product VP, design lead, legal, finance) — 30 min each
+  [Engineering director 1:1s with each manager happen weekly; not listed separately]
+```
+
+**Monthly written artifact:** A 1–2 page engineering update covering: delivery summary, health metrics, team changes, and any decisions the exec team should be aware of. Published in the last week of each month. This is the artifact that builds executive trust without requiring executives to attend engineering meetings.
+
+---
+
+## Implementation Notes
+
+**Start with the weekly staff meeting.** It is the highest-leverage meeting in the cadence and the one that decays fastest without structure. Get the agenda template right before building the rest.
+
+**Run the cadence before adding new meetings.** Every org has too many meetings. Before adding anything from this playbook, audit what already exists. The goal is not to implement every tier at once; it is to replace whatever is broken with something that works.
+
+**Cadence debt compounds.** An org that skips the quarterly retrospective for two quarters, lets the metrics review become a status update, and stops publishing written updates will re-accumulate all the coordination failures this cadence is designed to prevent. The meetings are not the mechanism; the discipline of maintaining them is.

--- a/operating-cadence/escalation-framework.md
+++ b/operating-cadence/escalation-framework.md
@@ -1,0 +1,260 @@
+# Escalation Framework
+
+## Leadership Context
+
+Escalation failure is one of the most expensive and least discussed problems in engineering organizations. When escalation works, problems surface early enough that they can be managed — a delivery risk is caught in week 3 of a 12-week project, not in week 10; a personnel situation is addressed before it affects the team; a reputational risk reaches the CTO before it reaches the press. When escalation fails, the organization pays the compound interest on every day the problem was visible to someone below the decision-making level but not above it. This playbook covers when to escalate, to whom, in what format, and how to do it without blame or alarm — and how to distinguish the situations that require escalation from the ones that should be handled at the team level without surfacing upward.
+
+## When to Use This
+
+- A new IC or engineering manager is onboarding and needs to understand what "good escalation behavior" looks like in this org
+- Post-incident review of a significant delivery failure, customer escalation, or personnel situation reveals that escalation happened too late, too early, or not at all
+- A new manager is being onboarded and needs to understand the escalation norms before they inherit a team
+- An engineering Chief of Staff is designing or auditing the escalation operating model
+
+**What this document covers:** Leadership-layer escalation — delivery risk, people risk, and reputational risk. This is distinct from on-call escalation, which covers production incidents and follows its own protocol (see [On-Call Restructuring Framework](../incident-management/on-call-restructuring-framework.md)).
+
+---
+
+## Escalation Triggers
+
+Not every problem warrants escalation. The threshold question is: does this situation require a decision, resource, or intervention that is not available at the level where the problem currently lives? If yes, escalate. If no, handle it at the current level and document what was done.
+
+The following three categories cover the large majority of escalation-worthy situations.
+
+### Category 1: Delivery Risk
+
+Delivery risk escalation is appropriate when a commitment is in jeopardy and either (a) the jeopardy requires a decision above the team level, or (b) a cross-functional partner or executive needs to know before the miss happens rather than after.
+
+**Escalation triggers in this category:**
+- A project is 30% or more behind schedule and the root cause cannot be resolved at the team level within the next 5 business days
+- A dependency (cross-team, vendor, or cross-functional) is blocking progress and the blocker owner is not responding to the team or manager
+- A scope or timeline commitment was made to a customer, partner, or executive, and engineering now believes that commitment will not be met
+- An unforeseen technical risk (security vulnerability, architectural issue, third-party integration failure) has emerged that will add more than two weeks to a project timeline
+- The team has lost a key person (departure, extended leave) and the gap cannot be absorbed without affecting a committed delivery
+
+**Threshold for escalation in this category:** If a delivery risk is not resolved at the current level within 5 business days of being identified, it should be escalated. Not surfaced in passing — formally escalated with a memo or structured update.
+
+**Common mistake:** Waiting until the risk has materialized into a miss before escalating. A delivery risk that surfaces in week 4 of a 10-week project with an escalation memo and a mitigation plan is manageable. The same risk surfaced in week 9 with "we're going to miss" is a crisis. The escalation that feels premature in week 4 is almost always the right call.
+
+---
+
+### Category 2: People Risk
+
+People risk escalation is appropriate when a situation involving a specific person on the team requires action, awareness, or resources beyond what the manager can provide, or when the situation creates risk for the org that leadership needs to know about.
+
+**Escalation triggers in this category:**
+- A team member's performance has been formally documented (verbal or written) and has not improved within the agreed improvement period
+- A team member has raised a complaint (against a peer, manager, or cross-functional partner) that involves potential harassment, discrimination, or a code of conduct violation — this escalates immediately to HR and the relevant management chain
+- A team member appears to be at significant personal risk (mental health crisis, expressed statements of self-harm) — this escalates immediately to HR and, if needed, to emergency services
+- A key team member is at flight risk (has shared job search activity, has received an outside offer, or has expressed significant dissatisfaction) and their departure would create a material delivery or institutional knowledge gap
+- A manager is struggling with a direct report situation and needs director-level coaching or intervention to resolve it
+- A team conflict (between two engineers, or between an engineer and a manager) is escalating to the point where it is affecting team function
+
+**Threshold for escalation in this category:** People situations are context-dependent, but the default rule is: if a manager has had more than one direct conversation about a performance or behavior issue and the situation is unchanged, escalation to the director is appropriate. This is not about creating a paper trail; it is about the director having accurate information to make resourcing and organizational decisions.
+
+**Common mistake:** Managers over-protecting their team by not surfacing people risks upward. A director who discovers a performance situation 60 days after the manager first identified it, with no escalation in between, has lost the window to intervene constructively. The manager's instinct to handle it independently is understandable; the operational consequence is that leadership cannot allocate resources (HR support, coaching, temporary capacity help) to the situation.
+
+---
+
+### Category 3: Reputational and External Risk
+
+Reputational risk escalation is appropriate when a situation involves external parties (customers, regulators, press, investors), when a decision has legal or compliance implications, or when the situation could reach executive or board awareness from a channel other than engineering.
+
+**Escalation triggers in this category:**
+- A customer has escalated a technical issue to their executive sponsor, and engineering leadership is not already on the email thread
+- A security vulnerability has been discovered that may have already resulted in data exposure — this escalates immediately regardless of severity assessment
+- A public incident, outage, or data exposure is being discussed externally (on social media, in press, in customer community forums) before a formal communication has been issued
+- A regulatory inquiry, audit request, or legal hold has been received
+- A vendor or partner has communicated a material change (pricing increase, service discontinuation, breach notification) that affects engineering's ability to meet its commitments
+- A team member has communicated to someone outside the org (customer, press, social media) in a way that creates a commitment or creates reputational risk for the company
+
+**Threshold for escalation in this category:** Immediate, or within the same business day. Reputational and external risks do not wait for the weekly staff meeting.
+
+**Common mistake:** Treating a customer complaint that has escalated to executive level as a "support issue" rather than a leadership issue. By the time a customer's VP of Engineering is emailing the CTO, the window for managing the relationship through normal channels has closed. The escalation should have happened when the customer first expressed dissatisfaction, not when they escalated past the engineering team.
+
+---
+
+## Escalation Levels
+
+### Team → Engineering Manager
+
+**What belongs here:** Day-to-day delivery friction, team-internal interpersonal issues, sprint-level scope questions, individual IC performance feedback, dependency gaps within a team.
+
+**What the manager is expected to do:** Resolve it, or escalate within 5 business days if it cannot be resolved at this level.
+
+**What the manager should document:** A brief written note to themselves (or in the team's task tracker) with: the issue, what was tried, and the outcome. This documentation exists for the manager's benefit — if the situation escalates, there is a record.
+
+---
+
+### Engineering Manager → Engineering Director
+
+**What belongs here:** Cross-team dependency blockers, delivery risks that affect a committed initiative, team-level people situations that have not resolved after two direct conversations, vendor or tooling issues that require budget authority above the team level.
+
+**What the director is expected to do:** Unblock, decide, or escalate within 2 business days.
+
+**How to escalate:** The escalation memo format (see below) or a brief async written update to the director with the same structure. The format matters because it forces the manager to crystallize what they actually need from the director.
+
+---
+
+### Engineering Director → VP Engineering / CTO
+
+**What belongs here:** Delivery risks affecting a company-level commitment or a customer-facing commitment, people situations involving a manager or above, decisions that require budget authority above the director level, any situation with reputational or external risk (see Category 3), any people situation involving potential legal or HR implications.
+
+**What the VP/CTO is expected to do:** Engage within 24 hours on Category 3 issues, within 48 hours on Category 1 and 2 issues.
+
+**How to escalate:** The escalation memo format, delivered to the VP/CTO directly (not through a chain of intermediaries). The director should confirm receipt and response timeline before assuming the escalation landed.
+
+---
+
+### VP Engineering / CTO → CEO / Board
+
+**What belongs here:** Delivery failures with material revenue impact, security incidents with data exposure, regulatory notifications, personnel situations involving executive-level individuals, strategic risks to the engineering organization's ability to support company goals.
+
+**How to escalate:** Written escalation memo with an executive-ready format. For Category 3 issues (external risk), phone call first, then memo. The memo documents the conversation; it does not replace it.
+
+**The rule about boards:** Nothing should reach the board that the CEO and CTO have not already discussed. If a board member is learning about a material engineering risk from a source other than the CTO or CEO, something in the escalation chain failed.
+
+---
+
+## The Escalation Memo Format
+
+A well-formed escalation memo takes 15–20 minutes to write and can be 5–8 sentences. It is not a project update or a status report. It is a decision-enabling document.
+
+**Five sentences:**
+
+```
+1. SITUATION
+[What is happening, when it started, and what the current state is. One to two sentences. 
+No attribution, no blame, no editorializing — just the facts.]
+
+2. IMPACT
+[What the consequence is if this is not resolved, and by when it matters. Be specific: 
+revenue, customer relationship, compliance deadline, delivery commitment, personnel stability.]
+
+3. OPTIONS
+[Two or three options for responding to this situation, stated neutrally. Include a 
+"do nothing" option if it is realistic, and name its cost.]
+
+4. RECOMMENDATION
+[What you believe the right option is and why. This is where your judgment goes. 
+If you do not have a recommendation, say so explicitly — "I don't have a recommendation; 
+I need your input on option 2 or 3."]
+
+5. BY WHEN
+[When a decision or action is needed to stay ahead of the issue. Be specific about 
+the date and what happens after that date if the decision is not made.]
+```
+
+**Example escalation memo:**
+
+> **Situation:** The data pipeline dependency for the fraud detection model (Q4 OKR) was expected to be complete by November 15. The data engineering team has encountered a data quality issue in the upstream events table that will delay delivery to November 29 — two weeks behind plan.
+>
+> **Impact:** The fraud detection model requires 4 weeks of clean data to train. If the pipeline is not complete by November 29, the earliest the model can be trained and validated is December 27 — after the Q4 cutoff. The Q4 OKR for fraud loss reduction ($600K/year estimated impact) will be missed, and the work will carry into Q1.
+>
+> **Options:** (1) Accept the Q4 miss, carry the work into Q1, and update the Q4 OKR score accordingly. (2) Reprioritize the data engineering team to resolve the data quality issue by November 22, requiring them to deprioritize their current sprint commitment (the analytics dashboard release). (3) Scope down the fraud model to use a smaller, already-validated dataset, accepting reduced model accuracy — estimated impact is 60% fraud reduction instead of 80%.
+>
+> **Recommendation:** Option 3 — reduced scope now, full model in Q2 with the complete dataset. The $600K/year estimate was based on the full 80% reduction; even 60% recovers ~$450K/year and delivers in Q4 as committed. This avoids disrupting the data team's sprint commitment.
+>
+> **By when:** Need a decision by November 14 to allow time for the reduced-scope implementation plan.
+
+---
+
+## Non-Escalation Anti-Patterns
+
+### Hero Culture: Fixing It and Not Telling Anyone
+
+The most common escalation failure in engineering organizations is not failing to escalate a crisis — it is a manager or IC resolving a significant risk through heroic personal effort and never surfacing it to leadership.
+
+**Why this is a problem:** Leadership cannot learn from risks they do not know occurred. The headcount decision that would have prevented the crunch does not get made. The architectural investment that would have prevented the recurrence stays off the roadmap. The manager who absorbed an unsustainable load for six weeks without saying anything gets praised for execution and burned out in Q2.
+
+**The calibration question:** "If I had told my manager what was happening, what would have happened?" If the answer is "they would have helped" or "they would have made a better decision" — escalate next time. If the answer is "nothing, I handled it faster" — this is the one case where the hero move was right. Most people who use this test honestly find that they should have escalated earlier more often than they actually did.
+
+### False Alarm Fatigue: Escalating Too Early
+
+The opposite failure: escalating every uncertainty to the director level, with the effect that the director spends most of their time triaging issues that could have been resolved at the team level, and begins to discount escalations because most of them do not require their intervention.
+
+**The calibration question:** "Have I tried two specific things to resolve this at my level, and neither worked?" If no, handle it at the current level first. If yes, escalate.
+
+**The intent behind this threshold:** It is not about making escalation feel onerous. It is about ensuring that when something reaches the director, the director knows it genuinely requires their level of authority or perspective.
+
+---
+
+## Escalation Response SLA
+
+Escalation is a two-way process. When someone escalates to you, you owe them a response within a defined timeframe. The absence of a response is not the same as "working on it" — it reads as "did not receive this" or "chose not to act."
+
+| Escalation type | Expected response time | What the response must include |
+|---|---|---|
+| Category 3 (external/reputational risk) | Same business day | Acknowledgment, whether you are engaging, and what the next step is |
+| Category 2 (people risk, potential legal/HR) | Within 24 hours | Acknowledgment and whether you are looping in HR or escalating further |
+| Category 1 (delivery risk) | Within 48 hours | Acknowledgment of the escalation, your read on the options, and whether you are deciding or escalating further |
+| General escalation memo | Within 48 hours | A response to each of the five memo sections — situation understood, impact assessed, options considered, decision made or escalated, timeline |
+
+**The response is not the resolution.** A 24-hour acknowledgment does not mean the problem is solved in 24 hours. It means the person who escalated knows their message was received and that someone is acting.
+
+If you cannot respond within the SLA, delegate the acknowledgment to someone who can: "I received this. I am in back-to-back until Thursday. [Name] will reach out in the next 4 hours." The absence of any response within SLA is the failure mode.
+
+---
+
+## How to Escalate Without Blame
+
+Escalation language that assigns blame before the facts are established creates defensiveness, distorts the information that leaders receive, and makes the person being blamed less likely to be forthcoming in future escalations.
+
+**Language patterns that introduce blame:**
+- "The data team dropped the ball on..."
+- "[Name] failed to deliver..."
+- "This wouldn't have happened if product had..."
+- "We warned them this would happen, but..."
+
+**Language patterns that describe the situation without blame:**
+- "The data pipeline dependency was expected by November 15; it is now projected for November 29."
+- "The current state is X. The contributing factors we have identified are A, B, and C."
+- "The design requirement was received on [date], which left [N] days for implementation. That was not enough time."
+
+Blame language in an escalation memo signals that the author has already concluded who is at fault, which means they are bringing a conclusion to leadership rather than a problem that needs to be analyzed. Leadership that receives blame-laden escalations has to spend time evaluating whether the framing is accurate before they can address the actual issue.
+
+Blame does not mean there are no accountability conversations to be had. It means those conversations happen after the facts are established and the immediate situation is resolved, not in the escalation memo.
+
+---
+
+## Distinguishing Escalation From Venting
+
+Not every difficult conversation with a manager is an escalation. The internal checklist below helps distinguish situations that warrant a formal escalation memo from situations that warrant a different kind of conversation.
+
+**Before drafting an escalation memo, answer these questions:**
+
+1. Is there a decision that needs to be made that I cannot make at my level? (If yes, escalate.)
+2. Is there a resource I need that is not available to me at my level? (If yes, escalate.)
+3. Is there information that a level above me needs to have, regardless of whether any action is required right now? (If yes, escalate — but frame it as an FYI, not a request for action.)
+4. Am I seeking permission to do something I already know is the right thing to do? (If yes, make the decision and inform, don't escalate.)
+5. Am I frustrated about a situation and wanting someone above me to validate that frustration? (If yes, this is a conversation, not an escalation. Have the conversation, but do not dress it as an escalation memo.)
+
+Most escalation-vs.-venting confusion comes from question 5. Frustration is legitimate and worth expressing — but expressing it in the format of a formal escalation memo creates the expectation that the director will act when the person may only want to feel heard. Be clear about which you are asking for.
+
+---
+
+## On-Call vs. Leadership Escalation
+
+These are two different systems with two different purposes.
+
+**On-call escalation** is triggered by a production incident. The path is defined in the on-call runbooks: page the IC, page the responder, escalate within the incident if the IC cannot be reached or the incident exceeds defined severity thresholds. The on-call system exists to restore service. See [On-Call Restructuring Framework](../incident-management/on-call-restructuring-framework.md).
+
+**Leadership escalation** (this document) is triggered by a risk or decision that requires leadership-layer attention. It is not time-constrained in the same way an incident is, but it has urgency calibrated to the type of risk. Its purpose is not service restoration — it is decision-making, resource allocation, and risk management.
+
+**The interaction between the two systems:** A significant production incident will often trigger both. The on-call system restores service; the leadership escalation ensures that the right executive is aware, that the customer communication is managed, and that the post-incident investment decisions are made with full information. The incident postmortem is the handoff point: once service is restored, the on-call system's job is done and the leadership-layer review begins.
+
+One failure mode in practice: an incident is resolved by the on-call team, correctly, but no one escalates the severity or the customer impact to leadership. The CTO hears about a significant P0 incident three days later in the QBR. That gap is a leadership escalation failure, not an on-call failure.
+
+---
+
+## A Note on Escalation Culture
+
+The most important thing an engineering director or VP can do to make escalation work is to model the behavior they want to see, and to reward it when they see it.
+
+If an engineering manager escalates a delivery risk early and the director's response is frustration or criticism, that manager will not escalate early again. They will wait until the risk is a confirmed miss — which is exactly the wrong time.
+
+The response that builds escalation culture: "Thank you for surfacing this early. Here is what I think we should do. Let me know if the mitigation plan isn't working by [date]."
+
+The response that kills escalation culture: "Why is this the first I'm hearing about this? This should have been caught earlier."
+
+Both responses may be accurate. Only one of them builds the behavior you need.

--- a/operating-cadence/executive-communication-templates.md
+++ b/operating-cadence/executive-communication-templates.md
@@ -1,0 +1,371 @@
+# Executive Communication Templates
+
+## Leadership Context
+
+An engineering leader's ability to communicate upward is a direct multiplier on the team's impact. If the CTO, CEO, or board cannot quickly understand what engineering has delivered, what it needs, and what risks it is managing, they will make resourcing and priority decisions with incomplete information — and engineering will consistently lose those decisions to functions that communicate better. This playbook covers the written artifacts that engineering leaders produce for executive and board audiences: the formats, the principles, and the failure modes to avoid. Getting these right is not about polish; it is about building the executive trust that translates into headcount, runway, and the ability to make consequential technical bets.
+
+## When to Use This
+
+- Preparing for a QBR, board presentation, or investor due diligence session where engineering will have a dedicated slot
+- After a significant incident and leadership needs an executive summary before the all-hands debrief
+- When requesting headcount, tooling budget, or a major cross-functional commitment
+- When a new engineering leader is learning what "writing upward" means in practice
+
+---
+
+## Principles for Writing Upward
+
+Before any template: the principles that make executive communication work.
+
+### Lead With the Ask
+
+Executive audiences read under time pressure. The most important sentence in any executive communication is the first one. If you bury the ask in the third paragraph after two paragraphs of context, the ask will be missed.
+
+**Wrong:**
+> "In Q3, the payments team made significant progress on the checkout reliability initiative. We resolved 14 of 18 known issues in the payment retry logic and improved error detection by adding distributed tracing to the payments service. As a result of this work, and in light of the upcoming Q4 holiday traffic projections, we believe we need to add two engineers to the payments team."
+
+**Right:**
+> "We need to add two engineers to the payments team before Q4 to meet holiday traffic reliability targets. Here is the context."
+
+The context is still there. The ask is not buried.
+
+### Quantify Impact
+
+Every claim in an executive communication should be quantifiable or should say explicitly why it cannot be quantified. Executives who read "significant improvement" or "faster response times" without numbers cannot make resource decisions based on those statements.
+
+**Wrong:** "We significantly reduced checkout errors this quarter."
+**Right:** "Checkout error rate dropped from 2.3% to 0.8% this quarter, which is estimated to recover approximately $180K in lost revenue per quarter at current conversion rates."
+
+If you do not know the business impact, say so and give the engineering metric: "We reduced checkout error rate from 2.3% to 0.8%. We have not yet quantified the revenue impact."
+
+### Distinguish Diagnosis From Recommendation
+
+Executive audiences need to know the difference between "here is what is happening" and "here is what we recommend doing about it." When these are conflated, executives cannot tell whether they are being asked to approve something, informed of something, or asked to make a judgment call.
+
+Format:
+1. What is happening (diagnosis)
+2. What it means for the business (impact)
+3. What we recommend (recommendation)
+4. What we need from you (ask)
+
+### Manage Risk Explicitly
+
+Engineering leaders who only surface risks after they have materialized lose executive trust quickly. Executive communication should include an honest risk register — not to create alarm, but to demonstrate that leadership is thinking ahead and managing proactively.
+
+Risk language that signals credibility: "We believe X is unlikely but are monitoring Y as an early indicator. If Y triggers, we will do Z."
+
+Risk language that signals loss of control: "We are working through some challenges in the infrastructure layer."
+
+---
+
+## Engineering QBR Structure
+
+**Audience:** Executive team (CTO, CPO, CEO, CFO depending on org)
+**Format:** 60–90 minute meeting with written pre-read distributed 48 hours in advance
+**Length:** Pre-read: 4–6 pages. Meeting slides: 15–20 slides maximum.
+
+### Section 1: Health Metrics (One Page)
+
+A dashboard view of the 4–6 metrics that best represent engineering health. Each metric should include: current value, prior quarter value, trend direction, and a one-sentence interpretation.
+
+**Template:**
+
+| Metric | Q3 Actual | Q2 Actual | Trend | Signal |
+|---|---|---|---|---|
+| Deployment frequency | 12/week | 8/week | ↑ | On track; target is 15/week by Q4 |
+| Change failure rate | 4.2% | 6.8% | ↓ | Improving; industry benchmark is <5% |
+| Mean time to restore (MTTR) | 38 min | 2.1 hours | ↓ | On track vs. Q3 target of <45 min |
+| P0 incidents | 2 | 4 | ↓ | Both Q3 incidents postmortem'd; fixes deployed |
+| Open critical bugs | 7 | 12 | ↓ | 3 require product decision before close |
+| On-call hours/engineer/week | 2.1 | 3.4 | ↓ | Acceptable; watch if any team exceeds 4 |
+
+**What to include:** Metrics where the number alone tells the story.
+**What to exclude:** Metrics that require engineering expertise to interpret. Save those for the architecture review.
+
+---
+
+### Section 2: Delivery Recap (One Page)
+
+What engineering committed to in Q3 and what was delivered. This section requires honesty. Executives who receive only good news from engineering will stop trusting the signal.
+
+**Format:**
+
+**Delivered as committed:**
+- [Initiative name]: [One sentence on what was delivered and why it matters]. [Business metric moved, if applicable.]
+
+**Delivered, modified scope:**
+- [Initiative name]: [One sentence on what was originally committed, what changed, and why]. [Business metric moved, if applicable.]
+
+**Not delivered:**
+- [Initiative name]: [One sentence on why this did not ship]. [What the consequence is]. [When it will ship, or why it was deprioritized].
+
+**Example (not delivered entry):**
+> Fraud detection model v2: Deprioritized in week 6 when the data team identified a data quality issue that would invalidate the training data. Rescheduled for Q4 with a new data pipeline prerequisite. Current fraud loss rate is $22K/month; v2 is estimated to reduce this by 60%.
+
+---
+
+### Section 3: Risks and Blockers (Half Page)
+
+**Format:** Three categories, brief entries.
+
+**Active risks:** Problems engineering is already managing.
+> Infrastructure vendor contract renewal is due January 15. Negotiation is in progress; current contract terms are $1.2M/year. Renewing at current terms is the likely outcome; renegotiation risk if we miss the 60-day window is contract lapse.
+
+**Emerging risks:** Signals that may become problems in the next quarter.
+> Attrition rate in the platform team is 25% annualized over the last two quarters. We have not lost a staff engineer yet, but the trend is a risk to Q4 delivery if it continues. Retaining the two remaining senior platform engineers is a priority.
+
+**Blocked items requiring exec action:**
+> The security audit firm engagement requires legal to execute the MSA. Currently in legal review for 3 weeks. Unblocking this before December 1 is necessary to stay on track for the Q1 SOC 2 report.
+
+---
+
+### Section 4: Team Updates (Half Page)
+
+Headcount, hiring, and organizational changes. Written for a finance and operations audience, not an engineering audience.
+
+**Format:**
+- Headcount: [current] engineers vs. [plan]. [Delta and explanation if material].
+- Open roles: [number open]. [Roles that are critical path if unfilled].
+- Attrition: [number of departures] in Q3. [Voluntary vs. involuntary]. [Any pattern worth naming].
+- Org changes: [any team reorganizations, new managers, reporting changes].
+
+---
+
+### Section 5: Asks (One Page)
+
+What engineering needs from the executive team to deliver on Q4 commitments. This is the most important section. Be specific.
+
+**Format for each ask:**
+- **Ask:** [What you need]
+- **By when:** [Date]
+- **Why it matters:** [What happens if this does not happen by that date]
+- **Who needs to act:** [Named person or function]
+
+**Example:**
+> **Ask:** Approve the $240K annual contract for the database observability tooling (vendor: Datadog, scope: production databases)
+> **By when:** November 15
+> **Why it matters:** We have three P1 incidents in Q3 directly attributable to database performance blind spots. This tooling closes that gap before Q4 holiday traffic.
+> **Who needs to act:** CFO to approve the budget variance; CPO to confirm it is within the engineering tools budget envelope.
+
+---
+
+## Board Engineering Update Format
+
+**Audience:** Board members (may include investors, independent directors, operators)
+**Length:** 1 page (in the board deck), or a 5-minute verbal presentation with a leave-behind
+**Cadence:** Quarterly or as part of a board-level product and technology update
+
+Board members are not engineering practitioners. They are looking for signal on three questions: Is the technology a risk or an asset? Is the team capable of delivering on the company's growth plan? Are there material issues engineering leadership is aware of and managing?
+
+**One-page format:**
+
+```
+ENGINEERING — Q3 2024
+
+DELIVERY
+[Two sentences: what shipped, what it unlocked for the business.]
+Example: "The payments infrastructure migration completed in August, reducing checkout 
+error rates from 2.3% to 0.8% and eliminating the manual reconciliation process that 
+cost ~12 engineering hours/week."
+
+PLATFORM HEALTH
+[One sentence per domain. Use signal words: stable, improving, at risk, recovering.]
+Example:
+- Reliability: Stable. Two P0 incidents in Q3; both resolved and postmortem'd.  
+- Security posture: Improving. SOC 2 Type II audit scheduled for Q1; pre-scan clean.
+- Scalability: At risk. Current architecture supports 2x current load; 
+  Q2 2025 growth projections require architectural work beginning in Q1.
+
+TEAM
+[One sentence on headcount and one sentence on any material people risk.]
+Example: "Team is at 48 of 52 planned headcount; four open roles are in late-stage 
+interviews. One staff engineer departure in Q3; backfill is the priority hire."
+
+RISKS TO WATCH
+[One to two risks, two sentences each. Name the risk, the probability, and what 
+engineering is doing about it.]
+Example: "The AWS us-east-1 dependency is a concentration risk; a regional outage would 
+take the product offline. We are evaluating multi-region active-passive for a Q2 
+implementation. Cost estimate is $80K/year incremental infrastructure spend."
+
+ASK FROM THE BOARD
+[Zero or one asks. Boards can provide: introductions, governance decisions, budget 
+approvals above the CEO's authority.]
+Example: "No asks this quarter."
+```
+
+---
+
+## Incident Executive Summary
+
+**Audience:** CEO, CPO, VP of Customer Success (and whoever else is tracking the incident)
+**Timing:** Within 2 hours of incident resolution; before any external communication
+**Length:** 5 sentences. That is the format, not a suggestion.
+
+```
+INCIDENT EXECUTIVE SUMMARY
+[Service / Date / Duration]
+
+1. WHAT HAPPENED
+[One sentence on the observable failure — what users experienced.]
+Example: "From 2:14 PM to 4:38 PM EST on November 12, users were unable to complete 
+purchases through the web checkout flow."
+
+2. CUSTOMER IMPACT
+[One sentence on scope — how many users, what percentage, what revenue impact if known.]
+Example: "Approximately 14,000 users encountered the failure; estimated revenue impact 
+is $340K based on average order value and the window of impact."
+
+3. ROOT CAUSE
+[One sentence on technical root cause, written for a non-technical reader.]
+Example: "A database configuration change deployed at 2:10 PM introduced a connection 
+pool limit that was too low for peak checkout traffic."
+
+4. FIX
+[One sentence on what was done to restore service.]
+Example: "The configuration change was reverted at 4:35 PM; full checkout availability 
+restored at 4:38 PM."
+
+5. PREVENTION
+[One sentence on what will be done to prevent recurrence — and the timeline.]
+Example: "We are implementing automated load testing for database configuration changes 
+before production deployment; this will be in place by November 26."
+```
+
+**What not to include in the executive summary:**
+- Stack traces, error codes, or technical diagnostics — these belong in the incident postmortem
+- Attribution or blame — this creates legal risk and is inappropriate before a full postmortem
+- Speculation about causes that have not been confirmed
+- Assurances that this will "never happen again" — these are not credible and undermine trust
+
+---
+
+## Major Initiative Status Memo
+
+**Audience:** Cross-functional leadership (CPO, CTO, CEO, relevant VP)
+**When:** When a major initiative is in flight and needs to be discussed at the leadership layer
+**Length:** 1–2 pages, written document (not slides)
+
+```
+[INITIATIVE NAME] STATUS MEMO
+Date: [Date]
+Author: [Engineering leader]
+Distribution: [Who this is going to]
+
+SITUATION
+[Two to three sentences. What are we building, why, and where are we in the timeline?]
+Example: "The identity platform migration moves user authentication from a legacy 
+vendor (Auth0) to our own infrastructure. This is required to support the enterprise 
+SSO feature on the Q4 roadmap and reduces annual vendor cost by $480K. We are in 
+week 6 of a 14-week implementation plan."
+
+PROGRESS
+[Two to three sentences or a brief table. What is done, what is in progress, what is 
+ahead? Honest on schedule.]
+Example: "Phases 1 (infrastructure setup) and 2 (internal user migration) are 
+complete. Phase 3 (external user migration) is in week 2 of 4. We are currently 
+3 days ahead of schedule; this buffer is intentional given the risk in phase 4."
+
+BLOCKERS
+[Each blocker gets: what it is, who owns resolution, by when.]
+Example:
+- Legal review of data processing addendum with the new infrastructure vendor is 
+  pending. Owner: legal. Needed by: November 20. Risk if delayed: phase 4 timeline 
+  slips by approximately one week.
+
+DECISION NEEDED
+[The specific decision this memo is asking for, by whom, by when.]
+Example: "We need CPO approval to send migration notification emails to all external 
+users beginning November 18. The communication draft is attached. Approval needed 
+by November 15 to allow 3 days for localization review."
+
+NEXT UPDATE
+[When leadership should expect the next status memo or update.]
+```
+
+---
+
+## Headcount Request Memo
+
+**Audience:** Engineering VP or CTO (and sometimes CFO or CEO)
+**When:** When requesting a new headcount approval outside of the annual plan
+**Length:** 1 page
+
+The headcount request memo has to answer the question the approver is actually asking: "Why now, why this role, and what happens if I say no?" If it does not answer all three, it will not get approved.
+
+```
+HEADCOUNT REQUEST
+Role: [Title and level]
+Team: [Team name and manager]
+Date needed by: [When the person needs to start — work backward from business need]
+Total compensation (est.): [Base + equity + benefits, as an annual cost]
+Submitted by: [Requestor name and date]
+
+BUSINESS CASE
+[Two sentences. What initiative or outcome requires this hire? Why can existing 
+capacity not absorb it?]
+Example: "The fraud detection model migration, committed to product in Q4, requires 
+ML engineering expertise the current team does not have. Pulling an existing engineer 
+from the payments team to cover this work would put the checkout reliability OKR at 
+risk."
+
+INITIATIVE
+[One sentence on what the hire will work on in their first 90 days.]
+Example: "This hire will own the fraud detection model re-training pipeline and 
+integrate it with the new feature store being built by the data team."
+
+REQUIRED SKILLS
+[3–5 bullet points. Be specific enough that recruiting can write a job description. 
+Be specific enough that the approver can understand what they are approving.]
+Example:
+- 4+ years of production ML engineering (not research)
+- Experience with real-time inference serving (sub-100ms latency constraints)
+- Familiarity with payment fraud domain preferred but not required
+- Python-native; experience with MLflow or equivalent experiment tracking
+
+COST
+[Annual cost all-in, including loaded benefits. Compare to the revenue or cost impact 
+the hire is expected to unlock.]
+Example: "Estimated fully-loaded cost: $280K/year. The fraud model is estimated to 
+reduce fraud losses by $600K/year at current transaction volume."
+
+RISK OF NOT HIRING
+[One to two sentences. What is the realistic outcome if this request is not approved?]
+Example: "If this hire is not approved by December 1 to allow for a Q1 start, we will 
+need to deprioritize the fraud detection migration to Q2 and accept $150K in 
+additional fraud losses in Q1 while we wait."
+```
+
+---
+
+## Common Pitfalls
+
+### Too Much Technical Detail
+
+Executives reading about a database migration do not need to know which ORM was used or the specifics of the migration tooling. Every sentence of technical detail that does not connect to a business outcome dilutes the communication and signals that the author does not understand their audience.
+
+Test: read the document and ask, for every sentence, "does this help the executive make a decision?" If the answer is no, cut it.
+
+### Passive Voice on Risks
+
+"There were some delays due to vendor dependencies" is passive voice on a risk. It obscures who is responsible, what the impact is, and what is being done. Executives reading passive voice on risks conclude, correctly, that the engineering leader is not fully in control of the situation.
+
+Write risks in active voice with an owner and a timeline: "The vendor delayed the API documentation by two weeks. We escalated to their VP of Engineering on October 15; we now have access and are back on schedule."
+
+### Missing the "So What"
+
+The most common failure in engineering-to-executive communication is stating facts without connecting them to consequences. Engineering leaders who write "we completed the infrastructure upgrade" and stop there have communicated half the message. The complete message includes what changed for the business as a result.
+
+Every delivery statement should have a "which means..." or "as a result..." attached to it. If you cannot complete that sentence, you do not yet understand the business impact of the work — and that is a separate problem worth solving.
+
+### Underselling Risk to Protect the Team
+
+Engineering leaders who downplay risk to executives to protect the team from scrutiny are doing the opposite of protecting the team. Executives who learn about a significant risk in a customer meeting or from a board member — rather than from the engineering leader — will conclude that engineering leadership is either unaware of the risk or hiding it. Both conclusions are damaging and hard to recover from.
+
+Surface risks early, frame them constructively, and bring a mitigation plan. That is what builds trust.
+
+### Updating After the Decision Is Made
+
+Executives cannot act on information they receive after the window to act has closed. A headcount request that arrives two weeks before the hiring freeze goes up is too late. An incident summary that lands 12 hours after the incident is resolved is too late for the CEO to have context for the customer conversation they already had.
+
+The timing of upward communication matters as much as the content. When in doubt, communicate earlier and with less polish than later and perfectly formatted.

--- a/org-design/team-topology-framework.md
+++ b/org-design/team-topology-framework.md
@@ -1,0 +1,271 @@
+# Team Topology Framework
+
+## Leadership Context
+
+How you structure your engineering organization determines what your software architecture becomes — not the reverse. Conway's Law is not a metaphor; it is a predictive model. When two teams share ownership of a service boundary, that boundary will accumulate negotiation overhead and slow down both teams. When a platform team has no explicit charter to reduce cognitive load on stream-aligned teams, it becomes a bureaucratic gate. Org design is architecture work, and it has the same stakes: get it wrong and you spend years paying the interest.
+
+This playbook treats org structure as a first-class engineering decision with measurable outcomes: deployment frequency, time to detect and recover from incidents, and the percentage of sprint capacity spent on coordination rather than delivery. Designed for Directors and Heads of Engineering who are inheriting a structure, scaling through a growth inflection, or rationalizing after an acquisition.
+
+---
+
+## When to Use This
+
+Org redesign carries real cost — migration periods, team disruption, knowledge transfer gaps. Don't trigger a reorg without one of the following signals:
+
+| Signal | Threshold to Act |
+|--------|-----------------|
+| Team size exceeds cognitive load ceiling | Team owns more services than it can hold context for; engineers cannot answer basic questions about half their systems without a Slack thread |
+| Ownership confusion | The same incident involves 3+ teams with no clear DRI; postmortems consistently cite "unclear ownership" |
+| Platform/product split has happened organically | A subset of engineers is doing infrastructure and tooling work but reporting to product-embedded teams; incentives are misaligned |
+| Acquisition integration | Two codebases, two deployment pipelines, two team structures; integration velocity is constrained by the org boundary |
+| New Director taking over | Inherited structure that was designed for a different stage or strategy |
+| DORA metrics plateau or regress | Deployment frequency, lead time, or MTTR has stopped improving despite technical investment; structural friction is the likely cause |
+
+Do not reorg in response to interpersonal conflict, a single bad quarter, or as a substitute for addressing a performance problem. Reorgs that are actually people moves in disguise produce cynicism that persists for years.
+
+---
+
+## The Four Team Types
+
+The Team Topologies framework (Skelton & Pais, 2019) identifies four fundamental team types. The value of the framework is not the labels — it is the explicit recognition that different team types have different interaction modes and different mandates, and conflating them causes predictable failure.
+
+### Stream-Aligned Teams
+
+**What they are:** A team aligned to a single flow of business value. Owns a product area, a customer journey, or a service domain end-to-end, from code to production. Responsible for the full lifecycle: build, deploy, operate, and iterate.
+
+**Interaction mode:** Mostly autonomous. Consumes platform capabilities as self-service. Occasionally asks enabling teams for expertise during a capability ramp.
+
+**Example:** The Payments team at a fintech owns the checkout flow, payment processing integrations, and fraud signals. They deploy independently. They are on-call for their own services. They do not wait for another team to provision infrastructure or review their deployments.
+
+**When to use:** The default team type. If a team is not explicitly one of the other three types, it should be stream-aligned.
+
+**Size:** 5–9 engineers. Below 5, you lose redundancy and on-call coverage. Above 9, coordination overhead begins to exceed delivery throughput.
+
+**Warning signs that a stream-aligned team has too much scope:**
+- Sprint velocity is dominated by unplanned work (bugs, incidents, coordination)
+- Engineers cannot describe the blast radius of a change without checking with another team
+- On-call rotations have fewer than 4 people, creating burnout risk
+
+---
+
+### Platform Teams
+
+**What they are:** A team that builds and operates internal platforms that reduce cognitive load for stream-aligned teams. The platform is the product; stream-aligned engineers are the customers.
+
+**Interaction mode:** X-as-a-Service. Stream-aligned teams consume platform capabilities through well-defined APIs, self-service portals, or shared tooling — not through ticket queues or Slack requests.
+
+**Example:** A Developer Experience (DevEx) platform team at a growth-stage company owns the deployment pipeline, the Kubernetes cluster abstractions, the secrets management interface, and the observability stack. Stream-aligned teams deploy by pushing code; the platform handles the rest.
+
+**When to use:** When 3+ stream-aligned teams are doing the same infrastructure or tooling work independently, or when SRE/infrastructure work is too intertwined with product delivery to be done well by any single product team.
+
+**Critical constraint:** A platform team that requires stream-aligned teams to file tickets and wait is not a platform team — it is a gatekeeper. The success metric for a platform team is reduction in time-to-production for stream-aligned teams, not utilization of the platform team's engineers.
+
+**Size:** Platform teams are typically smaller than the teams they serve. A 4–6 person platform team can support 30–50 engineers if the self-service surface is well designed. If the platform team is larger than 20% of the total engineering org, something is wrong — either scope is too broad or the team is compensating for poor self-service with manual support.
+
+**Common failure mode:** Platform team does heroic work keeping the infrastructure running but never builds the self-service layer that would allow stream-aligned teams to operate independently. This creates a dependency that grows linearly with the number of stream-aligned teams.
+
+---
+
+### Enabling Teams
+
+**What they are:** A specialist team that helps stream-aligned (or platform) teams acquire a new capability, then steps back. Their goal is to make themselves unnecessary to the teams they help.
+
+**Interaction mode:** Collaboration (time-bounded). An enabling team embeds, pairs, and teaches, then exits. It does not own the outcome — the stream-aligned team does.
+
+**Example:** A security engineering team at Capital One-scale runs a 6-week engagement with the Payments team to implement DAST scanning and threat modeling in the delivery pipeline. At the end, the Payments team owns and operates those controls. The security team moves to the next engagement.
+
+**When to use:**
+- Introducing a new practice org-wide (observability, chaos engineering, accessibility testing)
+- After an acquisition, to transfer institutional knowledge between codebases
+- When stream-aligned teams consistently struggle with a specific domain (database performance, ML model deployment) that does not justify a full-time specialist on every team
+
+**What it is not:** An enabling team is not a shared services team that does work on behalf of other teams indefinitely. If that is what is happening, the team has drifted into a bottleneck.
+
+**Size:** 3–5. Enabling teams should be small and temporary. If an enabling team is permanent and large, it has become a de facto platform team and should be chartered as one.
+
+---
+
+### Complicated-Subsystem Teams
+
+**What they are:** A team that owns a component where the complexity is high enough that only deep specialists can make changes safely. This is not general complexity — it is mathematical, scientific, or domain complexity that takes years to acquire.
+
+**Interaction mode:** X-as-a-Service. Stream-aligned teams consume the subsystem through a versioned API or interface; they do not modify the internals.
+
+**Example:** A Pricing Engine team at an insurance company owns a real-time actuarial pricing model. The underlying risk calculations require actuarial expertise that the rest of the engineering org does not have and cannot reasonably acquire. Stream-aligned teams call the pricing API; the team of actuarial engineers owns the model.
+
+**When to use:** Sparingly. This team type is only appropriate when the complexity genuinely requires specialists that cannot be distributed across stream-aligned teams. If the justification is "it's just complex," that is not sufficient — complexity that can be learned is a stream-aligned team problem.
+
+**Warning signs of overuse:** If more than 10% of the engineering org is on complicated-subsystem teams, you probably have a platform problem being mislabeled, or a knowledge-hoarding dynamic that has been institutionalized.
+
+---
+
+## Cognitive Load Threshold Framework
+
+Team Topologies defines three types of cognitive load: intrinsic (complexity of the domain itself), extraneous (process, coordination, tooling overhead), and germane (the learning investment that builds capability). The goal is to minimize extraneous load so teams can invest in germane load.
+
+In practice, a team is over-threshold when extraneous load is consuming capacity that should go to delivery.
+
+**How to detect an overloaded team:**
+
+Run a capacity audit. Ask engineers to categorize their last two weeks of work into four buckets:
+
+| Bucket | Description |
+|--------|-------------|
+| Feature delivery | New capability that ships to users |
+| Sustaining work | Bug fixes, tech debt, dependency updates |
+| Coordination overhead | Meetings, cross-team dependencies, waiting on approvals |
+| Unplanned/reactive | Incidents, urgent escalations, context switches |
+
+**Threshold:** If coordination overhead + unplanned/reactive exceeds 40% of capacity across three or more engineers on the team, the team is structurally over-scope. This is not a prioritization problem; it is an ownership problem.
+
+**Secondary signal:** Measure the number of external Slack channels a team is required to monitor. If a team has primary attention responsibilities in more than 4–5 channels outside their own, their information surface is too wide.
+
+**Tertiary signal (for platform-adjacent teams):** If a stream-aligned team is regularly blocked waiting for another team — more than twice per sprint on average — the platform boundary is in the wrong place or the platform is not self-service.
+
+**Worked example:**
+
+A 7-person API Gateway team at a mid-stage startup has accumulated ownership over: the external API, internal service mesh, developer portal, an authentication middleware layer, and the rate limiting service. During a quarterly planning session, engineers report that 55% of sprint capacity goes to coordination (with 4 downstream teams who depend on the gateway) and reactive incident response. Deployment frequency has dropped from 12 deploys/week to 3 over 18 months.
+
+Diagnosis: The team's scope has grown to cover what should be split into two teams — a stream-aligned API Product team and a platform team for the service mesh and developer infrastructure. The auth middleware belongs with neither; it is a complicated-subsystem candidate.
+
+---
+
+## Inverse Conway Maneuver
+
+Conway's Law predicts that organizations produce systems that mirror their communication structures. The Inverse Conway Maneuver turns this into a design strategy: define the architecture you want first, then restructure the org to match it.
+
+**The sequence:**
+
+1. **Define the target architecture.** Not implementation detail — service boundaries, ownership domains, and the key API contracts between them. This is a diagram with team names where service names will go.
+
+2. **Audit the current org against the target.** For each boundary in the target architecture, ask: does one team own both sides of this boundary? If yes, the boundary is at risk — dependencies are invisible and change is uncontrolled. Does the boundary currently require coordination between 3+ teams? If yes, the boundary is overloaded.
+
+3. **Identify the delta.** List the ownership changes required to match the target architecture. Some are team splits; some are team merges; some are responsibility transfers between existing teams.
+
+4. **Execute incrementally.** Full reorgs are high-risk. The safest execution path is to transfer ownership of one service domain at a time, with a defined overlap period (see Reorg Execution Checklist below).
+
+**Example:** A platform engineering team at a 200-person engineering org wants to move from a shared monolithic data platform to domain-oriented data ownership (Data Mesh pattern). The Inverse Conway Maneuver means: before writing the first line of code for domain data products, reorganize so that each domain team (Payments, Identity, Growth) has an embedded data engineer. The architecture follows the org; trying to ship the architecture without the org change fails because teams will not own data products they were not structured to maintain.
+
+**What it is not:** The Inverse Conway Maneuver is not an excuse to keep changing the org every time the architecture shifts. It should be used once, decisively, when there is a major architectural direction change. Repeated small reorgs in service of incremental architecture changes produce instability without benefit.
+
+---
+
+## Common Reorg Failure Modes
+
+**Reorg that increases coupling**
+
+A reorg that merges teams with complementary ownership domains (to "improve alignment") often increases coupling because the combined team now has a wider mandate but no cleaner boundaries. Engineers who were previously blocked by cross-team dependencies are still blocked — they are just blocked by internal team priorities now.
+
+*Detection:* If the reorg does not reduce the number of inter-team dependencies in your DORA data, it made things worse.
+
+**Platform team becomes a bottleneck**
+
+The platform team is formed with the right intent but never builds a self-service surface. Stream-aligned teams file tickets; the platform team has a growing backlog; everyone is frustrated. The platform team is understaffed and overloaded; the stream-aligned teams are slower than before the platform team existed.
+
+*Fix:* Set an explicit KPI for the platform team: percentage of platform interactions that are self-service (no ticket, no Slack request). Target 80%+ within 12 months. Below 50% means the platform team needs to rebuild the interface, not add more capacity.
+
+**Enabling team that never exits**
+
+An enabling team gets stood up to spread a new practice, does excellent work, and then becomes a permanent fixture because the receiving teams have become dependent on them. The enabling team is now doing work that should belong to stream-aligned teams.
+
+*Prevention:* Every enabling engagement has an explicit exit criterion defined before the engagement starts. Example: "The Security Enablement team's engagement with the Payments team ends when: DAST is integrated in the CI pipeline, threat model is documented and reviewed, and two Payments engineers have completed the security engineering certification."
+
+**Reorg as cover for a people problem**
+
+A reorg that is actually designed to move a difficult person or a low-performing team out of a reporting line it has been blocking will not fix the underlying problem. The people problem will re-emerge in the new structure, usually faster, and the reorg will have cost the org 3–6 months of productivity.
+
+**Over-specialization too early**
+
+A 30-engineer org creating 4 team types because the framework says so. Complicated-subsystem teams and enabling teams at early stage are premature. A 30-person org should have stream-aligned teams with a nascent platform function. Adding enabling teams before there is consistent practice to enable produces process overhead without payoff.
+
+---
+
+## Decision Table: Signals to Team Type
+
+| Signal | Recommended Action |
+|--------|--------------------|
+| Multiple teams duplicating infrastructure work | Stand up a Platform team; define the self-service interface first |
+| One team owns too many service domains | Split into two stream-aligned teams along the most natural ownership boundary |
+| A capability gap (observability, security, ML) is blocking multiple teams | Time-bounded enabling team engagement; exit criteria defined upfront |
+| A mathematical/scientific component requires deep specialists | Evaluate complicated-subsystem team; validate that the complexity is truly non-distributable |
+| Team has >9 engineers with shared ownership | Split the team; split the service boundary with it |
+| Team has <4 engineers carrying on-call rotation | Merge with adjacent team or redistribute ownership to reduce on-call risk |
+| Post-acquisition team integration | Treat as Inverse Conway Maneuver; target architecture first, then org delta |
+| DORA metrics plateau despite technical investment | Run cognitive load audit before assuming structural change is needed; audit may reveal it is a tool problem, not a structure problem |
+
+---
+
+## Reorg Execution Checklist
+
+The mechanics of a reorg matter as much as the design. A well-designed reorg executed poorly produces the same outcome as a poorly-designed one.
+
+### Pre-announcement (4–6 weeks before)
+
+- [ ] Target org design is documented: team names, charters, ownership domains, reporting lines
+- [ ] All current service ownership is mapped; no orphaned services in the transition
+- [ ] Every engineer has a home in the new structure; no one learns their team no longer exists without also learning where they land
+- [ ] Key technical leads and staff engineers have been briefed and have had input; they are not surprises
+- [ ] Manager-to-engineer ratios in the new structure are reviewed; no manager has more than 8 direct reports post-reorg
+- [ ] Overlap periods are defined for each ownership transfer (minimum 2 weeks; 4–6 weeks for high-criticality services)
+- [ ] Knowledge transfer plan is documented for each ownership transfer: what documentation needs to exist, who writes it, when
+
+### Announcement
+
+- [ ] Announce the full structure simultaneously, not in stages — partial announcements create anxiety in the groups that have not heard yet
+- [ ] Explain the "why" in terms of business outcomes, not just org efficiency: "We are restructuring so that the Payments team can deploy independently without waiting on the Gateway team" is more credible than "We are restructuring to improve team autonomy"
+- [ ] Separate the announcement from the effective date; give engineers 2–4 weeks between "this is happening" and "this is your team starting Monday"
+- [ ] Provide a written FAQ that directly addresses: reporting changes, on-call rotation changes, project ownership changes, what stays the same
+
+### Transition period
+
+- [ ] Dual-rostering during overlap: engineers from both old and new teams are on-call together for transitioning services
+- [ ] Runbooks and architecture documentation for transferred services are completed before the transition date, not promised for after
+- [ ] A single DRI owns the transition for each service transfer; ambiguity about who is responsible for what produces incidents
+- [ ] Weekly check-in with new team leads to surface friction early; the first 60 days are when structural problems become visible
+
+### Post-reorg stabilization (30–90 days)
+
+- [ ] First sprint retrospectives in the new structure are deliberately run; surface structural issues before they become resentments
+- [ ] Measure: are the cross-team dependencies that motivated the reorg actually reduced? (Check DORA inter-team dependency data)
+- [ ] Check on-call load distribution: is the reorg moving toward its load-balancing goal?
+- [ ] Check in with engineers who changed teams; track engagement signals
+
+---
+
+## Metrics to Track Post-Reorg
+
+Do not reorg and then wait 18 months to find out if it worked. Define a measurement plan before the reorg executes and review at 30, 60, and 90 days.
+
+**Delivery metrics (DORA)**
+
+| Metric | What to watch for post-reorg |
+|--------|------------------------------|
+| Deployment frequency (per team) | Should increase or hold steady; a drop indicates ownership confusion |
+| Lead time for change | Should decrease as cross-team dependencies are reduced |
+| Change failure rate | May increase temporarily during overlap period; should return to baseline within 60 days |
+| Time to restore service (MTTR) | Should not worsen; if it does, ownership clarity is the likely issue |
+
+**Team health metrics**
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| Sprint capacity on coordination + unplanned work | <35% | Baseline before reorg; improvement expected at 90 days |
+| On-call incident count per engineer per week | <2 (P2+) | Reorgs that spread ownership should reduce per-engineer load |
+| Inter-team blocker frequency | Tracked in Jira; baseline + delta | The primary signal that the reorg addressed its root cause |
+
+**Platform-specific (if a Platform team was created)**
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| % of platform interactions that are self-service | >70% at 6 months, >85% at 12 months | Ticket count as denominator; self-service interactions as numerator |
+| Time-to-first-deploy for new service | Should decrease quarter-over-quarter | The clearest outcome metric for a platform team |
+
+**What not to measure:** Do not track individual engineer productivity in the 90 days post-reorg. Context switching, knowledge transfer, and team forming all suppress individual output temporarily. This is expected and healthy. Measuring individual productivity during a transition creates pressure to avoid the knowledge transfer work that makes the transition succeed.
+
+---
+
+## Further Reading
+
+- Skelton, Matthew, and Manuel Pais. *Team Topologies: Organizing Business and Technology Teams for Fast Flow.* IT Revolution Press, 2019. The foundational text for this framework; chapter 6 covers the Inverse Conway Maneuver in depth.
+- Conway, Melvin E. "How Do Committees Invent?" *Datamation*, April 1968. The original paper; short and still precise.
+- Forsgren, Nicole, Jez Humble, and Gene Kim. *Accelerate: The Science of Lean Software and DevOps.* IT Revolution Press, 2018. Provides the DORA metric definitions and the statistical evidence for their relationship to org performance.

--- a/people/career-ladder-calibration.md
+++ b/people/career-ladder-calibration.md
@@ -1,0 +1,333 @@
+# Career Ladder and Calibration Playbook
+
+## Leadership Context
+
+A career ladder is not an HR artifact — it is the primary mechanism by which an engineering organization makes compensation, promotion, and retention decisions consistently at scale. Without a shared level definition, managers in the same org will promote different engineers for different reasons, pay bands will drift, and high performers will leave when they conclude that advancement depends on who their manager is. This playbook covers building a ladder from scratch, running calibration sessions that hold up under scrutiny, and handling the failure modes that quietly undermine both.
+
+The business outcome is straightforward: equitable promotion decisions reduce regrettable attrition, reduce the cost of external hiring (replacing a mid-level engineer typically runs 0.5–1x their annual salary in recruiting and ramp costs), and give managers a shared vocabulary for growth conversations that do not depend on a single person's judgment.
+
+## When to Use This
+
+**First career ladder.** The org has been making level decisions informally — "Senior" means whatever the hiring manager decided at offer time, and there is no shared standard for what promotion requires.
+
+**Inherited inconsistent levels.** Common after rapid headcount growth (50+ engineers in under 18 months) or after a Director transition. You inherit a team where two engineers with the same title are doing meaningfully different scopes of work, and no one can explain why.
+
+**Post-acquisition level normalization.** The acquired team has its own ladder — often with different level names, different anchors, and different compensation bands. Before you can manage across the combined org, you need a common frame.
+
+**Pre-performance cycle pressure.** The org is running its first formal performance cycle and managers lack calibration anchors. Without a shared frame, every calibration session will devolve into argument about edge cases.
+
+---
+
+## Part 1: IC Track vs. Manager Track
+
+### When to Fork the Ladder
+
+Fork the IC and manager tracks at the level where pure technical execution is no longer the primary job. For most engineering organizations, this is the transition from Senior (L5 equivalent) to Staff/Lead (L6 equivalent) on the IC side, and from Senior to EM or TL/M on the manager side.
+
+The fork matters because the leadership behaviors required to be an effective Director of Engineering are not a superset of what makes a great Staff Engineer. Both paths lead to significant organizational influence — they are parallel, not hierarchical. Treating them as hierarchical (IC as "lesser" than management) produces exactly the wrong incentive: technical leaders feel they must enter management to advance, even when that is not where they create the most value.
+
+The fork should be explicit in the written ladder. Show both tracks side by side at the Senior level so that the choice is visible and deliberate, not something engineers discover when it is already too late to change course.
+
+### What Staff+ Looks Like in Practice
+
+Staff Engineer is where most career ladders become vague and unhelpful. Descriptions like "leads technical direction" or "drives cross-team alignment" are true but not actionable. Here is what Staff-level work actually looks like in a mid-size engineering org (100–500 engineers):
+
+- **Initiative scope:** Owns a technical problem that spans at least two teams and has a meaningful business dependency. At ActBlue, this looked like: driving the migration of payment processing from a legacy monolith to an event-driven architecture, coordinating across the payments team, platform team, and compliance team over 18 months.
+- **Ambiguity tolerance:** Given a problem with no specified solution, produces a structured proposal with trade-offs, a recommended path, and a timeline — without requiring a manager to decompose it first.
+- **Manager multiplier:** A Staff Engineer's work makes the adjacent engineering managers more effective. They surface problems early, translate technical risk into business language, and write the design docs that make review and onboarding faster.
+- **Selective escalation:** Knows which decisions to make autonomously and which decisions require stakeholder buy-in. Gets this right more often than not, even under deadline pressure.
+
+Staff+ is not a reward for tenure. It is a description of the work the person is already doing. If an engineer is not already operating at this scope, the promotion is a bet on a change that has not happened yet — and those bets are expensive when they do not pay off.
+
+---
+
+## Part 2: Level Definition Format
+
+### Why Not Skill Checklists
+
+Skill checklists ("writes idiomatic Go," "can design a REST API") are easy to game and hard to evaluate fairly. An engineer who has been at the company two years and worked on Go exclusively will pass every Go-related item. An engineer hired six months ago from a Python shop may be a more sophisticated engineer but will miss every language-specific criterion.
+
+The definition format that holds up in calibration is structured around four axes:
+
+1. **Impact scope** — What is the scale and consequence of the work this person owns?
+2. **Decision autonomy** — What can this person decide without escalating? What does escalation look like when they do it?
+3. **Execution expectations** — What does "done" look like at this level, and over what time horizon?
+4. **Collaboration expectations** — Who does this person lead, influence, and coordinate with?
+
+These axes force the discussion toward evidence — "what did this person actually do?" — rather than toward abstract capability assessments.
+
+---
+
+## Part 3: Example Level Definitions
+
+### L3 — Software Engineer
+
+**Impact scope:** Owns individual features and bug fixes within a single, well-scoped system. Work is reviewed and guided by L4+ engineers. Mistakes are caught in code review or testing before they reach production.
+
+**Decision autonomy:** Chooses implementation approach within an established design. Does not make architectural choices. Escalates blockers to senior teammates within 24 hours rather than staying stuck.
+
+**Execution expectations:** Completes well-specified tasks in days to a few weeks. Work is accurate and follows team conventions. Produces readable code and adequate test coverage without prompting.
+
+**Collaboration expectations:** Participates in team rituals (standup, retro, sprint planning). Reviews code from teammates with useful feedback. Communicates status proactively when plans change.
+
+**What this is not:** L3 is not a holding stage for engineers waiting to become "real" engineers. It is the level at which someone is learning the system and the team's way of working. Forward movement to L4 is expected within 18–24 months of hire.
+
+---
+
+### L4 — Senior Software Engineer I
+
+**Impact scope:** Owns a feature domain or a subsystem. Work has visible product impact within the team's quarter. Can take a well-defined product or technical requirement from design through delivery without sustained manager guidance.
+
+**Decision autonomy:** Makes implementation and local design decisions autonomously. Escalates decisions that carry cross-team risk or that affect the system's overall architecture. Writes design docs for non-trivial work.
+
+**Execution expectations:** Delivers multi-week initiatives on schedule. Identifies scope risk early and surfaces trade-offs rather than silently accumulating delay. Test coverage, error handling, and observability are part of the definition of done — not afterthoughts.
+
+**Collaboration expectations:** Runs code review for L3 engineers on the team. Mentors new hires through onboarding. Capable of representing the team's technical work to stakeholders outside engineering without losing accuracy.
+
+---
+
+### L5 — Senior Software Engineer II
+
+**Impact scope:** Leads delivery of significant features or technical investments with impact visible to the product and business at the team or product area level. Drives technical strategy within their domain and contributes meaningfully to adjacent domains.
+
+**Decision autonomy:** Makes consequential technical decisions — service boundaries, data model choices, major dependency selections — with appropriate stakeholder review. Does not require a manager to decompose problems before beginning work. Escalates decisions with org-wide implications.
+
+**Execution expectations:** Owns outcomes, not just outputs. Identifies when the defined solution is wrong and redirects without requiring permission. Manages external dependencies (vendor APIs, platform team deliverables, infra capacity) as part of delivery.
+
+**Collaboration expectations:** Informal technical lead for one or more features in flight. Known across the engineering org as a reliable source of expertise for their domain. Writes documentation that enables teammates to work independently. Makes peers more effective.
+
+---
+
+### Staff Engineer (L6)
+
+**Impact scope:** Technical owner of an initiative that spans multiple teams, affects a product line, or addresses a platform-level risk. Work creates leverage across the org — reduces toil, unblocks future roadmap, or closes a risk that would otherwise require executive attention.
+
+**Decision autonomy:** Operates with a high degree of autonomy on technical architecture, tooling choices, and cross-team technical standards. Accountable for the outcomes of those decisions, including when they are wrong. Escalates decisions that have significant cost, compliance, or strategic implications — but arrives at escalation with a recommendation, not just a question.
+
+**Execution expectations:** Drives multi-month technical programs with ambiguous initial scope. Creates the structure that allows others to execute. Writes the technical design that becomes the team's shared understanding. Holds a high quality bar without being a bottleneck.
+
+**Collaboration expectations:** Partners with engineering managers as a peer — not to manage people, but to inform team structure and priorities. Builds relationships across engineering, product, and adjacent functions (security, data, platform). Represents engineering credibly to senior business stakeholders. Grows the technical capability of the org through documentation, review, and direct mentorship of L4–L5 engineers.
+
+**What this is not:** Staff is not a tenure award, a consolation for engineers who do not want to manage, or a title that makes an engineer feel better about not being a Principal. The work must be happening before the title is granted.
+
+---
+
+## Part 4: Calibration Session Structure
+
+### Purpose
+
+Calibration is not performance review. It is the mechanism that ensures level decisions are consistent across managers — that "Senior" means the same thing to a manager in the payments team as it does to a manager in the platform team.
+
+Calibration should happen at minimum once per year, prior to the compensation cycle, and before any batch promotions are finalized.
+
+### Pre-Read Format
+
+Each manager prepares a one-page write-up for each engineer under review. The format:
+
+```
+Name: [Engineer]
+Current level: [L4]
+Manager recommendation: [Promote to L5 / Sustaining at L4 / Needs support]
+Time in level: [14 months]
+
+Evidence of impact scope (2–3 bullet points of specific work, not traits):
+- Led delivery of the user authentication rewrite, reducing login latency by 40% across 1.2M active accounts
+- Identified and resolved a data race in the order processing service that was producing 0.3% silent data corruption; root cause required coordinating a fix across two teams
+
+Evidence of decision autonomy:
+- Proposed and delivered migration from session cookies to JWT without senior oversight; trade-offs documented in design doc X
+- Escalated one architectural risk (cache invalidation strategy) in Q3, arrived with three options and a recommendation
+
+Evidence of collaboration:
+- Runs code review for two L3 engineers; feedback is specific and actionable based on review history
+- Wrote onboarding guide for the payments service that reduced new hire ramp time from 3 weeks to 10 days
+
+Context (anything that affects interpretation):
+- Was primary on-call for 6 weeks during team staffing gap — may underrepresent "normal" scope
+- Joined the team 8 months ago via internal transfer; prior work at L5 scope should count
+```
+
+This format forces managers to work from evidence before the session, not to improvise in the room.
+
+### Facilitator Role
+
+Calibration sessions need a neutral facilitator — typically the Director or VP of Engineering, or a senior HR partner who knows the org. The facilitator does not advocate for any individual. Their job is to:
+
+- Ensure every engineer gets equivalent discussion time
+- Surface proxy arguments ("she works so hard") and redirect to evidence
+- Name calibration failure modes when they are happening (see Part 5)
+- Drive toward a decision when discussion has exhausted new evidence
+
+The facilitator is not the final decision-maker on every case. For clear cases (strong evidence at or above the target level, or clearly not there yet), the manager's recommendation stands. The facilitator earns their influence in contested cases.
+
+### Promotion vs. Not-Yet Criteria
+
+**Promote:**
+- Engineer is operating at the target level consistently and for a sustained period (typically 6+ months of clear evidence)
+- The promotion recognizes work that has already happened, not potential for work to happen
+
+**Not yet:**
+- Engineer is operating at the target level in some but not all dimensions
+- Evidence is strong for this cycle but was concentrated in the last 60 days (recency — see failure modes)
+- Manager can name specific gaps and a plausible path to close them in the next cycle
+
+**Not yet is not no.** The calibration session output for a not-yet case should include: what specifically needs to happen, over what time horizon, and what support the manager will provide. If a manager cannot articulate this, the case needs more discussion.
+
+### Forced Ranking — Do Not Use It
+
+Forced ranking (e.g., stack-ranking all L4 engineers against each other and requiring a fixed distribution of outcomes) is incompatible with a level-based promotion system. Level definitions describe an absolute standard, not a relative one. Two engineers can both meet the bar for L5 and should both be promoted, even if they are on the same team. Forced ranking will correctly identify your top performers. It will also incorrectly suppress promotion of everyone else and create a zero-sum dynamic that destroys peer collaboration.
+
+The legitimate version of forced ranking is using it as a calibration check, not as a decision mechanism: "If we had to rank these engineers, would the order surprise us? If so, why?" That is a useful question. Requiring a bottom 10% outcome is not.
+
+---
+
+## Part 5: Calibration Failure Modes
+
+### Grade Inflation
+
+**What it looks like:** Every manager promotes every report. L5 is the new L4. "Senior" describes 70% of the engineering org.
+
+**Why it happens:** Managers use promotion as a retention tool when they cannot offer salary increases, or when they lack the confidence to deliver difficult feedback. The ladder loses predictive validity — a title no longer reliably describes the scope of work the person owns.
+
+**How to catch it:** Track promotion rates by manager over time. A manager who promotes every eligible engineer in every cycle is not a great developer of talent — they are either managing an exceptional team or avoiding difficult conversations. Both are worth understanding.
+
+**How to address it:** Require managers to articulate the gap between the current level definition and the promoted level definition for each promotion. If the write-up does not distinguish between the two, the case is not ready.
+
+### Recency Bias
+
+**What it looks like:** An engineer who delivered one highly visible project in Q4 gets promoted, while an engineer who delivered consistently across the year does not.
+
+**Why it happens:** Recency is cognitively easier than sustained evaluation. Visible projects get promoted; steady contributors are overlooked.
+
+**How to catch it:** During calibration, ask managers to cite evidence from the full review period, not just the last quarter. If all the evidence in a write-up is from the past 90 days, flag it.
+
+**How to address it:** The pre-read format requires evidence across the review period. The facilitator's job is to name recency bias when it is happening: "You've cited three things from Q4. What do you have from Q1–Q3?"
+
+### Proximity Bias
+
+**What it looks like:** Engineers who are co-located with their manager, who are in the same timezone, or who are well-known in the organization get promoted faster than engineers who are remote, on different schedules, or who contribute in less visible ways.
+
+**Why it happens:** Calibration evidence is gathered by the manager, and managers observe their most proximate reports most easily. Platform engineers who work across teams in low-visibility ways accumulate less narratable evidence than product engineers who ship user-facing features.
+
+**How to catch it:** At calibration, ask: "Is there anyone on your team whose work I might not know about? What did they do?" This surfaces contributors who are not on the org's radar.
+
+**How to address it:** Encourage engineers to write their own contribution summaries as input to the pre-read. Some teams run "brag docs" — a running log of completed work that engineers maintain themselves. This is not about self-promotion; it is about ensuring the manager has evidence that is otherwise invisible.
+
+---
+
+## Part 6: Contested Promotions and Appeals
+
+### When a Promotion Is Contested
+
+A promotion is contested when:
+- A manager advocates strongly for promotion and the calibration group does not agree
+- An engineer expected promotion and did not receive it, and is not satisfied with the explanation
+- There is credible evidence that the decision was influenced by bias
+
+### Appeals Process
+
+Every engineer has the right to understand why a promotion did not happen and to request a second review. The appeals process should be:
+
+1. **First step:** Engineer meets with their manager to review the calibration outcome and the specific evidence gaps cited. This meeting should happen within two weeks of the cycle close.
+
+2. **Second step:** If the engineer believes the outcome was based on incomplete evidence or an inconsistent standard, they may request a skip-level conversation with the manager's manager. The skip-level is not a reversal mechanism — it is a quality check. The skip-level can confirm the outcome, reopen the case, or escalate to HR review.
+
+3. **Third step (rarely needed):** If the engineer believes the outcome reflects discriminatory bias, it is escalated to HR and handled through a separate process.
+
+The appeals process should be documented and communicated to every engineer before calibration runs. An undocumented appeals process is not a process — it is a rumor.
+
+### Skip-Level Input
+
+For promotions to Staff and above, skip-level input should be solicited before calibration, not as a last resort. The people best positioned to assess whether an engineer is operating at Staff scope are the Directors and VPs who observe their work across teams. Build skip-level observation into the promotion process: for any promotion above L5, the write-up should include one perspective from someone outside the immediate management chain.
+
+---
+
+## Part 7: Compensation Banding Philosophy
+
+### How Bands Work
+
+Each level maps to a salary band with a minimum, midpoint, and maximum. The band is wide enough to accommodate variance in market and tenure (typically 20–30% spread from min to max). The midpoint represents market rate for someone operating solidly at the level. Engineers in the lower half of the band are either new to level or in markets where labor costs are lower. Engineers at or above the midpoint have been at the level for some time and are performing well.
+
+### What to Communicate Without Causing Attrition
+
+The standard advice — "share the band" — is incomplete. Sharing a band without context tends to produce exactly what it is designed to prevent: engineers who learn they are at 75% of the band max immediately ask why they are not at 100%, and engineers who are near the top of the band conclude there is no room to grow.
+
+The framing that works:
+
+- Share the band for the current level and the band for the next level. The gap between them is the financial incentive for promotion — make it visible.
+- Explain that being in the lower half of the band is not a signal of low performance. It reflects market and tenure factors, not a verdict on the engineer's capability.
+- If an engineer is significantly below midpoint for their level and has been at level for 18+ months, that is a compensation problem to address in the next comp cycle — proactively, not in response to a resignation.
+
+### When Compensation Correction Is Needed
+
+Compensation corrections (adjustments not tied to a promotion) are sometimes necessary when:
+- An engineer was hired into the band low and has not been adjusted upward as they grew
+- Market rates have moved significantly and the band has not kept up
+- Compression has occurred — junior engineers hired recently are earning close to or more than senior engineers with 3+ years in level
+
+Corrections should be handled before they become retention problems. The signal that a correction is needed is usually a manager instinct ("I'm worried about losing this person") combined with a comp gap that cannot be explained by performance or tenure. Act on that signal early. Waiting for a competing offer is a worse outcome for the engineer and the org.
+
+---
+
+## Part 8: 6-Month Check-In Template for New Levels
+
+When an engineer is promoted, the most common failure is that no one revisits the expectations for the new level until the next performance cycle. The engineer got the title and the raise; the conversation about what is expected at the new level does not happen systematically.
+
+Run this check-in at the 6-month mark after every promotion:
+
+```
+6-Month Level Check-In
+Engineer: ___________
+New Level: ___________
+Date: ___________
+Manager: ___________
+
+1. What work have you owned in the past 6 months that reflects your new level?
+   (Engineer answer — should reference the impact scope dimension of the level definition)
+
+2. Where do you feel the clearest sense of operating at [new level]?
+
+3. Where does the new level expectation feel least settled or most unclear?
+
+4. In the last 6 months, is there a decision you made that you would characterize as clearly within your new level? Describe it.
+
+5. Is there a decision you escalated or deferred that you now think you should have owned? Describe it.
+
+6. What support would make the biggest difference to you in the next 6 months?
+
+Manager notes:
+- Is the engineer demonstrating the core behaviors for the new level consistently?
+- Any gaps from the level definition that are showing up in daily work?
+- What is the one thing that, if different, would make this engineer's growth in the new level clearly on track?
+```
+
+The check-in is not a mini-performance review. It is a calibration conversation between the engineer and their manager on whether the transition to the new level is working. Most promotions succeed. Some stall. This check-in surfaces the stalls before they become performance issues.
+
+---
+
+## Implementation Checklist
+
+- [ ] Draft level definitions using the four-axis format (impact scope, decision autonomy, execution expectations, collaboration expectations) — not skill checklists
+- [ ] Get at least two other senior leaders to review each level definition against actual engineers on the team before publishing
+- [ ] Write one worked example per level drawn from real work the team has shipped in the past 12 months
+- [ ] Decide where the IC/manager fork happens and document both tracks explicitly
+- [ ] Define Staff-level work in terms of actual recent initiatives — not abstract capabilities
+- [ ] Build the calibration session schedule: at minimum once per year, 30 days before the compensation cycle
+- [ ] Publish the pre-read format to all managers 4 weeks before calibration
+- [ ] Train the facilitator (Director or VP) on the three failure modes and when to name them
+- [ ] Document the appeals process and communicate it to the full engineering org before calibration runs
+- [ ] Build the compensation band communication template — both the current level band and the next level band
+- [ ] Schedule 6-month check-ins for all engineers promoted in the current cycle
+- [ ] Set a calendar reminder to review level definitions every 18–24 months for drift
+
+---
+
+## What Does Not Work
+
+**Publishing a ladder and not using it.** The ladder only has value if calibration decisions reference it explicitly. If managers are not citing level definitions during calibration, the ladder is a document, not a system.
+
+**Level definitions that describe potential.** "Has the potential to operate at Staff scope" is not an evidence-based statement. Calibration must be grounded in what has already happened. Promote on evidence, not on prediction.
+
+**Skipping calibration for years.** Level drift accumulates silently. Two years without calibration produces a distribution where some teams have been promoting aggressively and others have not, and the discrepancy is invisible until someone's lateral transfer exposes it.
+
+**Using the ladder only for promotions.** The level definitions should be the anchor for growth conversations in every 1:1 at every level. If an L4 engineer cannot tell you what L5 looks like in practice, the ladder is not doing its job.

--- a/people/headcount-capacity-planning.md
+++ b/people/headcount-capacity-planning.md
@@ -1,0 +1,254 @@
+# Headcount and Capacity Planning Playbook
+
+## Leadership Context
+
+Headcount planning is where engineering leadership earns or loses credibility with finance and the executive team. A Director or Head of Engineering who arrives at annual planning with a number and a story — without a model — is asking for trust they have not yet established. A leader who arrives with a model showing how each FTE maps to a specific initiative, a projected output, and a risk if the hire does not happen is having a fundamentally different conversation.
+
+The business outcome: accurate headcount modeling increases delivery confidence (teams are not perpetually understaffed), reduces time-to-hire pressure (you know when you need the person before it is urgent), and builds the kind of exec trust that translates into more headcount authority over time. Engineering leaders who consistently hit their delivery commitments get more headcount the next cycle. Leaders who miss because they failed to account for attrition, ramp time, or toil do not.
+
+## When to Use This
+
+**Annual planning.** The org is setting headcount targets and budget for the next fiscal year. Engineering needs to translate a product roadmap into an FTE model that finance can evaluate.
+
+**Reorg.** Teams are being restructured. The question is whether the new org design has the right people in the right places — or whether restructuring has created a coverage gap that needs a backfill or new headcount to close.
+
+**New product line.** Leadership has decided to build something net-new. The question is: what does the team need to look like, and when do you need to hire?
+
+**Missed delivery attributed to staffing.** A quarter ended with a major initiative delayed or descoped. Post-mortem attribution points to insufficient staffing, scope creep, or unexpected attrition. Leadership needs a model for what the team should have looked like to hit the target.
+
+---
+
+## Part 1: The Capacity Model
+
+### Four Inputs to Any Headcount Estimate
+
+Before building a model, acknowledge that engineering time is not uniformly available for new work. Four inputs consume available capacity before any line of new product code is written:
+
+**1. Net new work.** The roadmap initiatives — the things the business is asking engineering to build. This is where most headcount models start and stop, which is why they are wrong.
+
+**2. Maintenance and toil.** Production systems require ongoing attention: dependency upgrades, security patches, performance fixes, monitoring improvements, infrastructure drift, and the long tail of technical debt that never quite makes the sprint but never quite goes away. In most mature engineering orgs, 20–30% of engineering time is absorbed here. For orgs with significant legacy debt, the number is higher. It does not go on the roadmap; it is always there.
+
+**3. Org overhead.** Engineering time spent on activities that are necessary but do not directly produce code: sprint ceremonies, 1:1s, hiring (phone screens, loops, debrief time), on-call rotations, cross-functional meetings, documentation, and onboarding new hires. Rule of thumb: 15–25% of time depending on team seniority and org scale. Senior engineers in hiring-intensive environments can lose 30%+ of their time to recruiting in a hot quarter.
+
+**4. Attrition replacement.** Engineers leave. The average annual attrition rate in software engineering organizations varies by market and org culture, but 10–15% annually is a reasonable planning assumption in a healthy org; 20%+ is elevated and suggests structural problems. Attrition creates a gap that is not filled until the replacement hire is fully ramped — which takes 60–90 days to start, and then 3–6 months of ramp time for a mid-level engineer to reach full productivity. An org of 40 engineers at 12% annual attrition will lose roughly 5 engineers per year; those 5 slots are generating partial-to-zero capacity during replacement and ramp.
+
+### Approach 1: Initiative-Level Modeling
+
+Best for: annual planning, new product lines, cases where the roadmap is defined at the initiative level.
+
+For each initiative on the roadmap, estimate:
+- Team size needed (FTEs, by role where relevant)
+- Start date and ramp date (when does the team need to be at full capacity?)
+- Duration (how long is this initiative in flight?)
+- Required output (launch, capability, risk reduction, cost savings)
+
+Then stack the initiatives against the calendar and identify where demand exceeds available supply.
+
+**Example (simplified):**
+
+| Initiative | Required FTEs | Start | Full Ramp | Duration |
+|---|---|---|---|---|
+| Payments v2 | 4 | Jan | Mar | Q1–Q3 |
+| Data platform rebuild | 3 | Mar | May | Q2–Q4 |
+| Mobile rewrite | 5 | Jun | Aug | Q3–Q1+1 |
+| Platform reliability | 2 | Jan | Jan | ongoing |
+
+At peak overlap (Q2–Q3), this roadmap requires 14 FTE at full capacity. That does not include maintenance, overhead, or attrition replacement. Add those inputs and the real capacity need is closer to 18–20 FTE.
+
+**Trade-off:** Initiative-level modeling is intuitive and easy to present to non-engineering executives. Its weakness is sensitivity to scope changes — when initiative scope shifts mid-year (as it always does), the model breaks and requires manual reconstruction.
+
+### Approach 2: Story Point / Throughput Modeling
+
+Best for: teams with mature sprint data and stable velocity baselines; useful for quarterly planning horizons.
+
+Calculate historical team velocity (story points per sprint, averaged over 6–12 sprints). Estimate the story point volume of the roadmap. Divide to get the number of sprints required. Then factor in capacity loss (maintenance, overhead, attrition) and derive the FTE requirement that keeps the timeline intact.
+
+**Example:**
+
+- Current velocity: 120 story points per 2-week sprint for a team of 8 engineers
+- Roadmap estimate: 960 story points for the next 6 months
+- Raw capacity: 12 sprints = 960 points (fits, if capacity is 100% available)
+- Adjusted for maintenance (25%): effective capacity = 90 points/sprint → 960/90 = 10.7 sprints ≈ 22 weeks → slips by 6 weeks
+- To hit the original timeline: need ~10 FTE, not 8, to absorb maintenance load and maintain roadmap velocity
+
+**Trade-off:** Story point modeling is precise when velocity data is reliable and when the work is well-decomposed. It breaks down for highly uncertain work (new domains, platform-layer work, anything requiring significant discovery) and requires discipline in estimation that many teams do not have.
+
+**Practical recommendation:** Use initiative-level modeling for the annual plan (where initiative-level uncertainty is higher) and throughput modeling for quarterly planning (where sprint-level data is more reliable).
+
+---
+
+## Part 2: Building the Headcount Ask to Finance
+
+### The One-Page Model
+
+The finance team does not need a spreadsheet with 15 tabs. They need to answer one question: is the return on this headcount investment greater than the cost? Structure your ask around that question.
+
+**Format:**
+
+```
+Initiative: [Name]
+Business output: [What this team will produce — measured outcome, not activity]
+Required team: [N engineers + N roles, ramped by Month X]
+Fully-loaded annual cost: [$XXX,000 per engineer × N = $X.XM]
+Risk if not funded: [Revenue impact, delivery slip, competitor risk — in business terms, not engineering terms]
+ROI framing: [This team enables $X in revenue / avoids $X in risk / reduces $X in operational cost]
+```
+
+**Worked example:**
+
+```
+Initiative: Payments v2 — modernized payment processing engine
+Business output: Reduce transaction failure rate from 1.8% to <0.5%, enabling $4.2M in 
+  annual revenue currently lost to payment failures; reduce payment team toil by 
+  estimated 30%, freeing 1 FTE of capacity for roadmap work
+Required team: 4 engineers (2 senior, 1 mid, 1 junior) ramped to full capacity by March
+Fully-loaded annual cost: $1.1M (including benefits and overhead burden)
+Risk if not funded: Transaction failure rate persists; 6-month delay to any subsequent 
+  payments feature (architecture dependency); team attrition risk if legacy burden continues
+ROI framing: $4.2M revenue recovery / $1.1M team cost = 3.8x return in year one
+```
+
+This framing is legible to a CFO, a board member, and an engineering manager. It does not require translation.
+
+### Prioritizing When You Cannot Hire Everything
+
+The realistic outcome of annual planning is that you will not get every headcount request approved. You will get a budget and need to prioritize within it. The framework for sequencing:
+
+1. **Attrition backfills first.** If you are losing an engineer and not replacing them, you are shrinking the team. Unless the headcount was redundant, backfills protect existing capacity and should be filled before net-new hires.
+
+2. **Critical path initiatives next.** Identify which roadmap initiatives are on the critical path for the business — the ones where a delay has direct revenue, compliance, or competitive consequence. Staff those first.
+
+3. **Enabling investments third.** Platform and infrastructure work that unblocks other teams is often undersold in planning because its output is invisible to product teams until it is absent. Make the dependency explicit: "The data platform team's work in Q2 unblocks three product initiatives in Q3–Q4. Without that team at capacity, those initiatives slip."
+
+4. **Speculative work last.** Initiatives that are exploratory, depend on a strategic bet that has not been validated, or whose timeline is flexible should be the last to get headcount. They should also be the first to be paused if mid-year budget pressure forces a reduction.
+
+---
+
+## Part 3: Backfill vs. New Headcount
+
+When a headcount request is for a departing engineer's replacement, the instinct is to backfill the exact same role. This is sometimes correct and sometimes a missed opportunity to reshape the team.
+
+### Decision Criteria for Backfill
+
+**Backfill at the same level when:**
+- The departing engineer's work is genuinely needed and no one on the team can absorb it
+- The team is already understaffed and adding scope would destabilize delivery
+- The departing engineer owned critical institutional knowledge that needs to stay on the team
+
+**Backfill at a different level when:**
+- The departing engineer was overleveled for the work that actually needs doing (common after rapid growth; orgs hire at senior levels when the work does not require seniority, then find themselves with a senior engineer backlog problem)
+- The team has grown in seniority and the work distribution has shifted — what you needed two years ago is not what you need now
+- You have an internal promotion candidate who can fill the vacated scope if supported
+
+**Use the backfill as an opportunity to reshape when:**
+- The org design has changed (a reorg happened) and the work distribution across teams is now different
+- A new technology or architecture decision has shifted what skills are most valuable
+- The departing engineer was a high-scope individual and absorbing their work into existing team members is a legitimate growth opportunity, not a compression problem
+
+**The budget is not automatically reused.** Finance treats backfills as automatic because the headcount was already approved. Engineering leaders should treat them as a planning choice. If the work does not need to be done, the headcount is better redeployed.
+
+---
+
+## Part 4: Common Headcount Planning Errors
+
+### Ignoring Ramp Time
+
+A new hire who starts in January is not at full productivity in February. Mid-level engineers typically take 60–90 days to contribute independently and 4–6 months to be fully productive in a complex codebase. Senior engineers ramp faster in terms of productivity but slower in terms of organizational context — the organizational influence that justifies their seniority takes time to develop.
+
+**Consequence:** If your model assumes January headcount produces January capacity, your Q1 delivery plan is already overstated.
+
+**Fix:** In your headcount model, represent new hires at 25% capacity in month 1, 50% in months 2–3, 75% in months 4–5, and 100% from month 6 onward. Adjust for role seniority and codebase complexity.
+
+### Ignoring Attrition
+
+Most headcount plans model from current team size and add net-new hires. They do not subtract projected attrition. An org with 40 engineers at 12% attrition will lose approximately 5 engineers per year — roughly one every 10 weeks. If those departures are not in the model, the team ends the year 5 people short of the plan, not 0.
+
+**Fix:** Project attrition for the planning period (use historical rate plus any specific risk signals: engineers in the market, team morale concerns, comp gaps) and add attrition replacement hires to the plan explicitly.
+
+### Conflating Contractor Cost with FTE Cost
+
+Contractors are expensive on a per-hour basis but have no benefits, no equity, no severance, and no long-term commitment. In a short-duration scenario (3–6 months of surge capacity), contractors can be cost-effective. Over 12+ months, the cost differential narrows or reverses, and the organizational investment cost (onboarding, context transfer, knowledge continuity) makes FTE the better choice.
+
+**The conflation error:** Presenting a contractor option as "cheaper" than FTE without accounting for fully-loaded FTE cost (benefits = ~20–30% of base salary, employer payroll taxes = ~7–8%, equity = plan-specific) or for contractor overhead (agency margin, which runs 30–50% of contractor hourly rate for staffing agency placements).
+
+**Fix:** Build a comparison that uses fully-loaded cost for both options and accounts for the duration of the engagement.
+
+### Counting Engineers as Fungible
+
+Not all engineers can do all work. A backend engineer specialized in distributed systems cannot immediately contribute to a mobile codebase. A data engineer cannot immediately staff a platform reliability initiative. When planning headcount, the model needs to account for role specificity — not just "4 engineers" but "4 engineers with the specific skills the initiative requires."
+
+---
+
+## Part 5: 12-Month Rolling Model Template
+
+This model should be maintained by the engineering Director and updated monthly. It is the input to quarterly business reviews and annual planning discussions.
+
+| Month | Required FTE | Current FTE | Gap | Open Recs | Expected Fill | Notes |
+|---|---|---|---|---|---|---|
+| Jan | 38 | 36 | -2 | 2 | Feb | Ramping 1 new hire from Dec |
+| Feb | 38 | 37 | -1 | 1 | Mar | 1 filled; 1 still in process |
+| Mar | 40 | 38 | -2 | 3 | Apr–May | Payments v2 team buildout begins |
+| Apr | 40 | 39 | -1 | 2 | May | One expected attrition in Q2 |
+| May | 42 | 41 | -1 | 2 | Jun | Mobile team expansion |
+| Jun | 42 | 42 | 0 | 0 | — | Fully staffed for current plan |
+| Jul | 44 | 42 | -2 | 2 | Aug | Q3 roadmap expansion |
+| Aug | 44 | 43 | -1 | 1 | Sep | |
+| Sep | 44 | 44 | 0 | 0 | — | |
+| Oct | 44 | 43 | -1 | 1 | Nov | Annual attrition projection |
+| Nov | 46 | 44 | -2 | 2 | Dec–Jan | Annual planning headcount |
+| Dec | 46 | 44 | -2 | 2 | Jan | Ramp expected in Q1 |
+
+**Required FTE:** What the current roadmap plan requires at full capacity, accounting for maintenance load and overhead.
+
+**Current FTE:** Actual headcount, including engineers in ramp (shown at partial capacity in the capacity model but counted as 1 in the headcount model).
+
+**Gap:** Negative means understaffed; positive means overstaffed (unusual, but worth tracking if a roadmap shift eliminates a team's work).
+
+**Open Recs:** Active job requisitions approved and in process.
+
+**Expected Fill:** When, based on pipeline, you expect the role to be filled. Does not include ramp time.
+
+This model is not a guarantee. It is a shared assumption about what staffing will look like month-to-month, which gives the engineering Director and the product team a common frame for discussing roadmap feasibility.
+
+---
+
+## Part 6: Presenting Headcount Needs at Board Level
+
+When headcount comes up in a board or executive team setting, the audience has changed. They do not need the model — they need the story the model tells. Three bullets, not a spreadsheet:
+
+**Bullet 1: What we are building and why now.**
+> "We are investing in a new payments infrastructure that will reduce transaction failure rates from 1.8% to under 0.5%. This is a Q1 priority because the current architecture is a dependency blocker for three product initiatives in the second half of the year."
+
+**Bullet 2: What team we need and what it costs.**
+> "We need a team of 4 engineers ramped by March. Fully loaded, that is $1.1M annually. We are requesting approval to open 2 net-new requisitions; the other 2 will be internal transfers from an existing team whose roadmap is complete."
+
+**Bullet 3: The risk of not acting.**
+> "If this team is not in place by March, the Q3 product roadmap has two initiatives that slip to Q4 at minimum. One of those initiatives — the enterprise checkout flow — has a contracted delivery commitment. A delay there creates a contract risk worth approximately $800K."
+
+This framing answers the board's actual questions: Is this a good investment? What are we getting? What happens if we don't do it? The spreadsheet is your backup — bring it, but do not lead with it.
+
+---
+
+## Implementation Checklist
+
+- [ ] Identify your capacity model approach (initiative-level vs. throughput) based on roadmap maturity
+- [ ] Calculate the four capacity inputs for the current team: net new work, maintenance/toil, org overhead, attrition replacement
+- [ ] Build the 12-month rolling model and get it to a shared location where product and finance can see the current state
+- [ ] For each headcount request, build the one-page initiative model (output, cost, ROI, risk-of-no)
+- [ ] Adjust all model projections for ramp time — no new hire is productive at 100% until month 6
+- [ ] Project attrition for the planning period and add replacement hires to the plan explicitly
+- [ ] Audit all open backfill requests — confirm each is the right role at the right level before re-posting
+- [ ] Prepare the 3-bullet executive summary for each major headcount cluster before the planning meeting
+- [ ] Update the rolling model monthly; review the gap column with your product counterpart quarterly
+
+---
+
+## What Does Not Work
+
+**Headcount as a negotiating anchor.** Asking for 20 engineers expecting to get 12 trains finance to discount every request. If your model supports 12, ask for 12. If the model supports 20 and you believe it, defend 20.
+
+**Treating headcount like budget that rolls over.** Unfilled headcount at end of year is often swept by finance into next year's baseline at a lower level. Carry headcount to the point of an active req; if a role has been open for more than 4 months, surface the fill-rate problem, do not let the role silently expire.
+
+**Planning for headcount without planning for onboarding.** Every new hire requires bandwidth from the existing team to ramp — code review, pairing, architecture walkthroughs. If the team is already at capacity, adding two new hires in the same month will reduce total output before it increases it.
+
+**The "we just need one more person" trap.** When a team is struggling to deliver, the instinct is to add headcount. The more likely cause is scope that is not properly bounded, technical debt that is consuming untracked time, or unclear priorities. Headcount does not fix unclear priorities — it amplifies them. Diagnose before you hire.

--- a/program-management/change-management-framework.md
+++ b/program-management/change-management-framework.md
@@ -1,0 +1,274 @@
+# Change Management Framework
+
+## Leadership Context
+
+The most common reason technical and organizational changes fail is not technical — it is that people do not know why the change is happening, do not trust the process, or cannot see what the change means for them. A migration that is technically complete but operationally unused has not succeeded. A reorg that was announced but never reinforced reverts within a quarter. This framework applies to the transitions that engineering leaders must manage at the org level: infrastructure migrations, process overhauls, tooling consolidations, and organizational restructuring. The business outcomes at stake are adoption rate (does the change actually stick?), rollback risk (do we have to undo it?), and people trust during uncertainty (do teams remain productive through the transition?). All three are leadership problems before they are technical ones.
+
+## When to Use This
+
+Apply this framework when:
+
+- A reorg or role change affects more than one team
+- A major technology migration requires teams to change how they work (new CI/CD platform, new data stack, new observability tooling)
+- A process change is being mandated rather than adopted voluntarily (new incident process, new code review standard, new release gate)
+- A tooling consolidation eliminates or replaces a tool that teams rely on
+- A compliance-driven change requires behavioral change from engineers (new secret management process, new data handling policy)
+
+For incremental improvements adopted at a team's own pace, the overhead of a structured change process is not warranted. This framework applies when the change is imposed, time-bounded, or affects teams that did not choose to make it.
+
+---
+
+## Change Types and Their Distinct Needs
+
+Not all changes are managed the same way. The type of change determines which levers matter most.
+
+### Technical Changes: Migrations and Deprecations
+
+**Examples:** Cloud provider migration, CI/CD platform replacement, observability tooling consolidation, database engine upgrade.
+
+**Primary risks:** Technical continuity (does the new thing work as well as the old thing?), adoption (do teams actually switch, or do they maintain parallel workflows indefinitely?), and knowledge gaps (do teams know how to operate the new system?).
+
+**What matters most:** A clear cutover date with enforcement, hands-on enablement (documentation alone is insufficient for tooling changes), and a deprecation timeline that is announced well in advance and honored.
+
+**What does not work:** Soft deadlines ("we'd like to be on the new platform by Q3"), migrations where the old system remains fully available indefinitely, and training that consists of a one-time Zoom session with no follow-up.
+
+### Process Changes: New Workflows and Standards
+
+**Examples:** New incident management process, code review standards, architectural review gate, launch readiness checklist.
+
+**Primary risks:** Compliance theater (teams perform the process without internalizing it), inconsistent adoption across teams, and rollback by attrition (the process is followed for 6 weeks, then quietly abandoned).
+
+**What matters most:** A compelling "why" that connects the process change to outcomes that matter to engineers (not just to leadership), visible enforcement without micromanagement, and feedback loops that allow the process to evolve based on experience.
+
+**What does not work:** Process changes announced as mandates with no rationale, processes that add work without visible benefit to the people doing the work, and changes that are never reinforced after the initial announcement.
+
+### Organizational Changes: Reorgs and Role Changes
+
+**Examples:** Team restructuring, engineering function split or merge, reporting line changes, role redefinition.
+
+**Primary risks:** Productivity loss during transition, talent attrition from people who feel their role was diminished, and loss of informal coordination that was built around the previous structure.
+
+**What matters most:** Individual conversations with directly affected people before the announcement, honest answers to the questions people actually have (career impact, team relationships, reporting structure), and a post-announcement stabilization period with explicit leadership presence.
+
+**What does not work:** "Change by announcement" — communicating a reorg in a large group meeting or email with no prior individual outreach to affected people. This approach prioritizes operational efficiency over the people most affected and is consistently the primary source of attrition during reorgs.
+
+---
+
+## The 5-Phase Change Model
+
+### Phase 1: Diagnose
+
+**Goal:** Understand the current state, the case for change, and the stakeholder landscape before designing the change.
+
+**Activities:**
+- Document the current state: what exists today, who depends on it, what pain or risk it creates
+- Build the case for change: what business outcome does this change produce? What is the cost of not changing? (If the cost of not changing is low, the change should not be a mandate.)
+- Map the stakeholder landscape: who is affected? Who will resist? Who are the informal influencers whose buy-in will move others?
+- Identify the non-negotiables: what aspects of the change cannot flex? A migration to a new cloud provider for compliance reasons cannot be optional. A preferred coding style can be.
+
+**Output:** A 1-page change brief: problem, case for change, success criteria, scope, stakeholders, and non-negotiables.
+
+**Common mistake at this phase:** Designing the change before diagnosing the current state. The result is a change that solves the problem leadership perceives, not the problem that is actually causing friction.
+
+### Phase 2: Design
+
+**Goal:** Define the change and the path to it, including how affected people will be supported through the transition.
+
+**Activities:**
+- Define the desired end state (what does success look like 90 days after the change is complete?)
+- Map the transition path: what must happen for the org to move from the current state to the end state? What is the sequence? What are the dependencies?
+- Design the support structure: training materials, documentation, office hours, champions program (designating a point person per team who receives extra support and serves as the team-level resource)
+- Define the rollback criteria: at what point would the change be acknowledged as failing? What would trigger a reversal or a significant design modification?
+- Set the timeline: when does the transition begin? When does enforcement begin? When does the old state become unavailable or unsupported?
+
+**Output:** Change plan — 2–3 pages. Sections: desired end state, transition path (phased), support structure, timeline, rollback criteria.
+
+**Common mistake at this phase:** Designing the change without input from the people most affected. This produces a change that is technically logical but functionally ignores the realities of how work is done. Include representatives from affected teams in the design phase — not to give them veto power, but to surface gaps the designers cannot see.
+
+### Phase 3: Align
+
+**Goal:** Build the shared understanding and commitment that the change requires before execution begins.
+
+**Activities:**
+- Communicate the "why" broadly and repeatedly before the "what" (the details of the change). People who understand the reason for a change tolerate its friction better than people who have only been told what to do.
+- Hold individual conversations with highly affected people before the broad announcement. This is non-negotiable for organizational changes. For technical and process changes, do it with team leads and informal influencers.
+- Collect and respond to concerns — design a feedback mechanism (see the Feedback Loop Design section) that gives people a structured way to raise concerns without producing an endless open comment period.
+- Confirm alignment with each team lead explicitly: do they understand the change? Do they have what they need to lead it within their team?
+
+**Output:** Stakeholder alignment confirmation. Each decision-maker and influencer has been briefed, their concerns have been heard and addressed (or explicitly acknowledged as unable to be addressed with reasoning), and they are prepared to support the change within their teams.
+
+**The alignment trap:** Alignment does not mean consensus. Some changes will not have consensus. Alignment means the affected people have been heard, their concerns are understood, and the decision has been made with that input incorporated. Waiting for everyone to agree produces paralysis. The goal is informed commitment, not universal approval.
+
+### Phase 4: Execute
+
+**Goal:** Implement the change in a way that manages disruption and maintains trust.
+
+**Activities:**
+- Launch with a clear, consistent message (see the Communication Plan template below)
+- Implement in phases where possible: pilot with one team before rolling out broadly; use a canary approach for technical changes
+- Maintain high visibility of leadership during the transition — this is not the time for engineering leaders to become less accessible
+- Track adoption weekly (see Success Metrics section)
+- Surface and resolve issues in real time; do not accumulate problems and address them in batches
+- Honor the support commitments made during the design phase (training, office hours, champions) — cutting support at this stage signals to the org that the commitment was performative
+
+**Common mistake at this phase:** Launching and then disappearing. A change that is announced, launched, and then left to self-execute without active reinforcement will revert. The execution phase requires active leadership presence through the entire transition window.
+
+### Phase 5: Reinforce
+
+**Goal:** Embed the change into normal operations so it persists without ongoing active management.
+
+**Activities:**
+- Update team norms, documentation, and onboarding materials to reflect the new state as the default (not "the new process" — just "the process")
+- Remove the old state: if the old tool is still available, some people will continue using it. Deprecate and remove on the timeline committed in Phase 2.
+- Recognize and celebrate adoption publicly — name teams and individuals who have successfully adopted the change; this signals that the change is permanent
+- Close the feedback loop: what concerns were raised during execution? What was addressed? What was not addressed and why? Publish a brief summary.
+- Conduct a 90-day retrospective: is the desired end state being achieved? What metrics are improving? What is not working?
+
+**The most common reinforcement failure:** The change succeeds in Phase 4 and leadership moves on. Three months later, the old practices have crept back because they were never formally closed. The reinforce phase is what separates a change that lasts from a change that requires re-running the same process 18 months later.
+
+---
+
+## Stakeholder Resistance Model
+
+Resistance to change comes from three root causes. Diagnosing the actual cause determines the right response.
+
+### Root Cause 1: They Do Not Understand Why
+
+**Symptom:** Questions like "why are we doing this?" and "who decided this?" appearing weeks after the announcement.
+
+**Underlying cause:** The "why" was communicated once, in a broad announcement, and did not connect to things the person cares about. Engineers who are skeptical of management decisions filter announcements for subtext. If the "why" does not ring true, they discount it.
+
+**Response:**
+- Communicate the case for change at the team level, not just in an all-hands. The team lead walking through the "why" is more credible than a VP email.
+- Connect to outcomes that matter to the affected engineers: if the migration reduces deploy time from 45 minutes to 8 minutes, that is the "why" for engineers, not the compliance rationale.
+- Repeat the "why" in multiple formats (written, verbal, in 1:1s for skeptics) for the first 4 weeks.
+
+### Root Cause 2: They Do Not Trust the Process
+
+**Symptom:** "We've been through this before and it didn't work" or "the timeline is unrealistic" or "they didn't ask us before deciding."
+
+**Underlying cause:** Past change processes have failed, been reversed, or been designed without input. The org has accumulated change debt — resistance that builds up when change is repeatedly done poorly.
+
+**Response:**
+- Acknowledge the history explicitly. If past changes failed, say so and describe what is different about this approach. Pretending the past did not happen produces cynicism, not alignment.
+- Include affected teams in the design phase. The change does not need to be co-designed, but the affected people need to have had a real opportunity to shape it.
+- Keep every commitment made during design and execution. Process trust is rebuilt one kept commitment at a time; one broken commitment undoes weeks of progress.
+
+### Root Cause 3: They Do Not See What Is in It for Them
+
+**Symptom:** Questions about career impact, workload, and whether the new process makes their job harder or easier.
+
+**Underlying cause:** The change was framed from the org's perspective (compliance requirement, cost reduction, standardization) without a credible account of what it means for the individual.
+
+**Response:**
+- Answer the "what does this mean for me?" question directly and specifically for each affected role. Do not make people infer the personal implication from an organizational rationale.
+- Be honest when the change is net-negative for some people (more work, loss of familiar tools, role scope reduction). Acknowledging it builds more trust than papering over it.
+- For organizational changes, address career impact questions in individual conversations before the broad announcement.
+
+---
+
+## Communication Plan Template
+
+| Audience | Key Message | Channel | Timing | Owner |
+|---------|------------|---------|--------|-------|
+| Engineering team leads | Why the change is happening, what success looks like, what their team is expected to do, support available | 1:1 conversation + written summary | 2 weeks before broad announcement | VP Engineering |
+| All engineers | What is changing, when, why, and where to get help | All-hands (verbal) + written Confluence post | Announcement day | VP Engineering + TPM |
+| Affected team daily standup | Team-specific impact, questions answered in real time | Team standup (verbal) | Week 1 and Week 2 of execution | Team lead |
+| Executive stakeholders | Status, adoption metrics, risks | Weekly status update | Weekly during execution | TPM |
+| Support / customer-facing teams | If the change is visible externally — what customers may notice and how to respond | Email + briefing session | 1 week before launch | Program lead |
+
+**Timing principle:** Communicate the "why" before the "what." Communicate the "what" before the "when." People who learn the "when" before the "why" react to the deadline, not the rationale.
+
+---
+
+## Feedback Loop Design
+
+Unstructured feedback ("if you have concerns, reach out to the team") produces one of two outcomes: silence (people do not bother because they do not believe it will change anything) or a flood of unstructured input that is impossible to action. Design the feedback loop explicitly.
+
+**Structured collection options:**
+
+1. **Office hours:** 30-minute open sessions twice per week during the first 4 weeks of execution. Any engineer can attend. The TPM or engineering lead takes questions. Decisions from office hours are published in a shared FAQ document within 24 hours.
+
+2. **Async Q&A doc:** A shared document where anyone can add questions anonymously. The program lead answers weekly. Visible to all. This is the most efficient format for high-volume changes — questions cluster, and answering one question answers many people simultaneously.
+
+3. **Team lead feedback loop:** Team leads collect concerns from their teams and bring them to the weekly sync. This works well for concerns that require discussion rather than a direct answer.
+
+**What to do with feedback:**
+
+- Publish a log of questions raised and answers given. This is visible evidence that concerns are being heard.
+- Distinguish between concerns that will change the approach and concerns that have been heard but will not change the approach. Be explicit about which is which.
+- Close the feedback loop at 30 and 60 days: publish a summary of what was raised, what changed as a result, and what did not change with reasoning.
+
+**The endpoint:** Feedback collection cannot be open-ended. After 60 days, move from active feedback collection to normal channels (team syncs, manager 1:1s). Signal this explicitly: "We are closing the structured feedback period. The change is now part of normal operations. Concerns go through your manager or to [channel]."
+
+---
+
+## Rollback Criteria
+
+Both technical and process changes can fail. Define the rollback criteria before the change launches — not in the moment when you are under pressure and the sunk cost feels too high to acknowledge.
+
+**Criteria for acknowledging a technical change is failing:**
+
+- Adoption rate below 30% after 60 days of active enforcement
+- Measurable degradation in a key metric attributable to the change (deploy frequency, incident rate, on-call load) that has not improved after 30 days of operation
+- Three or more teams independently escalating that the new system is causing productivity losses
+
+**Criteria for acknowledging a process change is failing:**
+
+- Compliance theater: teams are performing the process in name only, and the outcomes the process was supposed to produce are not materializing
+- Significant increase in the metric the process was supposed to improve (e.g., incident rate goes up after implementing a new incident process)
+- Team leads reporting that the process is generating more overhead than value
+
+**What rollback means for technical changes:** It does not always mean reverting to the old system. Rollback may mean: pausing the migration and running parallel systems while the issues are resolved, reducing the scope (migrating 3 of 6 services instead of all 6), or replacing the target system with a different option.
+
+**What rollback means for process changes:** Process rollback is usually a redesign, not a return to the previous state. If the new incident process is failing, the response is typically: identify specifically what is not working, redesign those elements, and re-launch — not abandon the process and return to the previous ad hoc approach.
+
+**The hardest call:** When to acknowledge a reorg is failing. Signs include: key people leaving, cross-team coordination breaking down in ways that are attributable to the structure change, and the informal org reassembling the old structure through workarounds. Acknowledging this early and making adjustments is less expensive than maintaining a failing structure for a full year. The signal is usually in attrition and escalation patterns — watch both closely in the first 90 days.
+
+---
+
+## Success Metrics
+
+Track these three signals throughout execution.
+
+### Adoption Rate
+
+The percentage of affected teams or users operating in the new state. Defined specifically per change type:
+
+- For tooling migrations: percentage of teams whose production deployments are running through the new system (not the old one)
+- For process changes: percentage of completed work that followed the new process (e.g., percentage of incidents that used the new incident process)
+- For organizational changes: percentage of team leads reporting active collaboration through the new structure (survey-based)
+
+**Target:** 80% adoption by end of Phase 4 (execution). 100% by end of Phase 5 (reinforce), or explicit documentation of exceptions.
+
+### Ticket Volume
+
+Operational friction from a change shows up as support tickets, Slack questions to the program team, and escalations. Track the volume of change-related support requests week over week.
+
+**Expected pattern:** Volume peaks in week 2–3 of execution, then declines as enablement materials mature and the org builds familiarity. A volume that does not decline after week 4 signals that the support structure is insufficient or the change is generating unanticipated friction.
+
+**Threshold:** If change-related support volume is still high at week 6, run a root cause analysis: is the enablement material inadequate, or is the change itself creating issues that need to be addressed?
+
+### Sentiment Signal: One-Question Pulse Survey
+
+At week 4 and week 8 of execution, send one question to all affected engineers:
+
+> "On a scale of 1–5, how confident are you that [the change] is making your work easier or better? (1 = it is making things significantly harder; 5 = it is clearly an improvement)"
+
+Average score target: 3.5 or above by week 8. Below 3.0 is a signal for active diagnosis — what is driving the low scores? The survey is anonymous. Results are published to the full affected group.
+
+This single-question survey takes 10 seconds to answer, produces actionable signal, and signals to the org that leadership cares whether the change is working for the people it affects.
+
+---
+
+## Common Failure Modes
+
+**Change by announcement.** The change is communicated in a company-wide email or all-hands, and the assumption is that awareness equals adoption. It does not. Announcement is Phase 3; execution and reinforcement are where change actually happens. Orgs that confuse announcement with execution consistently see changes fail to stick.
+
+**Skipping the "why."** Mandating a change without a credible rationale creates compliance without commitment. Engineers who do not understand the "why" will find workarounds, perform the process in letter rather than spirit, or leave when the first compelling alternative arises. The "why" is not a courtesy — it is a precondition for adoption.
+
+**Launching too many changes simultaneously.** Every change competes for organizational attention. An org in the middle of a reorg, a major platform migration, and a new incident process simultaneously is an org where all three changes will be slower, messier, and more expensive than any one would be alone. Sequence changes deliberately. The rule of thumb: no more than one high-friction change per team at a time.
+
+**The support that does not get delivered.** The change plan committed to office hours, champions, and training. The office hours had low attendance after week 2, so they were cancelled. The champions program was never actually resourced. The training was a one-time session that is no longer discoverable. Support commitments that are not delivered signal that the commitment was performative — and erode trust in the next change process.
+
+**Measuring the wrong thing.** Tracking completion ("the migration is 80% done") instead of adoption ("80% of teams are operating in the new state"). A migration that is technically 80% complete but has 30% adoption is failing in the metric that matters. Adoption is the outcome; completion is a leading indicator.

--- a/program-management/launch-readiness-checklist.md
+++ b/program-management/launch-readiness-checklist.md
@@ -1,0 +1,289 @@
+# Launch Readiness Checklist
+
+## Leadership Context
+
+The decision to launch is a leadership decision, not an engineering decision — and the quality of that decision depends on the quality of the information provided. Unstructured go/no-go conversations produce launches that slip because no one owned the call, launches that proceed when they should not because the relevant concern was never surfaced, and launches that generate on-call crises because operational readiness was assumed rather than verified. This playbook establishes a structured gate framework that gives the person making the go/no-go call a complete picture across eight readiness domains, a documented record of who accepted which risks, and a launch day sequence with explicit decision points. When a launch fails, the gate record answers the question executives will ask: what did we know, and what did we decide?
+
+## When to Use This
+
+Apply this launch gate framework for:
+
+- Any release that directly affects external customers (new feature, pricing change, data processing change)
+- Major infrastructure changes (database migrations, cloud provider changes, networking changes, authentication system updates)
+- Compliance-relevant releases (data residency, retention policy changes, third-party data sharing, GDPR/HIPAA-relevant features)
+- Launches coordinated with a customer, partner, or press announcement
+- Any release that, if it fails, would require an all-hands incident response
+
+Do not apply this framework to routine weekly deployments of well-tested features to existing surfaces. The overhead of a full gate process should be reserved for launches with meaningful blast radius. For routine releases, the CI/CD pipeline governance guide provides the right level of controls.
+
+**Minimum threshold:** If rollback would take more than 30 minutes, run the gate process.
+
+---
+
+## The 8 Readiness Domains
+
+### Domain 1: Engineering
+
+Code complete means all features in the launch scope have been merged, reviewed, and deployed to the staging environment. It does not mean "in progress" or "mostly done."
+
+**Checklist:**
+- [ ] All launch-scope features merged and code-reviewed (no open PRs in scope)
+- [ ] Unit test coverage at or above team threshold (define threshold before launch date, not the day before)
+- [ ] Integration tests passing in staging environment
+- [ ] Performance benchmarks run and results reviewed — p50, p95, p99 latency under load conditions that represent the expected launch traffic, not just typical traffic
+- [ ] Load test completed at 2× expected peak traffic (or rationale documented for why this threshold is appropriate)
+- [ ] No P0 or P1 bugs open in launch scope; P2 bugs reviewed and either resolved or waivered with rationale
+- [ ] Feature flags configured correctly for launch state (confirm flags are in the expected position for launch, not left in a test state)
+- [ ] Database migrations tested on a production-representative data volume
+- [ ] Third-party API integrations tested with production credentials in staging (not test keys, which may have different rate limits and behavior)
+
+**Owner:** Engineering lead for the primary service(s) in scope.
+
+### Domain 2: Operations
+
+A feature that works but cannot be operated is not ready to launch. Operations readiness covers the tooling and documentation that the team will use after the launch, not just the launch itself.
+
+**Checklist:**
+- [ ] Runbooks written for the top 3–5 expected failure modes of the launched feature
+- [ ] Monitoring dashboards exist and display the right signals (not generic service dashboards repurposed for this feature — dashboards with metrics specific to the launched functionality)
+- [ ] Alerting configured with:
+  - At least one alert on the primary success metric (e.g., checkout completion rate, API success rate)
+  - At least one alert on the primary error signal (5xx rate, exception rate, queue depth)
+  - Alert thresholds calibrated to production baseline — not default values from the monitoring platform
+- [ ] On-call engineer briefed on the launch, the feature behavior, and the runbooks before launch begins
+- [ ] Operational ownership confirmed: which team is on call for this feature, and do they know it?
+- [ ] Log verbosity reviewed — sufficient to diagnose failures without flooding the log aggregation pipeline
+
+**Owner:** Engineering lead plus on-call rotation lead.
+
+### Domain 3: Security
+
+Security review is not a checkbox that legal requires. It is the domain where unreviewed assumptions about data flow, access control, and authentication surface before they are exploitable.
+
+**Checklist:**
+- [ ] Threat model reviewed and updated for the launched feature (if the feature processes new data types, integrates a new third party, or changes authentication/authorization logic — a fresh threat model is required)
+- [ ] Pen test scope defined: if the launch is compliance-relevant or involves a new attack surface, define what will be tested and by whom, even if the pen test runs post-launch
+- [ ] Dependency vulnerability scan completed and results reviewed (SCA); critical and high CVEs either remediated or waivered with expiration date
+- [ ] Authentication and authorization behavior verified in staging — test the paths that should fail, not just the paths that should succeed
+- [ ] Secrets management confirmed: no credentials, tokens, or API keys in application code or pipeline configuration
+- [ ] Data encryption confirmed: data at rest and in transit are encrypted per the organization's baseline
+- [ ] Access control review: who can access what the feature exposes, and does that match the intended design?
+
+**Owner:** Security lead (or engineering lead if no dedicated security team, with sign-off from a senior engineer who was not the feature author).
+
+### Domain 4: Compliance
+
+Compliance readiness is the domain most often treated as a final rubber stamp and least often treated as an integrated part of launch planning. When compliance review is not started until two weeks before launch, either the launch slips or corners are cut.
+
+**Checklist:**
+- [ ] Legal sign-off obtained on: terms of service changes (if any), data processing changes, any change that affects the contractual relationship with customers
+- [ ] Data privacy review completed: what new personal data is collected, where it is stored, how long it is retained, who has access, and is this consistent with the privacy policy?
+- [ ] GDPR/CCPA/HIPAA applicability confirmed and controls verified (if applicable — confirm which regulations apply before the gate, not during it)
+- [ ] Data residency requirements verified: if customers have contractual data residency requirements, confirm that the launched feature complies
+- [ ] Third-party data sharing review: if the feature sends customer data to a new third party, confirm that DPAs (data processing agreements) are in place and the data flow is disclosed in the privacy policy
+- [ ] Regulatory notification requirements reviewed: some changes require advance regulatory notification; confirm this requirement has been evaluated
+
+**Owner:** Legal/compliance lead. Engineering lead is responsible for ensuring this review was initiated with sufficient lead time (minimum 2 weeks; 4 weeks for complex privacy implications).
+
+### Domain 5: Support
+
+Customer support is the first team to feel the blast from a launch failure and the last team included in launch planning. Launching without a support-ready state generates a wave of unroutable tickets and a customer experience that undermines the feature's reception.
+
+**Checklist:**
+- [ ] Support team trained on the feature before launch: what it does, what the expected user experience is, what the common error states look like, and how to interpret them
+- [ ] Escalation path defined: what questions or issues does support escalate to engineering, and to whom specifically? Named escalation contacts, not just "the engineering team"
+- [ ] Known issues documented for support: the bugs that exist and will not be fixed before launch — support needs to know about these before customers report them
+- [ ] Internal knowledge base or FAQ updated (if the feature changes existing workflows)
+- [ ] Support SLA impact assessed: will this launch meaningfully increase ticket volume? If yes, capacity planning completed
+
+**Owner:** Support lead (or customer success lead if support is embedded). Engineering lead initiates the support briefing at least one week before launch.
+
+### Domain 6: Communications
+
+The communication plan covers both internal and external audiences. Internal communications prevent launch-day surprises for people who find out about the launch from a customer complaint. External communications set customer expectations.
+
+**Checklist:**
+- [ ] Internal announcement drafted and approved (audience: all of engineering, sales, account management, support, executive team)
+- [ ] External communications drafted and reviewed: blog post, email announcement, in-product notification, or press release — whichever applies
+- [ ] Legal and compliance reviewed external communications (required if communication describes data handling, pricing, or regulatory compliance)
+- [ ] Communication timing confirmed: internal announcement goes out at T-24h; external at T-0 or coordinated with launch timeline
+- [ ] Social media/PR response plan in place: who responds if there is negative public reaction to the launch?
+- [ ] Customer-facing documentation (help center, API docs) updated and ready to publish at launch
+
+**Owner:** Product or marketing lead for external communications. Engineering lead for internal technical announcements.
+
+### Domain 7: Rollout Plan
+
+A launch without a rollout plan is a binary on/off event. Most non-trivial launches should not be binary.
+
+**Checklist:**
+- [ ] Canary percentage defined: what percentage of traffic or users receives the launch in the first phase? Typical starting points: 1%, 5%, 10% depending on risk level
+- [ ] Canary success criteria defined: which metrics must be healthy at canary scale before expanding rollout? (e.g., "error rate below 0.1%, p99 latency below 300ms, zero payment failures in the cohort")
+- [ ] Canary hold period defined: how long does the launch stay at canary scale before expanding? (minimum 1 hour for low-risk; 24–48 hours for high-risk)
+- [ ] Rollback trigger defined and documented: what specific metric or event causes the team to roll back, and who makes that call?
+- [ ] Rollback procedure tested: not just written — a person has run through the rollback procedure in staging and confirmed it works within the target time window
+- [ ] Full rollout schedule defined: canary → partial (25–50%) → full, with time estimates between each phase
+
+**Owner:** Engineering lead, confirmed by TPM.
+
+**Rollback trigger examples:**
+- Error rate exceeds 1% for 5 consecutive minutes at canary scale
+- Any payment failure attributed to the launched feature
+- p99 latency exceeds 500ms (or 2× baseline, whichever is more restrictive) for 10 consecutive minutes
+- On-call engineer's judgment that the launch is creating customer impact
+
+### Domain 8: Business
+
+The business gate exists because launches affect more than engineering. Sales teams need to know what they can commit to. Account managers need to know what their customers will see. Executives need to know they are aware before the launch happens, not after.
+
+**Checklist:**
+- [ ] Executive sponsor has provided explicit go/no-go sign-off (email or documented verbal in the gate record)
+- [ ] Sales enablement completed: if the feature changes pricing, packaging, or the product's competitive positioning, sales leadership has been briefed and enablement materials are ready
+- [ ] Account management notified: for features that directly affect existing customer accounts, the account team has been informed and has a response plan for customer questions
+- [ ] Success metrics confirmed: what are the 30-day and 90-day metrics the business will use to evaluate whether the launch achieved its goals? These should be agreed before launch, not reverse-engineered after.
+- [ ] Revenue or contractual commitments tied to this launch reviewed: if a customer contract or sales commitment depends on this launch date, confirm the launch is on track to honor it
+
+**Owner:** Product or engineering executive sponsor.
+
+---
+
+## Owner-Per-Domain Accountability Table
+
+Before the gate meeting, confirm that every domain has a named owner who will attest to readiness. An owner is an individual — not a team, not "TBD."
+
+| Domain | Owner | Status | Notes |
+|--------|-------|--------|-------|
+| Engineering | Marcus Webb | 🟢 Ready | Load test completed Mar 28 |
+| Operations | Sarah Chen | 🟡 At Risk | Alert thresholds not yet calibrated; completing by Apr 1 |
+| Security | Priya Agarwal | 🟢 Ready | Threat model reviewed Mar 25 |
+| Compliance | Jordan Lee (Legal) | 🟢 Ready | DPA signed with vendor Mar 20 |
+| Support | Chris Nguyen (Support Lead) | 🟢 Ready | Training completed Mar 29 |
+| Communications | Alex Park (Marketing) | 🟡 At Risk | Blog post pending final legal review |
+| Rollout Plan | Marcus Webb | 🟢 Ready | Canary plan documented |
+| Business | VP Product | 🟢 Ready | Executive sign-off received |
+
+---
+
+## Go/No-Go Decision Process
+
+### Who Calls It
+
+One person calls the go/no-go. Not the committee. The committee provides input; one person decides and is accountable. For most external-customer launches: the engineering lead or VP of Engineering. For compliance-relevant launches: VP of Engineering plus legal lead, with explicit dual sign-off.
+
+If the decision-maker is unclear before the gate process begins, clarify it in the program brief — not the day of the launch.
+
+### Blocker vs. Waiver
+
+**A blocker** is a readiness item that is not complete and, if the launch proceeds, would directly cause customer harm, data loss, security exposure, or a compliance violation. Blockers stop the launch.
+
+**A waiverable item** is a readiness item that is not complete but the risk of proceeding can be accepted, documented, and mitigated. Examples: load test not run at exactly 2× peak (ran at 1.5×); alert thresholds calibrated but not validated against historical data; external blog post delayed by 24 hours.
+
+### Waiver Approval Chain
+
+All waivers are documented before the launch, not after. The waiver record includes:
+
+- What item is being waivered
+- Why it is not complete
+- What the risk is if the item is not complete
+- What mitigation is in place
+- Who approved the waiver and when
+
+| Domain | Waivered Item | Risk | Mitigation | Approved By | Date |
+|--------|--------------|------|------------|-------------|------|
+| Engineering | Load test at 1.5× peak, not 2× | Higher-than-expected traffic could degrade p99 latency | Canary phase at 1% with 24h hold; expand only if p99 < 300ms | VP Eng | Apr 1 |
+
+No verbal waivers. If it is not in the waiver log, it is not waivered — it is a blocker.
+
+---
+
+## Launch Day Runbook Template
+
+### T-24 Hours
+
+- [ ] Confirm all domain owners are available and reachable for launch window
+- [ ] Final status check: all blockers resolved, all waivers documented
+- [ ] Go/no-go call confirmed in writing (email or Slack, timestamped)
+- [ ] Rollback procedure confirmed with the person responsible for executing it
+- [ ] On-call engineer briefed and has access to runbooks
+- [ ] Monitoring dashboards opened and baselined — record pre-launch metric values for comparison
+- [ ] Communication drafts finalized and ready to send on schedule
+- [ ] Support team notified: launch is proceeding at [time]
+
+### T-1 Hour
+
+- [ ] Deployment artifact confirmed in the release pipeline (correct SHA, correct environment)
+- [ ] Feature flags confirmed in launch position in staging
+- [ ] All domain owners or designated stand-ins online or on-call
+- [ ] Incident channel or war room opened (Slack channel or Zoom bridge — ready to use, not to create in the moment)
+- [ ] Monitoring alerts muted for any alerts known to fire during deployment (document which ones and why)
+
+### T-0: Launch Begins
+
+- [ ] Deploy initiated by designated engineer
+- [ ] Canary traffic confirmed routing to new version (verify in monitoring, not just in the deployment tool)
+- [ ] First 5-minute check: error rate, latency, primary success metric — compare to baseline
+- [ ] Internal announcement sent
+- [ ] Clock starts on canary hold period
+
+**If any metric exceeds rollback trigger within the first 15 minutes:** the engineering lead calls the rollback. No committee decision. One person calls it, names the trigger, and initiates rollback. Document the decision.
+
+### T+1 Hour
+
+- [ ] Canary metrics stable (error rate, latency, primary success metric within expected range)
+- [ ] On-call engineer has reviewed the monitoring dashboard and confirmed no anomalies
+- [ ] Any issues identified in the first hour documented in the issue log
+- [ ] Rollout decision: hold at canary, expand to next tier, or roll back — engineering lead makes the call
+
+### T+24 Hours
+
+- [ ] 24-hour metric review: success metrics compared to target; any negative trends?
+- [ ] Support ticket volume reviewed: is volume within the expected range?
+- [ ] Any issues resolved or tracked in the issue log
+- [ ] Decision: expand rollout, hold at current %, or roll back
+- [ ] Engineering lead sends 24-hour launch update to executive stakeholders (2–3 sentences: status, key metric, any issues)
+
+---
+
+## Post-Launch Review Cadence
+
+### 24-Hour Review
+
+Attendees: engineering lead, TPM, on-call lead. 30 minutes.
+
+- Key metrics vs. targets
+- Any issues opened in the first 24 hours
+- Rollout progression decision
+- Action items for the first week
+
+### 72-Hour Review
+
+Attendees: engineering lead, product lead, support lead. 30 minutes.
+
+- Metric trends (are they stable, improving, degrading?)
+- Support ticket volume and top issues
+- Any rollback-warranting signals?
+- Go/no-go for full rollout if not already complete
+
+### 2-Week Review
+
+Attendees: full domain owner group. 60 minutes.
+
+- Business metrics vs. targets (30-day and 90-day targets framed)
+- What went well in the launch process?
+- What should change for the next launch?
+- Any follow-on work required (bug fixes, performance work, documentation gaps)?
+- Gate framework improvements based on what was discovered during this launch
+
+---
+
+## Common Launch Failures
+
+**Launching on Friday.** The logic is always the same: the launch has been delayed and the team wants to get it out before the weekend, or the launch is on a fixed schedule and Friday happened to be the date. The problem: on-call coverage is thinner on weekends, incident response is slower, and a Friday launch that starts going wrong at 5pm has the worst possible conditions for rapid response. Move the launch to Tuesday–Thursday, or accept that the Friday launch requires explicit weekend coverage planning and approval from the on-call lead.
+
+**Skipping canary.** Full-traffic launches feel faster, and they are — until something goes wrong. A 1% canary that catches a bug affects 1% of users. A full-traffic launch that catches the same bug affects 100% of users. The canary is not for launches you are confident about. It is for every launch.
+
+**Go/no-go by committee with no one owning the call.** The meeting ends with "we think we're good" and no one wrote down who said go. When the launch fails, no one remembers who made the call. Designate the decision-maker before the gate process begins. Record their decision.
+
+**Operations readiness treated as post-launch work.** "We'll add proper monitoring after we see how it behaves in production." This is not a plan — it is an intention to operate blind and learn from failures rather than from metrics. Monitoring and alerting are launch requirements, not follow-on items.
+
+**The readiness gate that is really a status broadcast.** Domain owners show up, report green across all domains, and the meeting ends in 10 minutes. No one asked hard questions. The gate is serving as a ceremony, not as a real control. A well-run gate asks: what could still go wrong, who would know first, and what would we do about it? If the answer to all three is clear, the gate is doing its job.

--- a/program-management/program-planning-playbook.md
+++ b/program-management/program-planning-playbook.md
@@ -1,0 +1,275 @@
+# Program Planning Playbook
+
+## Leadership Context
+
+Multi-team technical programs are where engineering leadership makes or breaks delivery credibility with the business. When a program slips, the root cause is almost never a technical problem — it is a planning problem: scope that was never agreed to, dependencies that were invisible until they were blocking, and milestone dates that were set to satisfy a deadline rather than reflect actual sequencing. This playbook documents how to scope, launch, and run a program in a way that gives executives accurate visibility and gives engineers clear ownership. The output is not a Gantt chart — it is a shared understanding of what "done" means and what it will take to get there.
+
+## When to Use This
+
+Apply program-level treatment when:
+
+- Three or more teams have work that must coordinate to deliver a shared outcome
+- The effort spans six or more months, or crosses a fiscal boundary
+- No single team owns the end-to-end result — the deliverable lives in the integration between teams
+- An executive or external stakeholder is tracking the outcome and needs status without attending every team meeting
+
+Single-team efforts with a committed roadmap slot are projects, not programs. Epics within a single team are backlog items, not programs. The distinction matters because programs require dedicated coordination overhead that is wasteful for smaller efforts.
+
+---
+
+## Program vs. Project vs. Epic
+
+The wrong label creates the wrong structure. Use this framework to pick the right one before committing to planning overhead:
+
+| Dimension | Epic | Project | Program |
+|-----------|------|---------|---------|
+| Teams involved | 1 | 1–2 | 3+ |
+| Duration | Weeks | 1–3 months | 3+ months |
+| Exec visibility needed | No | Sometimes | Yes |
+| Shared milestone dates | No | Sometimes | Yes |
+| Dedicated TPM or coordinator | No | No | Yes |
+| Cross-team dependencies | Rare | Occasional | Defining characteristic |
+
+**When to escalate from project to program:** The moment you draw a dependency arrow between two teams on a whiteboard and hear "we don't know when they can get to that," you have a program. Add coordination structure immediately — retrofitting program management onto a stalled effort is harder than starting with it.
+
+---
+
+## Program Brief
+
+The program brief is a four-page document that must exist before the kickoff. It is not a project plan — it is the shared frame that all planning is built on. If the brief is wrong, every decision downstream is misaligned.
+
+**Required sections:**
+
+### Problem Statement
+
+What problem is this program solving, and for whom? State the business outcome, not the technical deliverable.
+
+Bad: "Migrate the payment service to the new infrastructure stack."
+Better: "Reduce payment processing latency p99 from 850ms to under 200ms, eliminate the $1.2M/year Heroku contract, and meet the SOC 2 Type II audit requirement for infrastructure standardization — all before the Q4 audit window."
+
+The problem statement must name the consequence of not doing the program. If there is no consequence, the program should not exist.
+
+### Success Criteria
+
+Measurable outcomes that define "done." Not activity milestones ("migrate completed") — state outcomes ("p99 latency under 200ms in production for 30 consecutive days, zero payment failures attributed to infrastructure, SOC 2 audit finding resolved").
+
+Limit to 3–5 criteria. More than five means the scope is not bounded.
+
+### Scope Boundary
+
+Explicitly list what is in scope and what is out of scope. The out-of-scope list is as important as the in-scope list — it is the document you point to when someone tries to add work mid-program.
+
+**In scope:**
+- Payment service, checkout service, fraud detection service
+- AWS/Kubernetes migration for these three services
+- Runbook authoring and DR drill for migrated services
+
+**Out of scope:**
+- Admin tooling (separate initiative, Q1 next year)
+- Notification service migration (dependency not yet resolved)
+- Performance optimization beyond latency target (follow-on work after migration)
+
+### Key Risks
+
+List the top 5 risks. For each: what is the risk, what is the likelihood, what is the impact, what is the current mitigation. This is seeded from the RAID log (see the RAID Dependency Tracking playbook) but distilled for the brief.
+
+Format:
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Fraud detection service has undocumented stateful behavior that breaks in Kubernetes | Medium | High — could block go-live | Spike planned in Week 2 to map state dependencies |
+| Q4 hiring freeze reduces platform team capacity below plan | Low | Medium — extends timeline by 4–6 weeks | Identified two contractor options; decision gate at Week 4 |
+
+### Team Assignments
+
+Name the teams, their lead, and their scope of accountability within the program. Ambiguity in team assignments is the fastest way to produce work that falls between the cracks.
+
+| Team | Lead | Scope | Milestone Commitment |
+|------|------|-------|---------------------|
+| Platform | Sarah Chen | AWS/Kubernetes configuration, migration tooling | Environments ready by March 1 |
+| Payments | Marcus Webb | Payment service migration, integration testing | Service migrated by April 15 |
+| Security | Priya Agarwal | Threat model review, pen test scope, SOC 2 evidence | Audit-ready posture by May 1 |
+
+### Milestone Dates
+
+A milestone is a defined, verifiable state — not "in progress" or "mostly done." The milestone has passed or it has not. State the milestone, the date, and who signs off.
+
+| Milestone | Date | Sign-off |
+|-----------|------|---------|
+| Program brief approved | Jan 10 | VP Eng + CTO |
+| Environments ready for migration | Mar 1 | Platform lead |
+| Payment service migrated (staging) | Apr 1 | Payments lead |
+| Payment service migrated (production) | Apr 15 | VP Eng |
+| Audit-ready posture confirmed | May 1 | Security lead + CISO |
+| Program closed | May 31 | TPM |
+
+---
+
+## Kickoff Structure
+
+The kickoff is not a presentation. It is the single meeting where alignment becomes real or does not happen at all. Three things must be true when the kickoff ends:
+
+1. **Every team knows what they own.** If someone can leave the kickoff unsure of what they are responsible for, the kickoff failed.
+2. **Every team knows the first dependency they have on another team.** Not all dependencies — just the first one. This surfaces blocking relationships early enough to resolve them.
+3. **Everyone has seen and can challenge the success criteria.** If success criteria are defined by leadership and shown to the room for the first time in the kickoff, the room will nod and then go build something different. The kickoff is where criteria get challenged and confirmed.
+
+### Pre-Read (Required)
+
+Send at least 48 hours before. Must include: program brief (all sections), milestone schedule, and the dependency matrix (draft is fine). If participants have not read the brief, do not run the kickoff — you will spend the meeting explaining context instead of building alignment.
+
+### Kickoff Agenda (90 minutes)
+
+- **0–10 min:** Problem statement and success criteria. Read them aloud. Ask: does anyone disagree? Do this before anything else.
+- **10–30 min:** Team-by-team scope walkthrough. Each team lead summarizes their scope in 3 minutes. The room confirms: is this what we expected? Are there gaps?
+- **30–50 min:** Dependency review. Walk the dependency matrix. For each dependency: who produces the deliverable, who consumes it, what is the handoff date, what is the format/interface. Surface unknowns immediately.
+- **50–70 min:** Risk review. Walk the top 5 risks from the brief. Ask each team lead: do you have risks to add? Who owns each mitigation?
+- **70–85 min:** Working agreement. How will the program sync work? Who makes decisions vs. who is informed? What is the escalation path when a dependency is late?
+- **85–90 min:** Next steps. Confirm first milestone date, first sync date, and any pre-work that must happen before Week 1 of execution.
+
+### Anti-Patterns
+
+**The kickoff that is really a status update.** If the teams have been working for weeks before the kickoff, you are not doing a kickoff — you are doing a retroactive alignment meeting. Kickoff happens before execution begins.
+
+**Presenting a plan to the room instead of building one.** Handing teams a completed Gantt chart and asking for questions signals that the planning is done and they are here to receive it. Alignment built this way does not last past the first dependency conflict.
+
+**Skipping the dependency walkthrough.** Teams consistently underestimate how coupled their work is until they are forced to name their dependencies out loud. The dependency walkthrough is the most valuable 20 minutes in the kickoff.
+
+**The 3-hour kickoff.** Attention collapses after 90 minutes. If there is more content than fits in 90 minutes, cut the content — not the time limit.
+
+---
+
+## Milestone Tracking
+
+### Leading vs. Lagging Indicators
+
+A lagging indicator tells you a milestone was missed. A leading indicator tells you 2–3 weeks in advance that a milestone is at risk.
+
+**Lagging indicators:** milestone date passed, deliverable not complete.
+
+**Leading indicators:**
+- Key dependency has not been confirmed by the date it was supposed to be confirmed
+- A team's sprint velocity is below what the milestone requires (e.g., they need to ship 12 story points per sprint to hit the milestone and are averaging 7)
+- Scope is being added within a workstream without a corresponding milestone date extension
+- A team has stopped surfacing blockers (often means they have stopped looking for them)
+
+Track leading indicators weekly. When a leading indicator turns yellow, do not wait for the milestone date to surface the risk.
+
+### What "On Track" Actually Means
+
+"On track" has a specific definition. A workstream is on track when:
+- The current sprint contains the work that the milestone plan says it should
+- All upstream dependencies for the next milestone have confirmed delivery dates
+- There are no open blockers that the team cannot resolve without external help
+- Scope since the last sync has not increased
+
+"On track" does not mean: work is happening, no one has raised an issue, or the team thinks they will be fine.
+
+**Green/Yellow/Red definitions for program reporting:**
+
+| Status | Definition |
+|--------|-----------|
+| Green | On track per above criteria. No changes to milestone dates. |
+| Yellow | At risk. One or more leading indicators are negative, or a dependency is unresolved. Mitigation plan exists. Dates not yet changed. |
+| Red | Off track. A milestone date will slip, or a dependency failure is blocking progress. Escalation required. |
+
+Red is not a failure state — it is information. Programs that have no red workstreams for months are not managed programs; they are programs where problems are being hidden.
+
+---
+
+## Weekly Program Sync
+
+### Format (15–20 minutes standing agenda)
+
+The weekly sync is a decision meeting, not a status broadcast. Status is in the written update sent before the meeting. If teams need to read their status aloud, the sync is too long.
+
+**Required pre-read (sent 24 hours before):**
+- RAG status per workstream
+- Blockers requiring cross-team resolution
+- Decisions needed this week
+
+**Standing agenda:**
+
+1. **Blockers** (5 min): What is blocked and what does it need? No blocker should leave the meeting unowned.
+2. **Dependency status** (5 min): Any dependency that is at risk of missing its date. Walk the dependency matrix. If a handoff is on time and unambiguous, do not discuss it.
+3. **Decisions needed** (5–10 min): Decisions that require cross-team alignment or escalation. Assign an owner and a date for each. If the decision cannot be made in this meeting, name who makes it and when.
+
+**What does not belong in the sync:**
+- Team-level sprint updates (not a cross-team concern)
+- Technical design decisions (take offline with the relevant engineers)
+- Celebrations or recognition (valuable, but not in the 15-minute sync)
+
+### Working Session (Optional, Bi-Weekly)
+
+For programs with complex dependencies, add a 60-minute bi-weekly working session separate from the sync. This is where teams resolve technical interface questions, unblock design decisions, and do the coordination work that cannot happen asynchronously. The weekly sync reports on what the working session produced.
+
+---
+
+## Closure Criteria
+
+A program is done when it is integrated, stable, and handed off — not when it has shipped.
+
+**Shipped** means code is in production. **Done** means:
+
+- All success criteria from the program brief have been met and verified
+- Ownership of all outputs has transferred to the teams that will maintain them (runbooks updated, alerts configured, on-call rotation updated)
+- Any operational anomalies observed in the first 30 days post-launch have been addressed or explicitly accepted as known issues with a plan
+- The program's shared planning artifacts (dependency matrix, RAID log, milestone tracker) have been archived or closed
+- Stakeholders have received a written closure summary
+
+**Common premature closure signals:**
+- "We shipped it, so we're done" — integration testing and operational stability are post-ship work
+- The team that built it still owns the operational support — handoff did not complete
+- Success criteria were never formally verified — someone assumed the numbers were good
+
+### Closure Checklist
+
+- [ ] All success criteria confirmed with measurement evidence
+- [ ] Production stability confirmed for defined period (typically 2–4 weeks post-launch)
+- [ ] Operational handoff complete: runbooks, monitoring, alerting, on-call
+- [ ] Program artifacts archived (RAID log closed, milestone tracker frozen)
+- [ ] Written closure summary sent to all stakeholders
+- [ ] Retrospective completed (see below)
+- [ ] Any open items from the program either resolved or transferred to a named owner with a follow-up plan
+
+---
+
+## Program Retrospective
+
+Run the retro within two weeks of program closure. Delay kills memory; waiting a month produces a retro of vague impressions, not specific events.
+
+### Attendees
+
+Program leads from each team, the TPM, and the executive sponsor (for 30 minutes at the end, not the whole retro).
+
+### Format (90 minutes)
+
+**Pre-work:** Each participant submits 3–5 items per category to a shared doc before the meeting.
+
+Categories:
+- What enabled this program to succeed?
+- What slowed us down?
+- What would we change in how we planned?
+- What would we change in how we coordinated?
+- What did we assume that turned out to be wrong?
+
+**Meeting:**
+- 30 min: Review and cluster submitted items. Identify themes.
+- 30 min: Discuss the top 3–5 themes in depth. Name the root cause, not just the symptom.
+- 20 min: Produce 3–5 concrete changes to make to the next program. Each change has an owner.
+- 10 min: Executive sponsor join. Share top 3 themes and changes. Get feedback.
+
+**Output:** A 1-page retro summary with themes, root causes, and changes committed. Distribute to all participants and archive with program artifacts.
+
+---
+
+## Common Failure Modes
+
+**Scope creep without scope decisions.** New work enters the program because no one said no. The fix is a documented scope boundary in the brief, and a process for approving scope changes. Any scope addition must name what it displaces (another deliverable, a date, or team capacity). Scope additions that displace nothing are not real additions — they are magical thinking.
+
+**Phantom dependencies.** Dependencies that are listed but not actively managed. The dependency matrix says Team A needs output from Team B by March 15, but no one has spoken to Team B about it since the kickoff. Phantom dependencies surface at the worst moment: when Team A goes to use the output and it does not exist. Fix: weekly dependency review with explicit confirmation from the producing team.
+
+**The coordinator tax.** When the TPM becomes the information bottleneck — all updates flow through them, all decisions wait for them, all coordination is synchronous with them in the loop. The right model is a program infrastructure that enables asynchronous coordination: a shared status document that teams update directly, a RAID log that any lead can update, and a sync format that surfaces only what requires the group's attention. A TPM who is needed for every communication is a single point of failure, not a coordination asset.
+
+**Milestone date anchoring.** Dates set in the program brief based on a desired outcome, not on a bottoms-up estimate from the teams doing the work. The earliest symptom is that no team can explain how the milestone date was derived. The fix is to build the milestone schedule from team-level estimates, then have the conversation about the gap between what teams can realistically deliver and what leadership wants — not paper over it.
+
+**The program that is really three projects.** Three separate efforts packaged under a shared banner for executive visibility, but without genuine interdependencies or shared outcomes. These do not benefit from program-level coordination — they benefit from three separate project plans and a shared reporting roll-up. Running them as a program adds overhead without adding value. Dissolve these when you identify them.

--- a/program-management/raid-dependency-tracking.md
+++ b/program-management/raid-dependency-tracking.md
@@ -1,0 +1,237 @@
+# RAID Log and Dependency Tracking
+
+## Leadership Context
+
+The RAID log is the artifact that separates programs that surface problems early from programs that discover them when they are already blocking. Every multi-team program accumulates risks, makes assumptions, generates issues, and creates dependencies — the question is whether they are tracked in a structured format that enables proactive management, or scattered across Slack threads and meeting notes where they become invisible until they cause damage. A maintained RAID log is also the primary input for board-level or executive program reporting: when a VP asks "what are our biggest risks heading into Q4?", the RAID log should produce that answer in minutes, not require a frantic synthesis session the night before.
+
+## When to Use This
+
+Apply RAID tracking from the day the program brief is signed through program closure when:
+
+- The program has external dependencies (another team, a vendor, a regulatory body)
+- Multiple workstreams must coordinate to deliver a shared milestone
+- A deliverable in one workstream is required as input to another team's work
+- An executive or board-level stakeholder receives regular program status
+
+Do not wait for a problem to materialize before creating the RAID log. The log is most valuable when it is started during program planning, before execution begins.
+
+---
+
+## RAID Defined
+
+RAID stands for Risks, Assumptions, Issues, Dependencies. Each category has a distinct meaning; putting items in the wrong category is one of the most common RAID log failures because it obscures what action is needed.
+
+### Risks
+
+A risk is a condition that may occur in the future and would negatively affect the program if it does. It has not happened yet. The appropriate response is mitigation — reducing the likelihood or impact before the risk materializes.
+
+**Examples:**
+- The fraud detection service may have undocumented stateful behavior that does not transfer cleanly to Kubernetes. (Not confirmed — needs investigation.)
+- A hiring freeze may reduce platform team capacity below what the milestone schedule requires.
+- The third-party compliance vendor may not be available to complete their review before the audit window.
+
+**Not risks:** The fraud detection service has a bug that breaks the Kubernetes integration (this happened — it is an issue). The platform team has already confirmed they are understaffed (this is a known constraint, not a future possibility — it is an issue).
+
+### Assumptions
+
+An assumption is something the program plan takes as true that has not been explicitly confirmed. Every program plan is built on assumptions. The RAID log makes them explicit so they can be validated on a schedule rather than discovered when they turn out to be wrong.
+
+**Examples:**
+- We are assuming the compliance vendor can complete their review in 3 weeks based on past engagements.
+- We are assuming the fraud detection service migration can reuse the payment service migration tooling.
+- We are assuming the SOC 2 audit scope does not expand to cover the admin tooling, which is out of program scope.
+
+**Why assumptions matter:** When an assumption fails, the program impact can be as large as a high-severity risk. The difference is that an assumption failure is often discovered later — because no one was actively checking whether the assumption was still true. The RAID log assigns an owner and a validation date to every assumption. If the validation date passes without confirmation, the assumption escalates to a risk.
+
+### Issues
+
+An issue is a problem that has already occurred and is affecting the program now. It requires immediate action and active management, not monitoring.
+
+**Examples:**
+- The fraud detection service has a bug that breaks Kubernetes networking. Engineering lead is investigating. Blocker for the April 1 staging milestone.
+- The compliance vendor review is delayed by 2 weeks due to capacity constraints on their end. May push the audit-readiness milestone.
+- The platform team environment configuration has a permission error that is preventing the payments team from running integration tests.
+
+**The difference between an issue and a risk that materialized:** When a risk materializes, close the risk entry and open an issue entry. Do not leave a closed risk as the only record of an active problem — the issue tracker is where active problems live.
+
+### Dependencies
+
+A dependency is a deliverable that one workstream needs from another team, vendor, or external party in order to proceed. Dependencies are different from risks because they are definite — Team A will need output from Team B on a specific date. The RAID log tracks whether that handoff is on schedule.
+
+**Examples:**
+- Payments team needs Kubernetes environment configuration from Platform team by March 1 to begin integration testing.
+- Security team needs the completed threat model from each migrated service before they can scope the pen test.
+- Compliance certification requires legal sign-off on data processing agreements by April 15.
+
+---
+
+## Risk Register Format
+
+One row per risk. Maintain in a shared document (Confluence, Notion, Google Sheets) with edit access for all program leads.
+
+| ID | Description | Likelihood | Impact | Score | Owner | Mitigation | Review Date | Status |
+|----|-------------|-----------|--------|-------|-------|------------|-------------|--------|
+| R-001 | Fraud detection service has undocumented stateful behavior that may not migrate cleanly to Kubernetes | M | H | 6 | Marcus Webb | Spike planned Week 2 to map all stateful dependencies; go/no-go gate before migration begins | Feb 15 | Open |
+| R-002 | Hiring freeze reduces platform team capacity below plan | L | M | 3 | Sarah Chen | Two contractor options pre-identified; decision gate at Week 4 if freeze is confirmed | Feb 28 | Open |
+| R-003 | Compliance vendor unavailable before audit window | L | H | 4 | Priya Agarwal | Contract with alternative vendor signed; Priya to confirm scope compatibility by Feb 1 | Feb 1 | Open |
+
+**Likelihood/Impact scale:**
+- H = High (likely to occur / would significantly delay or block the program)
+- M = Medium (possible / would cause material schedule or scope impact)
+- L = Low (unlikely / manageable without significant impact)
+
+**Score** = Likelihood × Impact (H=3, M=2, L=1). Use score to prioritize weekly review attention. Score 6–9: review every week. Score 3–5: review every two weeks. Score 1–2: review monthly.
+
+**Status:** Open, Monitoring (mitigation in place, still tracking), Closed (risk passed or no longer applicable), Escalated (risk materialized — open Issue entry).
+
+### Risk Review Cadence
+
+- Score 6–9 risks: discussed in every weekly program sync
+- Score 3–5 risks: reviewed at every other sync; owner confirms mitigation is on track
+- Score 1–2 risks: reviewed monthly; owner confirms no change in likelihood or impact
+- Any risk that increases in likelihood or impact is reviewed immediately, not at the next scheduled interval
+
+---
+
+## Assumption Log
+
+| ID | Assumption | Owner | Validation Method | Validation Date | Status |
+|----|-----------|-------|-------------------|-----------------|--------|
+| A-001 | Compliance vendor can complete review in 3 weeks based on prior engagement | Priya Agarwal | Confirm scope and timeline with vendor in kickoff call | Jan 20 | Pending |
+| A-002 | Fraud detection service migration can reuse payment service tooling without modification | Marcus Webb | Engineering spike in Week 2 | Feb 10 | Pending |
+| A-003 | SOC 2 audit scope does not expand to admin tooling | Priya Agarwal | Written confirmation from audit firm | Jan 31 | Confirmed |
+
+**What to do when an assumption fails:**
+
+1. Close the assumption entry with status "Failed."
+2. Open a risk entry (if the failure creates future uncertainty) or an issue entry (if the failure is already impacting the program).
+3. Notify program leads and update the milestone forecast if the assumption was load-bearing for a date.
+4. Do not absorb assumption failures silently into team-level work. If an assumption fails and it only becomes visible when a milestone slips, the RAID log failed its purpose.
+
+---
+
+## Issue Tracker
+
+| ID | Description | Date Identified | Severity | Owner | Current Action | Target Resolution | Status |
+|----|-------------|-----------------|----------|-------|----------------|-------------------|--------|
+| I-001 | Fraud detection Kubernetes networking bug — integration tests failing | Feb 12 | High | Marcus Webb | Engineering debugging as of Feb 12; escalated to staff architect | Feb 19 | Open |
+| I-002 | Compliance vendor 2-week delay | Feb 8 | Medium | Priya Agarwal | Re-sequencing internal review tasks to absorb partial delay; evaluating alternative vendor for remaining scope | Feb 22 | Open |
+
+**Severity scale:**
+- High: Blocking a milestone or a critical dependency handoff
+- Medium: Not blocking today but will become a blocker within 2 weeks without intervention
+- Low: Degrading team velocity but workarounds exist; not milestone-threatening
+
+**Escalation rule:** Any High severity issue that has no clear resolution path within 48 hours is escalated to the program executive sponsor. Medium issues unresolved after one week are reviewed in the weekly sync with an escalation decision made at that point.
+
+---
+
+## Dependency Matrix
+
+The dependency matrix is a team × team table that makes all inter-team handoffs visible in one view. Unlike the RAID log issue list, the dependency matrix is organized around the structure of the program — who needs what from whom.
+
+### Format
+
+**Rows:** Teams that consume deliverables (the team that is waiting).
+**Columns:** Teams that produce deliverables (the team delivering).
+**Cells:** Description of the dependency, date needed, and current status.
+
+|  | **Platform Team** | **Security Team** | **Legal/Compliance** | **Vendor (Compliance)** |
+|--|-------------------|-------------------|----------------------|------------------------|
+| **Payments Team** | K8s environment config by Mar 1 — 🟡 at risk (env config scope expanding) | Threat model review sign-off by Mar 15 — 🟢 on track | Data processing agreement by Apr 15 — 🟢 on track | N/A |
+| **Security Team** | Network policy templates by Feb 20 — 🟢 on track | N/A | Audit scope confirmation by Jan 31 — ✅ done | Pen test scheduling by Mar 1 — 🔴 vendor at capacity |
+| **Platform Team** | N/A | Security review of K8s configuration by Mar 1 — 🟢 on track | N/A | N/A |
+
+**Status codes:**
+- ✅ Done — deliverable received and confirmed
+- 🟢 On track — delivery date confirmed, work in progress
+- 🟡 At risk — delivery is possible but a named concern exists; mitigation in place
+- 🔴 Blocking — delivery will miss date without intervention; escalation required
+
+Update the matrix before every weekly sync. Stale status codes are the primary signal that the RAID process is being treated as theater.
+
+---
+
+## Visual Dependency Map
+
+The matrix provides detail. The visual map provides a communication artifact for stakeholders who need the overview.
+
+### Swimlane Approach
+
+Use a swimlane diagram when the primary concern is sequence — understanding what must happen before what.
+
+Each team gets a lane. Dependencies are drawn as arrows between lanes, labeled with the deliverable and due date. Critical path is highlighted. This format works well for linear programs (work flows left to right) and for board presentations.
+
+**Tool:** Lucidchart, Miro, or draw.io. Export as PNG for embedding in program status reports.
+
+**When to use swimlane:** The program has a clear sequential structure and the primary risk is schedule delay. The swimlane makes the critical path visible.
+
+### Gantt-Style Dependency View
+
+Use a Gantt-style view when teams need to see their workstreams in parallel and understand how their work lands relative to others.
+
+Each team's milestones appear as bars on a shared timeline. Dependency arrows connect the bars. The critical path is the chain of dependencies with the least slack.
+
+**Tool:** Notion timeline, Linear milestones, Asana Gantt, or a Google Sheet with conditional formatting.
+
+**When to use Gantt:** The program has parallel workstreams and the primary risk is teams not understanding how their timeline affects others. The Gantt makes slack (or the absence of it) visible.
+
+**Which to use:** Choose swimlane for exec communication; Gantt for team coordination. For a complex program, maintain both — they serve different audiences.
+
+---
+
+## Weekly RAID Review Ritual
+
+Build RAID review into the weekly program sync as a standing 5-minute segment. The ritual should take no more than 5 minutes if the RAID log was updated before the meeting.
+
+**Review order:**
+1. Any new risks added since last week? Owner, mitigation, score?
+2. Any assumptions due for validation this week? Confirmed or escalated?
+3. Any issues that changed severity since last week? Any issues that resolved?
+4. Any dependencies that changed status since last week? Any new 🔴 entries?
+
+**What to update in the RAID log weekly (owner responsibility, not TPM):**
+- Risk status and mitigation progress
+- Assumption validation results
+- Issue current action and target resolution
+- Dependency matrix status codes
+
+**What the TPM does:** Reviews the log before the sync, identifies items that require group discussion or escalation, and surfaces those in the meeting. The TPM is not the person updating the log — the workstream lead is. A RAID log updated only by the TPM is a RAID log that is out of date within two weeks.
+
+---
+
+## RAID Health Signals
+
+A RAID log that is being actively maintained looks different from one that is being performed as process theater. Use these signals to assess health:
+
+### Signals of a Live RAID Log
+
+- Issue entries have been updated in the last 7 days
+- At least one risk has been closed (resolved or materialized into an issue) in the last two weeks
+- Assumption validation dates are being met or explicitly extended with a reason
+- Dependency matrix status codes changed from the previous week (either improving or deteriorating — stasis is a warning sign)
+- Program leads can explain the top 3 open risks without looking at the document
+
+### Signals of a Theater RAID Log
+
+- The log was last updated at program kickoff and has not changed since
+- All risks are "Low" likelihood — no one is surfacing real concerns
+- The issue list is empty while the program is in active execution — real programs generate issues
+- Dependency matrix has all 🟢 entries for more than 3 consecutive weeks during a complex integration phase — this is statistically unlikely if the program is real
+- No one can tell you what R-003 is without opening the document
+
+**What to do when the RAID log has gone stale:** Do not reboot the log in a meeting. Call each workstream lead individually, ask them to walk you through their current status from memory, and update the log based on what you learn. The stale log is a symptom — the cause is usually that leads feel the log is a reporting artifact rather than a decision-support tool. Fix the perception, not just the document.
+
+---
+
+## RAID Log Maintenance at Scale
+
+For programs with 5+ workstreams, the RAID log becomes unwieldy if all items are maintained in a flat list. Apply these conventions:
+
+**Archive resolved items.** Closed risks, confirmed assumptions, and resolved issues move to an "Archive" tab or section. The active log stays short — target fewer than 20 active items total. Active logs over 30 items are not being closed aggressively enough.
+
+**Tag by program phase.** Add a "Phase" column (Planning, Execution, Integration, Launch, Post-Launch). Filter by phase to understand what is relevant now vs. what is upcoming.
+
+**Separate vendor/external dependencies.** External dependencies have different management paths — you cannot directly resolve them. Create a dedicated section or tab for vendor and third-party dependencies and manage them through a relationship owner rather than the standard workstream lead path.
+
+**Link to source systems.** Where a risk or issue has a corresponding Jira ticket, engineering incident, or legal review document, link directly from the RAID log entry. This reduces the double-maintenance burden and makes it easier for leads to update status where they are already working.

--- a/program-management/stakeholder-communication-templates.md
+++ b/program-management/stakeholder-communication-templates.md
@@ -1,0 +1,283 @@
+# Stakeholder Communication Templates
+
+## Leadership Context
+
+The highest-leverage thing a TPM or engineering leader does is give stakeholders accurate information at the right frequency. Bad program communication produces one of two failure modes: stakeholders who are constantly surprised because they did not know things were going wrong, or stakeholders who are overwhelmed and stop reading updates because the signal-to-noise ratio is too low. Both failure modes erode trust and slow decision-making. The templates in this playbook exist to remove the weekly cost of deciding how to communicate — so the work becomes choosing the right facts to surface, not structuring them from scratch each time.
+
+## When to Use This
+
+Apply these templates for any program with:
+
+- More than one team contributing to a shared outcome
+- At least one executive or senior stakeholder who is not embedded in the day-to-day work
+- A duration longer than 4 weeks
+
+For shorter or single-team efforts, a brief Slack message or a comment on a ticket is sufficient. The overhead of a structured status report is justified when there are multiple audiences with different information needs and when the program runs long enough that stakeholder mental models will drift without active maintenance.
+
+---
+
+## The 3 Writing Principles for Upward Communication
+
+Before the templates: the underlying principles that determine whether a status update is actually useful.
+
+**1. Lead with status, not detail.**
+
+The recipient reads the first sentence and decides whether this communication requires action. If the first sentence is "This week the team completed the integration testing phase and began the canary configuration work," the reader does not know whether things are going well or poorly. Lead with the answer: "The program is on track for the April 15 production milestone" or "The program is at risk: a vendor delay has put the May 1 audit-readiness milestone in jeopardy."
+
+The detail belongs in the body. Never bury the lede.
+
+**2. Quantify impact.**
+
+"The vendor review is taking longer than expected" is not actionable. "The vendor review is 10 days behind schedule, which puts the May 1 audit-readiness milestone at risk and may require the team to either reduce the pen test scope or request an extension from the audit firm" is actionable.
+
+Impact statements answer three questions: how much (time, money, scope), which milestone or outcome, and what the consequence is if it is not resolved.
+
+**3. Make the ask explicit.**
+
+Every communication that requires something from the reader must say so explicitly in a dedicated section. "Asks / decisions needed" is a named section, not a buried sentence in a paragraph. If the reader has to figure out what they are being asked to do, most of them will not do it.
+
+---
+
+## Stakeholder Map Template
+
+Before choosing a communication format, map the stakeholders. Different tiers of stakeholders need different levels of detail at different frequencies.
+
+| Tier | Who | What They Need to Know | Preferred Format | Frequency |
+|------|-----|----------------------|-----------------|-----------|
+| Decision-makers | VP Eng, CPO, legal lead (if compliance-relevant) | Status, blockers requiring exec action, milestone risk | Weekly status report; escalation memo when needed | Weekly |
+| Influencers | Engineering leads per team, senior architects | Workstream-level status, technical decisions, dependency changes | Weekly sync (verbal) + written summary | Weekly |
+| Informed | Product managers, account team, support lead | High-level milestone status, launch timing, known issues | Milestone announcements, launch notifications | At milestones; ad hoc for major changes |
+
+**Decision-makers** need status and ask — they do not need implementation detail.
+
+**Influencers** need enough context to make technical decisions within their workstream and flag cross-team concerns.
+
+**Informed stakeholders** need to know when something changes that affects them. They do not need weekly updates; they need timely notification when relevant events occur.
+
+**Communication preferences per tier:** Learn them. Some executives read every word of a written update; others scan the subject line and first sentence. Some prefer a Slack message to an email. Some want to be called before a written escalation goes out. Ask once and record it — the preference does not change.
+
+---
+
+## Weekly Status Report
+
+### Format
+
+**Subject line:** `[Program Name] — Week of [date] — [Status: On Track / At Risk / Off Track]`
+
+The status goes in the subject line. A reader who only reads subject lines knows the program status. This is a feature, not redundant.
+
+---
+
+**[Program Name] — Week of April 7 — On Track**
+
+**Summary**
+
+The program is on track for the April 15 production milestone. The payment service migration completed staging validation this week. The platform team resolved the networking policy issue from last week. One dependency remains at risk: the security team's pen test scheduling is blocked on the vendor; Priya has a confirmed call with an alternative vendor on April 9.
+
+*[Summary is 3–5 sentences. Status first, then most important update, then any named risk. Never more than one paragraph.]*
+
+---
+
+**Workstream Status**
+
+| Workstream | Lead | Status | This Week | Next Week | Milestone |
+|-----------|------|--------|-----------|-----------|---------|
+| Platform | Sarah Chen | 🟢 | K8s environment validated; network policies deployed | Final capacity tuning | Mar 1 ✅ |
+| Payments | Marcus Webb | 🟢 | Staging migration complete; canary config ready | Canary launch (Apr 15) | Apr 15 🟢 |
+| Security | Priya Agarwal | 🟡 | Threat model review complete; pen test vendor at capacity | Confirm pen test scope with alt. vendor (Apr 9) | May 1 🟡 |
+
+*Status codes: 🟢 On Track | 🟡 At Risk (mitigation in place) | 🔴 Off Track (escalation needed)*
+
+*[Keep the workstream table to 4–6 rows. If there are more workstreams, group minor ones. The purpose of this table is to let the reader identify which workstreams require attention — it is not a comprehensive project status view.]*
+
+---
+
+**Asks / Decisions Needed**
+
+1. **Pen test vendor approval (by April 9):** If the alternative vendor's scope differs from the original, Priya will need VP Engineering approval to proceed with the modified scope. Priya will send a one-paragraph summary of the difference after the April 9 call. VP approval needed by April 10 to stay on timeline.
+
+*[If there are no asks this week, write "No decisions needed this week." Never omit this section — its consistent presence trains stakeholders to look for it.]*
+
+---
+
+**Coming Up**
+
+- April 15: Payment service production launch (canary)
+- April 22: Canary metrics review; go/no-go for full rollout
+- May 1: Audit-readiness milestone (at risk — see above)
+
+*[Coming Up is 3–5 bullets. Upcoming milestones and decision points only. Not a sprint backlog.]*
+
+---
+
+### Calibrating Frequency
+
+Weekly is the default. Adjust:
+
+- **Increase to twice-weekly** when a milestone is within 2 weeks and risks are unresolved, or when executive attention has increased due to a recent issue.
+- **Decrease to bi-weekly** when the program is in a steady execution phase with no active escalations, well-confirmed milestones, and no new risks in 3+ weeks.
+- **Move to milestone-only** for informed-tier stakeholders who do not need weekly visibility — send an update only when a milestone is hit or a significant risk emerges.
+
+A weekly status report that consistently contains no risks, no asks, and only minor milestone progress is a signal to reduce frequency — it is generating noise. Reduce it to bi-weekly and tell your stakeholders you are doing so.
+
+---
+
+## Escalation Memo
+
+The weekly status report covers normal program operations. The escalation memo is for situations where the weekly cadence is not fast enough — where a decision is needed before next week's update.
+
+Use the escalation memo when:
+- A milestone will slip unless a decision is made in the next 48–72 hours
+- A blocker has appeared that the program team cannot resolve without executive action
+- A risk has materialized into an issue that materially changes the program outlook
+
+### Format
+
+**Subject:** `[ESCALATION] [Program Name] — [One-sentence description of the issue]`
+
+---
+
+**Situation**
+
+*[2–3 sentences. What happened? When did it happen? What is the current state?]*
+
+The compliance vendor (Acme Compliance) has notified us that they cannot complete the pen test before May 15 — two weeks later than the May 1 audit-readiness milestone requires. We learned this on April 9. This puts the SOC 2 Type II audit timeline at risk.
+
+---
+
+**Timeline**
+
+- **April 9:** Received vendor notification of capacity constraint
+- **May 1:** Current audit-readiness milestone (pen test completion required)
+- **May 15:** Earliest vendor availability
+- **June 1:** SOC 2 audit window opens — this is the hard external deadline
+
+---
+
+**Options**
+
+*[2–3 options, each with the key tradeoff stated in one sentence. Do not advocate in this section — present objectively.]*
+
+**Option A — Use alternative vendor (Beta Security):** Beta Security can complete the pen test by April 28. Beta Security has not tested our stack before, which means a 1-week onboarding period is required and the scope may differ from the original. Cost: $45K (vs. $30K with Acme). Deadline maintained.
+
+**Option B — Reduce pen test scope:** Acme can complete a scoped test (payments and auth systems only, excluding admin tooling) by May 1. This means admin tooling is excluded from the SOC 2 audit scope, which requires legal confirmation that this scope is acceptable. Timeline maintained; scope risk.
+
+**Option C — Accept the delay:** Proceed with Acme on their May 15 timeline and assess whether the June 1 audit window can be adjusted with the audit firm. This requires outreach to the audit firm immediately to determine flexibility. Risk: if the audit window is fixed, we miss it.
+
+---
+
+**Recommendation**
+
+*[One paragraph. State which option you recommend and why. Be direct. You are the person with context; make the call and let the exec confirm or override.]*
+
+Recommend Option A. The $15K cost delta is modest relative to the cost of an audit timeline slip. Beta Security's onboarding period is manageable — Priya will schedule a scope kickoff call the week of April 12. The alternative vendor risk is lower than either scope reduction or timeline delay.
+
+---
+
+**Decision Needed By**
+
+April 11, 5pm. We need to execute a contract with Beta Security by April 12 to start onboarding on April 13. A decision after April 11 makes Option A unavailable without schedule impact.
+
+---
+
+**Contact**
+
+Priya Agarwal (Security Lead), Marcus Webb (Program Lead). Available by Slack or phone for questions before April 11.
+
+---
+
+## Program Kickoff Email
+
+Send this 48 hours before the kickoff meeting. It is not a welcome note — it is the pre-read delivery mechanism.
+
+---
+
+**Subject:** [Program Name] Kickoff — Pre-Read and Agenda — [Date, Time]
+
+[Name of distribution list or recipients],
+
+The kickoff for [Program Name] is scheduled for [Day, Date at Time, Timezone] in [location/link].
+
+**Please read before the meeting:**
+- Program Brief: [link] — 4 pages. Sections: problem statement, success criteria, scope boundary, risks, team assignments, milestones.
+- Dependency Matrix: [link] — draft; we will confirm and correct this together in the meeting.
+
+**What the kickoff will accomplish:**
+1. Confirm scope and success criteria — if you disagree with anything in the brief, the kickoff is where to say so.
+2. Confirm team ownership and the first cross-team dependency each team has.
+3. Agree on the program working model: sync cadence, escalation path, decision-making structure.
+
+**What the kickoff will not do:**
+- Resolve technical design questions (those go offline to the relevant engineers)
+- Present a completed project plan for your teams to execute
+
+**Agenda:** [link to agenda doc]
+
+If you cannot attend and have not arranged a delegate, contact [TPM name] by [date] so we can decide whether to proceed.
+
+[TPM name]
+
+---
+
+## Milestone Announcement Template
+
+Sent to the full stakeholder distribution (decision-makers + informed) when a major milestone is reached.
+
+---
+
+**Subject:** [Program Name] — [Milestone Name] Complete
+
+[Distribution],
+
+[Program Name] reached a significant milestone today: [milestone name and one-sentence description of what it means].
+
+**What this means:**
+- [Business impact or next phase enabled — 1–2 sentences]
+- [Any action required from stakeholders — or "no action required"]
+
+**What's next:**
+- [Next milestone name and date]
+- [Any dependency or condition that must hold for the program to remain on track]
+
+[For launches visible to customers, add:] Customers may notice [describe the visible change]. If you receive customer questions, [support contact or FAQ link] is the right resource.
+
+Questions: contact [TPM name or program DL].
+
+[TPM name and engineering lead name]
+
+---
+
+**Example:**
+
+**Subject:** Payment Migration Program — Staging Migration Complete
+
+[Distribution],
+
+The Payment Migration Program reached a significant milestone today: the payment service has successfully migrated to the AWS/Kubernetes infrastructure in the staging environment. All integration tests are passing and performance benchmarks are within target.
+
+**What this means:**
+- The program is on track for the April 15 production launch (canary phase)
+- The platform team has confirmed the production environment will be ready by April 12
+
+**What's next:**
+- April 12: Production environment confirmed
+- April 15: Canary launch begins (1% traffic to new infrastructure)
+- April 22: Canary metrics review; go/no-go for full rollout
+
+No action required from this group. The go/no-go decision will be communicated before the April 15 launch.
+
+Marcus Webb, Sarah Chen
+
+---
+
+## Common Pitfalls
+
+**Status updates that read as activity reports.** "This week the team completed X, Y, and Z" with no evaluation of whether that is good, bad, or concerning. The reader cannot tell if the program is healthy. Every update needs an explicit status judgment, not just a list of completed work.
+
+**Buried blockers.** A blocker mentioned in the third paragraph of a workstream description that reads "the team is working through some challenges with the vendor timeline" is not surfaced — it is hidden. If something is blocking or at risk, it belongs in the summary and in the asks section. Nowhere else.
+
+**Missing "what I need from you."** Status reports and memos that inform but do not ask produce stakeholders who read the update and move on, when they needed to do something. Make the ask explicit, name who it is for, and name the deadline. An ask buried in a paragraph is not an ask — it is background information.
+
+**The escalation memo that is also a status report.** The escalation memo should be short and focused on one issue. If it also contains the weekly workstream status table, the urgency of the escalation is diluted. Keep them separate. If you need to send both in the same week, send two messages.
+
+**Communicating at the wrong frequency.** Increasing cadence when nothing has changed trains stakeholders to skim (or stop reading). Maintaining cadence when things are on fire means your weekly update is the wrong vehicle — escalate. Calibrate frequency to signal density, not to habit.

--- a/strategy/build-vs-buy-framework.md
+++ b/strategy/build-vs-buy-framework.md
@@ -1,0 +1,393 @@
+# Build vs. Buy Framework
+
+## Leadership Context
+
+The build-vs-buy decision is one of the highest-leverage calls an engineering leader makes — not because individual decisions are irreversible, but because the pattern of these decisions over time determines what the engineering organization becomes. An org that builds everything accumulates custom systems that require specialized knowledge and ongoing maintenance, pulling capacity away from differentiated work. An org that buys everything accumulates vendor dependencies that constrain architecture, create data portability risk, and erode the engineering team's ability to solve novel problems.
+
+The failure mode is not choosing wrong. The failure mode is choosing without a framework — following instinct, optimizing for the wrong dimension (usually initial cost), or letting the decision get made by whoever is most vocal in the architecture meeting. This playbook provides a structured, repeatable approach to build-vs-buy decisions that produces a documented rationale, surfaces the trade-offs explicitly, and creates an audit trail for post-decision review.
+
+---
+
+## When to Use This
+
+| Trigger | Notes |
+|---------|-------|
+| Evaluating a new tool or platform category | Before any vendor demo or POC is scheduled |
+| Vendor contract renewal (>$50K annually) | Renewal is an implicit re-commit to buy; evaluate it explicitly |
+| Platform consolidation after acquisition | Two tools doing the same job; need a principled basis for which survives |
+| New engineering capability entering the org (observability, feature flags, data pipeline) | First-time adoption decisions set precedents that are hard to reverse |
+| Engineering leader taking over a vendor relationship | Inherited contracts deserve a fresh evaluation against current strategy |
+
+Do not use this framework for commodity tooling where the decision is obvious (e.g., "should we use AWS S3 for object storage" — buy). Use it for decisions where the answer is genuinely ambiguous, the cost is material, or the choice will constrain the engineering organization for 2+ years.
+
+---
+
+## The Three-Way Decision
+
+This framework evaluates three options, not two. "Build vs. buy" is a false binary for most decisions.
+
+**Build:** The engineering org designs, builds, and operates the capability internally. The org owns the code, the data, the roadmap, and the operational burden.
+
+**Buy:** Procure a commercial product or SaaS platform. The vendor owns the code and the roadmap; the org owns the integration and the configuration.
+
+**Partner:** Adopt an open-source solution with optional commercial support, or form a deep integration partnership with a vendor where the org contributes to the roadmap. Falls between build and buy — the org takes on more ownership than pure SaaS but less than full build.
+
+Most engineering orgs default to a buy-or-build framing and miss the partner option, which is often optimal for infrastructure-category decisions (databases, message brokers, observability agents) where the open-source ecosystem is mature and the commercial-support tier addresses the operational risk.
+
+---
+
+## The Five Decision Dimensions
+
+Evaluate every build-vs-buy decision on these five dimensions. Each dimension is scored 1–5 in the scoring matrix below. Score independently before combining — do not collapse the dimensions into a single judgment before seeing all five.
+
+### Dimension 1: Strategic Differentiation
+
+Does the capability in question constitute a source of competitive advantage? Would differentiated implementation of this capability meaningfully improve the business's competitive position?
+
+| Score | Description |
+|-------|-------------|
+| 5 | This capability is core to the product's value proposition; differentiated implementation is a competitive moat |
+| 4 | Differentiated implementation would provide meaningful advantage; competitors with better implementations are winning |
+| 3 | Neutral — competitors do not differentiate on this; it is a table-stakes capability |
+| 2 | Below the threshold of differentiation; customers do not notice or care about the implementation |
+| 1 | Commodity infrastructure; no customer or competitive relevance to the implementation |
+
+**Score 4–5 → Strong build signal.** Buying a capability that is core to your differentiation means your roadmap is owned by a vendor. **Score 1–2 → Strong buy or partner signal.** Building commodity capabilities diverts engineering capacity from differentiated work.
+
+### Dimension 2: Total Cost of Ownership (5-Year)
+
+Calculate the full cost of each option across a 5-year horizon. Do not compare initial cost — compare total cost.
+
+**Build cost components:**
+- Engineering time to design and build (months × engineer cost)
+- Ongoing engineering time to maintain, extend, and operate (annual FTE fraction × 5 years)
+- Infrastructure costs (compute, storage, networking)
+- Incident response load: estimated hours per year × engineer cost
+- Opportunity cost: what does the team not build while building this?
+
+**Buy cost components:**
+- License or SaaS fees (annual × 5, accounting for seat expansion as the org grows)
+- Integration engineering time (one-time)
+- Ongoing integration maintenance (annual FTE fraction × 5 years)
+- Migration cost if you switch vendors at year 3 (probability-weighted)
+
+**Partner cost components:**
+- Open-source setup and configuration (one-time)
+- Commercial support tier if applicable (annual × 5)
+- Engineering time to contribute to or customize the project
+- Operational burden (similar to build, but reduced by the community maintaining the core)
+
+| Score | Description |
+|-------|-------------|
+| 5 | Build is significantly cheaper at 5 years (>40% cost advantage) |
+| 4 | Build is modestly cheaper (20–40% cost advantage) |
+| 3 | Costs are comparable within modeling uncertainty |
+| 2 | Buy is modestly cheaper (20–40% cost advantage) |
+| 1 | Buy is significantly cheaper (>40% cost advantage) |
+
+**Common mistake:** Underestimating the operational cost of the build option. A custom-built system always requires ongoing engineering attention: dependency updates, scaling, incident response, onboarding new engineers. At a fully-loaded engineer cost of $250K/year, even 0.25 FTE of ongoing maintenance is $62.5K/year — $312K over 5 years, before the initial build cost.
+
+### Dimension 3: Integration Complexity
+
+How difficult is it to integrate the buy/partner option with existing systems? And how difficult would the build option be to integrate with downstream consumers?
+
+| Score | Description |
+|-------|-------------|
+| 5 | Buy option is deeply embedded in existing vendor ecosystem; integration is trivial or pre-built |
+| 4 | Integration is straightforward; standard APIs, good documentation, low surface area |
+| 3 | Moderate integration complexity; some custom work required but well-understood patterns |
+| 2 | High integration complexity; vendor APIs are poor, documentation is sparse, significant custom glue code required |
+| 1 | Integration complexity is severe; vendor requires proprietary data formats, deep coupling, or migration from current systems is extremely high-risk |
+
+**Note:** Score the buy/partner integration complexity on this dimension. The build option implicitly scores 5 on integration complexity since you own both sides — but factor in the design and API definition cost in the TCO dimension.
+
+### Dimension 4: Team Velocity Impact
+
+How does this decision affect the engineering team's ability to deliver over the next 12–18 months?
+
+| Score | Description |
+|-------|-------------|
+| 5 | Building this capability accelerates the team — engineers will learn from it and the internal API enables downstream features faster than any buy option |
+| 4 | Build has moderate velocity benefit; the team builds genuine capability in this domain |
+| 3 | Velocity impact is neutral; build and buy options result in similar delivery speed |
+| 2 | Building this absorbs significant capacity; team velocity on other work drops noticeably during the build period |
+| 1 | Building this is a significant multi-quarter distraction; the org will be meaningfully slower on other work for 6–18 months |
+
+**The time dimension matters here.** A build decision that scores 5 in the long run may score 1 for the first 12 months while the team is building. If the org is in a competitive sprint or has committed to delivery milestones, the short-term velocity cost may override the long-term capability argument.
+
+### Dimension 5: Vendor Risk and Lock-In
+
+For buy and partner options: what is the risk profile of the vendor relationship, and how difficult would migration be if the relationship ends?
+
+| Score | Description |
+|-------|-------------|
+| 5 | Vendor is financially stable, market leader; data is portable; migration to alternative is straightforward |
+| 4 | Vendor is established; some lock-in but manageable; competitive alternatives exist |
+| 3 | Moderate lock-in; migration would require significant engineering effort but is not catastrophic |
+| 2 | High lock-in; vendor-proprietary data formats or APIs; migration would be a major project |
+| 1 | Severe lock-in; vendor is a single point of failure; migration would threaten business continuity; vendor financial stability is uncertain |
+
+**For build option:** Score this dimension based on the risk of depending on a key internal contributor — if one engineer owns the system, the lock-in risk is actually high. Score 5 if the system is well-documented, tested, and operationally understood by multiple engineers.
+
+---
+
+## Scoring Matrix
+
+**For each dimension, score 1–5. Apply weights based on org type.**
+
+| Dimension | Raw Score (1–5) | Weight: Startup | Weight: Growth-Stage | Weight: Enterprise |
+|-----------|----------------|-----------------|---------------------|--------------------|
+| Strategic differentiation | | 30% | 25% | 20% |
+| Total cost of ownership (5-year) | | 15% | 20% | 25% |
+| Integration complexity | | 15% | 15% | 20% |
+| Team velocity impact | | 25% | 20% | 15% |
+| Vendor risk / lock-in | | 15% | 20% | 20% |
+| **Weighted total** | | /5 | /5 | /5 |
+
+**Score interpretation:**
+
+- **4.0–5.0 → Strong build signal**
+- **3.0–3.9 → Build or partner; deeper analysis required on the deciding dimensions**
+- **2.0–2.9 → Buy or partner; deeper analysis required**
+- **1.0–1.9 → Strong buy signal**
+
+The score is an input to the decision, not the decision. Any dimension scoring 1 or 5 should be examined independently of the weighted total — an extreme on a single dimension can override a moderate composite score. If vendor lock-in scores 1 (catastrophic risk) but the composite is 3.0, the lock-in risk warrants an explicit conversation before proceeding.
+
+---
+
+## Build Signals vs. Buy Signals vs. Partner Signals
+
+### Build Signals
+
+- The capability is a direct input to the product's value proposition (a recommendation engine for a recommendations company; a search relevance algorithm for a search company)
+- Existing off-the-shelf options have fundamental constraints that cannot be worked around without building a wrapper that is itself a significant engineering project
+- The team needs to develop institutional expertise in this domain, and building is the learning vehicle
+- The org is at enterprise scale with the engineering capacity to build and operate without the build being a significant capacity drain
+
+### Buy Signals
+
+- The category is mature, commoditized, and not a source of competitive differentiation (authentication, payment processing, email delivery)
+- Time-to-market pressure makes the build timeline untenable
+- The buy option's feature set exceeds what the engineering org would build in the next 2 years
+- The org is at early stage and the founding team's time is the scarcest resource — building infrastructure competes directly with building product
+
+### Partner Signals
+
+- The capability is infrastructure-adjacent: databases, message brokers, observability agents, identity providers
+- A well-maintained open-source project exists that covers 80–90% of the use case; the remaining 10–20% can be covered by configuration or thin wrappers
+- The commercial support tier of the open-source project provides the operational safety net the org needs without the full SaaS lock-in
+- The team wants to maintain technical fluency in the domain without fully owning the software lifecycle
+
+---
+
+## Common Cognitive Biases in Build-vs-Buy Decisions
+
+**Not-Invented-Here (NIH) Syndrome**
+
+Engineers overvalue building because building is more interesting than integrating, and because there is a cultural tendency to distrust external solutions. The tell: "we could build something better" is offered without a concrete analysis of what "better" means or what it costs.
+
+*Counter:* Require TCO analysis before any build proposal is considered. Make the engineer proposing the build estimate the 5-year cost including their own ongoing maintenance time.
+
+**Sunk Cost Bias on Existing Vendors**
+
+An org that has paid $400K over three years to a vendor that is no longer the right solution will often renew because "we have already invested so much in the integration." The sunk cost is gone regardless of the renewal decision. The decision is: is this vendor the right choice for the next 3 years, starting from the current state?
+
+*Counter:* Evaluate all vendor renewals on the same five dimensions as a new decision. The integration already existing should factor into the TCO analysis as a credit (no one-time integration cost) but should not override a score that points to switching.
+
+**Underestimating Integration Cost**
+
+Engineering teams consistently underestimate the cost of integrating a buy option. "We'll have it running in 2 weeks" routinely becomes 3 months when authentication, data model mapping, error handling, monitoring, and edge cases are fully accounted for.
+
+*Counter:* Require a written integration plan before any buy decision is finalized. The plan should identify: authentication mechanism, data model differences, error states, monitoring approach, rollback plan. If the team cannot produce this in a few hours, they do not understand the integration well enough to estimate it.
+
+**Optimizing for Demo Quality**
+
+Vendors are expert at making their products look good in a 45-minute demo. Decisions made on demo quality are decisions made on the vendor's best-case scenario. The demo shows features; it does not show operational reality, scaling behavior, or the support queue backlog.
+
+*Counter:* Run a proof-of-concept against your actual data and actual integration requirements before any buy decision over $50K/year. Require a reference call with an org at similar scale.
+
+**Anchoring on Initial Cost**
+
+The buy option costs $30K/year and the build option looks like it costs nothing (we will use existing engineers). This comparison ignores the 5-year TCO of both options and the opportunity cost of the engineering time.
+
+*Counter:* The first line of the TCO analysis for the build option is: what is the cost of the engineers doing this work, in terms of what they are not working on?
+
+---
+
+## Decision Log Template
+
+Document the decision before it is made. The decision log forces the team to make the inputs explicit and creates an audit trail for the 12-month post-decision review.
+
+```
+## Build-vs-Buy Decision Log
+
+**Decision:** [Describe the capability or tool being evaluated]
+**Decision date:** [Date]
+**Decision owner:** [Name, title]
+**Participants:** [Names of engineers and stakeholders who contributed]
+
+---
+
+### Options Evaluated
+
+1. Build: [brief description]
+2. Buy: [vendor name and product]
+3. Partner: [open-source project or hybrid approach]
+
+---
+
+### Scoring
+
+| Dimension | Build | Buy | Partner |
+|-----------|-------|-----|---------|
+| Strategic differentiation (raw) | | | |
+| TCO 5-year (raw) | | | |
+| Integration complexity (raw) | | | |
+| Team velocity impact (raw) | | | |
+| Vendor risk / lock-in (raw) | | | |
+| **Weighted composite** | | | |
+
+Org type applied: [Startup / Growth-stage / Enterprise]
+Weights applied: [list weights used]
+
+---
+
+### TCO Summary (5-year)
+
+| Cost component | Build | Buy | Partner |
+|----------------|-------|-----|---------|
+| Initial build / integration | | | |
+| Ongoing maintenance (annual × 5) | | | |
+| License / vendor fees (annual × 5) | | | |
+| Infrastructure | | | |
+| Estimated migration cost (probability-weighted) | N/A | | |
+| **Total 5-year** | | | |
+
+---
+
+### Decision
+
+**Chosen option:** [Build / Buy / Partner]
+**Rationale:** [3–5 sentences. Name the deciding dimensions. Acknowledge the trade-offs.
+Do not just restate the scores — explain why those scores led to this decision given the
+org's current situation.]
+
+**Assumptions that must hold for this decision to remain correct:**
+- [Assumption 1: e.g., "We remain at <100 engineers; at 200+, the build option becomes worth revisiting"]
+- [Assumption 2: e.g., "The vendor maintains its current pricing tier"]
+- [Assumption 3]
+
+**Conditions that would trigger re-evaluation:**
+- [Condition 1: e.g., "Vendor raises price by >50%"]
+- [Condition 2: e.g., "Team velocity on feature delivery drops below X due to maintenance burden"]
+- [Condition 3]
+
+**12-month review date:** [Date]
+```
+
+---
+
+## Post-Decision Review Checklist
+
+At 12 months after the decision, review the decision log against what actually happened. This is not a blame exercise — it is a calibration exercise that improves future decisions.
+
+- [ ] TCO: How do actual costs compare to the 5-year projection at month 12 (annualized)?
+- [ ] Integration complexity: Did the integration take as long and cost as much as projected?
+- [ ] Team velocity: What was the actual velocity impact over the first 12 months?
+- [ ] Vendor risk: Have any of the vendor risk assumptions changed?
+- [ ] Assumptions: Are the assumptions in the decision log still valid?
+- [ ] Conditions: Have any re-evaluation triggers been hit?
+- [ ] Regret score: If the team could make this decision again with 12 months of information, would they make the same choice?
+
+If the regret score is high: document what data would have changed the decision and update the framework's decision criteria. Build institutional learning from individual decisions.
+
+---
+
+## Worked Examples
+
+### Example 1: Feature Flag System
+
+**Context:** A 60-engineer growth-stage SaaS company. Current state: feature flags are managed through environment variables in Terraform. The process is manual, requires a deploy, and is not accessible to non-engineers. Product managers want self-service flag management.
+
+**Options evaluated:**
+1. Build: custom feature flag service, flag evaluation SDK, admin UI
+2. Buy: LaunchDarkly at $30K/year for 60 seats
+3. Partner: Unleash (open-source) with self-hosted deployment
+
+**Scoring (growth-stage weights):**
+
+| Dimension | Build | Buy (LaunchDarkly) | Partner (Unleash) |
+|-----------|-------|--------------------|-------------------|
+| Strategic differentiation (25%) | 2 | 1 | 1 |
+| TCO 5-year (20%) | 3 | 3 | 4 |
+| Integration complexity (15%) | 5 | 4 | 3 |
+| Team velocity impact (20%) | 1 | 4 | 3 |
+| Vendor risk / lock-in (20%) | 5 | 3 | 4 |
+| **Weighted composite** | **2.9** | **3.0** | **3.0** |
+
+**TCO analysis:**
+- Build: 4 engineer-months initial ($133K) + 0.1 FTE maintenance ($25K/year × 5 = $125K) = $258K
+- Buy: $30K/year × 5 = $150K + 2 weeks integration ($16K) = $166K
+- Partner: 3 weeks setup ($25K) + hosting ($5K/year × 5 = $25K) + 0.05 FTE maintenance ($12.5K/year × 5 = $62.5K) = $112.5K
+
+**Decision:** Buy (LaunchDarkly). The composite scores are nearly identical, but team velocity impact tips the decision — the 4-month build timeline would delay two product features the team has committed to in H1. At growth stage, delivery commitments take precedence over infrastructure optimization. The 12-month assumption: if the team exceeds 150 engineers and LaunchDarkly pricing increases proportionally, re-evaluate Partner (Unleash) at renewal.
+
+---
+
+### Example 2: Data Pipeline
+
+**Context:** A 150-engineer fintech. Current state: data pipeline is a tangle of Python scripts scheduled in cron, with no lineage, no alerting, and manual recovery when jobs fail. Data engineering team is 6 people. Analytics team is 8 people and blocked on data quality.
+
+**Options evaluated:**
+1. Build: internal orchestration layer on top of Airflow
+2. Buy: dbt Cloud + Airbyte Cloud at $80K/year combined
+3. Partner: Airflow (Apache) self-hosted + dbt Core (open-source) + custom orchestration
+
+**Scoring (growth-stage weights):**
+
+| Dimension | Build | Buy (dbt Cloud + Airbyte) | Partner (Airflow + dbt Core) |
+|-----------|-------|--------------------------|------------------------------|
+| Strategic differentiation (25%) | 2 | 1 | 1 |
+| TCO 5-year (20%) | 3 | 2 | 4 |
+| Integration complexity (15%) | 3 | 4 | 3 |
+| Team velocity impact (20%) | 2 | 4 | 3 |
+| Vendor risk / lock-in (20%) | 4 | 2 | 4 |
+| **Weighted composite** | **2.7** | **2.6** | **3.0** |
+
+**Key factor:** Vendor risk score of 2 for the buy option reflects that both dbt Cloud and Airbyte Cloud are storing and processing sensitive financial data; the combination creates data residency risk the compliance team cannot accept. This dimension score alone (1 or 2) triggers the "examine independent of composite score" rule.
+
+**Decision:** Partner (Airflow + dbt Core self-hosted). The compliance constraint overrides the velocity advantage of the buy option. The data engineering team takes on operational burden for Airflow, which is well-understood at this scale, and uses dbt Core for transformation with internal orchestration. 12-month review: assess whether the operational burden was correctly estimated and whether the compliance constraint has changed.
+
+---
+
+### Example 3: Auth Provider
+
+**Context:** An 8-engineer startup. Current state: home-grown authentication built in week 2 of the company. Handles email/password; no MFA, no SSO, no audit logging. Enterprise prospects are asking for SAML SSO as a deal requirement.
+
+**Options evaluated:**
+1. Build: extend current auth system to add MFA and SAML SSO
+2. Buy: Auth0 at $23K/year for the required tier
+3. Partner: Keycloak (open-source) self-hosted
+
+**Scoring (startup weights):**
+
+| Dimension | Build | Buy (Auth0) | Partner (Keycloak) |
+|-----------|-------|-------------|--------------------|
+| Strategic differentiation (30%) | 1 | 1 | 1 |
+| TCO 5-year (15%) | 4 | 3 | 4 |
+| Integration complexity (15%) | 3 | 4 | 2 |
+| Team velocity impact (25%) | 1 | 4 | 2 |
+| Vendor risk / lock-in (15%) | 3 | 3 | 4 |
+| **Weighted composite** | **2.0** | **3.0** | **2.5** |
+
+**Key factor:** Authentication is security-critical, and an 8-engineer team that builds and maintains auth is carrying operational risk that Auth0 has already solved at scale. The team velocity impact score of 1 for the build option reflects that adding MFA, SAML, and audit logging to a home-grown auth system is a 2–3 month project that the founding team cannot afford.
+
+**Decision:** Buy (Auth0). The startup weight on strategic differentiation (auth is not differentiated) and team velocity (3 months on auth is a startup-killer at this stage) makes this clear. The 12-month assumption: at $23K/year, Auth0 pricing is manageable; if the company grows to the tier requiring $150K+/year, evaluate Keycloak migration at that point.
+
+---
+
+## Further Reading
+
+- Christensen, Clayton M. *The Innovator's Dilemma.* Harvard Business Review Press, 1997. The original framework for distinguishing core, differentiating capability from commodity capability — foundational to the strategic differentiation dimension.
+- Fowler, Martin. "Make or Buy?" *martinfowler.com*, 2018. https://martinfowler.com/bliki/MakeOrBuy.html. A concise primary-source treatment of the decision from an architecture perspective; covers the false binary and introduces the concept of integration as its own cost category.
+- CNCF. *Cloud Native Computing Foundation Landscape.* https://landscape.cncf.io/. The authoritative map of the open-source ecosystem for infrastructure and platform categories — essential reference when evaluating the partner option for DevOps and data platform decisions.

--- a/strategy/ma-technical-due-diligence.md
+++ b/strategy/ma-technical-due-diligence.md
@@ -1,0 +1,446 @@
+# M&A Technical Due Diligence Framework
+
+## Leadership Context
+
+Technical due diligence is the moment when an engineering leader's judgment most directly affects a business transaction. The quality of the technical assessment shapes acquisition price negotiation, integration budget, and — most consequentially — the timeline at which the combined engineering org will be able to move as a single unit after close. A diligence process that misses a $2M infrastructure migration, a GPL licensing exposure, or a five-person key-person risk does not fail in diligence — it fails 18 months post-close, when the cost is paid under integration pressure, at premium.
+
+The business outcome: thorough technical diligence reduces integration risk, produces defensible inputs to purchase price adjustments, and gives the post-close engineering leadership team a credible integration plan on day one rather than day 60.
+
+## When to Use This
+
+The diligence emphasis changes based on acquisition type. Use this framework to select and weight domains, not to run every domain at full depth for every acquisition.
+
+**Acqui-hire.** The primary asset is the team — engineering talent, culture, and working relationships. Architecture and technical debt assessments matter less. Key-person risk, team cohesion, and culture compatibility matter most. Prioritize: Team & Culture, Integration Complexity (people integration), Security Posture (because you are absorbing an endpoint fleet).
+
+**Product acquisition.** You are buying a working product and its user base. Architecture scalability, operational maturity, and technical debt matter significantly because you will own the ongoing cost of running and evolving the product. Prioritize: Architecture & Scalability, Technical Debt & Quality, Operational Maturity, Data Practices.
+
+**Technology acquisition.** You are buying IP, a technical capability, or a platform component that you intend to integrate into your own product. IP & Licensing and Integration Complexity dominate. Architecture matters insofar as it affects how extractable the technology is. Prioritize: IP & Licensing, Integration Complexity, Architecture & Scalability, Security Posture.
+
+---
+
+## Part 1: The 8 Assessment Domains
+
+### Domain 1: Architecture and Scalability
+
+**What you are evaluating:** Whether the system can handle the scale the combined business will require, and whether extending or evolving the architecture is tractable.
+
+**Artifacts to request:**
+- Architecture diagram (current state, not aspirational)
+- Service dependency map
+- Database schema overview
+- Traffic and load data: p50/p95/p99 latency, peak RPS, current infrastructure costs
+- Capacity limits and known bottlenecks
+
+**Questions to ask in the architecture walkthrough:**
+- What does your system look like at 10x current traffic? What breaks first?
+- What was the last major architectural change? How long did it take, and what did you learn?
+- What decisions do you regret most about the current architecture?
+- What is the single biggest technical risk in the system today?
+
+**Red flags:**
+- No architecture documentation; the only authoritative knowledge is in a founder's head
+- Single database serving all workloads with no read replicas or caching layer
+- Synchronous inter-service dependencies at scale (one slow service blocks all callers)
+- No load testing history; the team does not know where the system fails under stress
+- Architecture that cannot be extended without a full rewrite (e.g., a monolith with no seam for new services)
+
+**Yellow flags:**
+- Significant coupling that will require refactoring before integration, but is documented and understood
+- Infrastructure that is not cloud-native but has a plausible migration path
+- Scaling limits that are above current traffic but below projected post-acquisition traffic within 12 months
+
+---
+
+### Domain 2: Technical Debt and Code Quality
+
+**What you are evaluating:** The accumulated cost of past shortcuts and the ongoing drag those shortcuts impose on velocity. Technical debt is not inherently disqualifying — every engineering org carries it. The question is whether it is quantified, managed, and affordable.
+
+**Artifacts to request:**
+- Code coverage reports
+- Static analysis output (SonarQube, CodeClimate, or equivalent)
+- Dependency inventory (libraries, frameworks, versions)
+- List of known technical debt items (if tracked)
+- CI/CD pipeline configuration and pass rates
+
+**Questions to ask:**
+- How much of your codebase was written more than 3 years ago and has not been touched since?
+- What is your oldest dependency? When was it last updated?
+- What is your test coverage, and where is it lowest?
+- If you had 3 months with no product requirements, what would you fix?
+
+**Red flags:**
+- Test coverage below 30% across core business logic
+- Critical dependencies on end-of-life libraries with no upgrade path (e.g., Python 2, jQuery < 3, unsupported database versions)
+- Build failures exceeding 15% of CI runs in the past 90 days
+- No automated deployment; all deployments are manual and require a specific person
+- Core business logic in undocumented stored procedures or scheduled jobs that no active engineer owns
+
+**Yellow flags:**
+- Coverage is uneven — high in new code, low in legacy systems
+- Some dependencies are outdated but not on a critical path and have documented upgrade plans
+- Technical debt is tracked and prioritized but has been backlogged due to product pressure (common; the question is whether leadership acknowledges it or rationalizes it away)
+
+---
+
+### Domain 3: Security Posture
+
+**What you are evaluating:** Whether the target has implemented reasonable security controls and whether you are inheriting liability — data breaches that have not been disclosed, vulnerabilities that have not been patched, compliance obligations that have not been met.
+
+**Artifacts to request:**
+- Most recent penetration test report and remediation status
+- Vulnerability management process documentation
+- Access control policies (who has prod access, how is it managed)
+- Incident history (security incidents in past 24 months)
+- SOC 2 Type II report (if applicable)
+- Data classification policy
+
+**Questions to ask:**
+- When was your last pen test? What were the critical findings, and what is the status of remediation?
+- How is production access managed? Who has it, and how is it audited?
+- Do you have a history of security incidents? Walk me through the most significant one.
+- How are API keys, credentials, and secrets managed in your codebase and infrastructure?
+
+**Red flags:**
+- Unpatched critical CVEs in production systems
+- Shared credentials for production access (no individual accountability)
+- Secrets committed to version control — historically or currently
+- A security incident in the past 24 months that was not publicly disclosed (creates undisclosed liability)
+- No pen test in the past 18 months
+- PII or payment card data in unencrypted storage or logs
+
+**Yellow flags:**
+- Pen test findings that are remediated but not verified by a follow-up test
+- Access controls that work but are not formally documented
+- Security policies that exist but are not enforced with tooling (honor system)
+- SOC 2 in process but not yet completed
+
+---
+
+### Domain 4: Team and Culture
+
+**What you are evaluating:** Whether the engineering team is the asset you think you are buying, whether key talent will stay through and after close, and whether the team's working culture is compatible with the acquiring org.
+
+**Artifacts to request:**
+- Org chart with tenure data
+- Attrition history (past 24 months)
+- Retention agreements (if any) proposed by the target or expected by the target team
+- Offer letters and equity schedules for key engineers (to understand post-close vesting cliffs and retention risk)
+
+**Questions to ask (in team interviews, not just leadership):**
+- What are you most proud of that you've built here?
+- What would make you stay through and after the acquisition? What would make you leave?
+- How does the leadership team make technical decisions? Give me a recent example.
+- What is the biggest source of frustration in your engineering process today?
+
+**Red flags:**
+- Founder or CTO is the sole technical decision-maker; no evidence of distributed technical ownership
+- Core engineers have significant unvested equity that will accelerate on acquisition (creates perverse exit incentive — they may leave immediately post-close regardless of retention agreements)
+- Recent spike in attrition in the 6 months before close (engineers often know a sale is coming and start looking)
+- Team culture is highly insular; the team has not worked with outside engineers or integrated external APIs at the human level
+
+**Yellow flags:**
+- Team is strong but small; losing 2–3 people post-close would meaningfully impair the team's capacity
+- Culture is informal and low-process in ways that will require change under the acquiring org — change management cost, not a disqualifier
+- Key engineers are loyal to the founder, not to the company; founder transition is a retention risk
+
+---
+
+### Domain 5: Operational Maturity
+
+**What you are evaluating:** Whether the target can operate its own systems reliably, and what the ongoing operational burden you are absorbing looks like.
+
+**Artifacts to request:**
+- Incident history (past 12 months): frequency, severity, time-to-resolve
+- On-call rotation structure
+- Runbooks for critical systems
+- SLA commitments and SLA performance data
+- Deployment frequency and rollback rate
+
+**Questions to ask:**
+- Walk me through your most recent P0 or P1 incident. How did you detect it, how did you respond, and what changed after?
+- How do you deploy? How often? What is your rollback procedure when a deployment goes wrong?
+- What is your monitoring and alerting stack? How do you know when something is wrong?
+- Who is on call, and what is the on-call burden? How many pages per week on average?
+
+**Red flags:**
+- No incident history tracked; incidents are handled ad hoc with no record
+- On-call falls entirely on 1–2 engineers; bus factor in operational response
+- No runbooks; system operation depends entirely on tribal knowledge
+- Deployments are rare (monthly or less) because they are risky — a symptom of no automated testing, no rollback capability, or no confidence in the system
+- Monitoring is absent or only surface-level (process-up vs. truly unhealthy)
+
+**Yellow flags:**
+- Operational processes exist but are inconsistently followed
+- Incident frequency is elevated but trending downward (indicates awareness and action)
+- On-call burden is high but the team acknowledges it and has a plan to reduce it
+
+---
+
+### Domain 6: Data Practices
+
+**What you are evaluating:** Whether data is handled in compliance with relevant regulations, whether data assets are reliable and accessible, and what the data integration complexity looks like.
+
+**Artifacts to request:**
+- Data map: what data is collected, where it is stored, who has access
+- Privacy policy and data retention policies
+- GDPR/CCPA compliance documentation (if applicable)
+- Data pipeline architecture overview
+- Known data quality issues
+
+**Questions to ask:**
+- Where does your customer data live, and who can access it?
+- How do you handle data deletion requests (right to erasure)?
+- What is your data retention policy, and how is it enforced technically?
+- How do downstream teams in the org consume data? Is there a data warehouse or BI layer?
+
+**Red flags:**
+- Customer PII stored without purpose limitation or retention enforcement
+- Data deletion requests fulfilled manually with no audit trail
+- Data practices that appear to conflict with stated privacy policy (legal liability)
+- No data quality monitoring; downstream consumers have low confidence in data accuracy
+- Cross-border data transfer without Standard Contractual Clauses or equivalent (EU-US data flows)
+
+**Yellow flags:**
+- GDPR/CCPA compliance is procedural but not fully automated; manual steps in deletion workflow
+- Data warehouse exists but is not well-maintained; significant stale or duplicated data
+- Data access is controlled but not formally audited
+
+---
+
+### Domain 7: IP and Licensing
+
+**What you are evaluating:** Whether the acquiring company will own clean title to the intellectual property it is purchasing, and whether there are licensing obligations — from open source or vendor agreements — that constrain what you can do with the technology.
+
+**Artifacts to request:**
+- All open source licenses used (with version-level detail)
+- Third-party software license agreements (commercial tools, SDKs, data providers)
+- IP assignment agreements for all current and past employees and contractors
+- Patent inventory (if any)
+- Any existing IP disputes or claims
+
+**Questions to ask:**
+- Do all employees and contractors have signed IP assignment agreements?
+- Have you ever used GPL-licensed code in a commercial or closed-source product? How did you handle it?
+- Are there any vendor agreements that restrict how you can use or redistribute the technology?
+- Have you ever received a DMCA or IP claim? How was it resolved?
+
+**Red flags:**
+- GPL v2 or v3 code incorporated into a commercial product without release of the full codebase under GPL (copyleft exposure — the license terms may require release of proprietary code)
+- Contractors who built core IP without signed IP assignment agreements (creates a cloud on title — the contractor may have a claim)
+- Vendor agreements with anti-assignment clauses (the agreement may terminate on change of control, requiring renegotiation post-close)
+- Any pending or threatened IP litigation
+
+**Yellow flags:**
+- LGPL use in products; LGPL is permissive in most cases but requires linking to a dynamic library, not static — some architectures create unintended copyleft obligations
+- IP assignments that are signed but predated key features; need to verify coverage
+- Vendor agreements with no assignment clause specified — may require consent to transfer
+
+---
+
+### Domain 8: Integration Complexity
+
+**What you are evaluating:** What it will actually cost — in time and engineering resources — to integrate this system into the acquiring company's product, infrastructure, and team.
+
+**Artifacts to request:**
+- API documentation (public-facing and internal)
+- Authentication and identity architecture
+- Infrastructure providers and toolchain (cloud provider, CI/CD, observability)
+- Current third-party integrations and data flows
+
+**Questions to ask:**
+- If you had to expose your core functionality as an API to an external system, what would that take?
+- What parts of the system would be hardest to separate or extract?
+- What identity and auth system do you use, and what would it take to federate with our SSO?
+- What data does your system depend on that comes from outside your system?
+
+**Red flags:**
+- Identity is baked into the application rather than abstracted; SSO integration requires a significant rearchitecture
+- The system produces data in proprietary formats with no documented schema or export capability
+- Heavy dependency on a third-party vendor that the acquiring company does not use and cannot easily replace
+- Core logic is embedded in a framework or platform that is incompatible with the acquiring org's standards (e.g., .NET when the acquiring org is all Go/Kubernetes)
+
+**Yellow flags:**
+- Integration will require parallel-running systems for 6–12 months before migration is complete
+- The target team has never integrated with an external identity system; the capability is not proven
+- Toolchain divergence (different cloud providers, CI systems, observability stacks) that creates onboarding friction but not a hard technical blocker
+
+---
+
+## Part 2: Scoring Model
+
+Rate each domain 1–5 for overall health. Apply weights based on acquisition type. Weighted score indicates overall technical health; use it as an input to price and integration budget negotiation, not as a hard go/no-go.
+
+**Rating scale:**
+- **5 — Strong.** Domain is a genuine asset; minimal integration or remediation work expected.
+- **4 — Solid.** A few gaps; known and manageable. Not a risk driver.
+- **3 — Adequate.** Visible weaknesses; integration or remediation will require investment. Budget accordingly.
+- **2 — Concerning.** Material issues that will require significant resource or timeline adjustments. Flagged in executive summary.
+- **1 — Critical risk.** A finding in this domain materially affects the acquisition decision or price. Escalate before close.
+
+**Weight table by acquisition type:**
+
+| Domain | Acqui-Hire | Product Acquisition | Technology Acquisition |
+|---|---|---|---|
+| Architecture & Scalability | 10% | 20% | 20% |
+| Technical Debt & Quality | 10% | 15% | 10% |
+| Security Posture | 15% | 15% | 15% |
+| Team & Culture | 30% | 15% | 10% |
+| Operational Maturity | 10% | 20% | 10% |
+| Data Practices | 10% | 10% | 10% |
+| IP & Licensing | 5% | 5% | 20% |
+| Integration Complexity | 10% | 10% | 25% |
+| **Total** | **100%** | **100%** | **100%** |
+
+**Weighted score interpretation:**
+- 4.0–5.0: Low technical risk; proceed with standard integration planning
+- 3.0–3.9: Moderate risk; adjust price or require escrow for identified remediation costs
+- 2.0–2.9: Elevated risk; integration budget should include 20–30% contingency; specific findings may warrant price reduction
+- Below 2.0: High risk; recommend price reduction, extended escrow, or pass
+
+---
+
+## Part 3: The 2-Week Diligence Sprint
+
+Two weeks is a compressed but workable timeline for technical diligence on a 20–100 engineer company. It requires parallel workstreams.
+
+**Day 1–2: Kick-off and artifact collection**
+- Establish NDA and data room access
+- Request all artifacts across all 8 domains
+- Schedule all stakeholder interviews (see below)
+- Assign domain owners from the diligence team
+
+**Day 3–5: Stakeholder interviews**
+- CTO / VP Engineering (2 hours): architecture, team structure, strategic technical decisions, roadmap
+- Staff or Senior Engineers (1 hour each, 3–4 people): "what would you fix if you could?" conversations; technical depth check; retention signal
+- Engineering Manager(s) (1 hour): team health, attrition history, process maturity, on-call burden
+- Head of Security or SecOps lead (1 hour): security posture, incident history, access control
+- Data or Analytics lead (1 hour): data practices, data quality, compliance posture
+
+**Interview ground rules:**
+- Interview engineers without their leadership present for at least one session. Engineers are more candid about technical debt, leadership quality, and team morale when not monitored.
+- Avoid leading questions ("Do you have any technical debt?"). Ask open-ended questions that require narrative answers ("What would you do first if you had 90 days with no product pressure?").
+- Take notes on what is not said as much as what is: evasion, redirection, and vague answers about architecture or security are signals.
+
+**Day 5–7: Code review and architecture walkthrough**
+- Conduct a focused code review on 2–3 areas: core business logic, authentication/authorization, and a recent feature that the team is proud of
+- Walk through the architecture diagram with the team's lead engineer; ask them to explain design decisions, not just describe components
+- Review CI/CD pipeline: inspect test suite structure, coverage metrics, build history
+
+**Day 8–10: Artifact analysis and scoring**
+- Score each domain using the rubric
+- Identify red flags and yellow flags per domain
+- Draft integration complexity estimate with engineering counterpart
+
+**Day 11–12: Report drafting**
+- Write the technical diligence report (see Part 4)
+- Identify the top 3 findings that affect price or integration budget
+- Prepare executive summary (5 things every executive needs to see — see Part 4)
+
+**Day 13–14: Internal review and delivery**
+- Review report with the M&A team and legal counsel
+- Surface any findings that affect deal terms (price adjustment, escrow, reps and warranties)
+- Deliver report to acquiring company leadership
+
+---
+
+## Part 4: The Technical Diligence Report
+
+### Format
+
+**Section 1: Executive Summary (1 page)**
+Five things every executive needs to see:
+
+1. **Overall technical health score** — weighted score, rating, and a one-sentence characterization
+2. **Top 3 risks** — the findings that most affect price, integration cost, or execution risk post-close
+3. **Team assessment** — will the team stay? Who are the key people, and what is the retention risk?
+4. **Integration cost estimate** — time and FTE cost to integrate the target's systems into the acquiring company's product and infrastructure
+5. **Recommendation** — proceed, proceed with conditions (price adjustment, escrow, required remediation pre-close), or pass
+
+**Section 2: Domain Assessments (1–2 pages per domain)**
+For each domain: rating (1–5), key findings (bulleted), red flags, yellow flags, and recommended action (buy-down, escrow, integration budget item, or no action required).
+
+**Section 3: Integration Plan Inputs (1 page)**
+- Estimated integration timeline (quarters, not days)
+- FTE requirements for integration (from the acquiring team)
+- Key dependencies and critical path
+- Integration risks (what could extend the timeline or cost)
+
+**Section 4: Post-Close Risk Register (see template in Part 5)**
+
+**Section 5: Appendix**
+- Artifact inventory (what was provided vs. requested)
+- Interview log (who was interviewed, dates, duration)
+- Scoring rubric (with weights applied)
+
+---
+
+## Part 5: Common Diligence Blind Spots
+
+### Hidden Dependencies
+
+The architecture diagram shows the target's systems. It does not always show the third-party services, vendor APIs, and data providers that the system depends on silently. A SaaS product that depends on a vendor for payments, identity, email delivery, and search indexing may have four critical dependencies that do not appear in the architecture diagram because they are "just APIs."
+
+**How to surface them:** Ask: "What would break in your product if Stripe stopped working? What about if SendGrid went down? What external services are you dependent on for your core user journey?" Build the dependency map from the user journey backward, not from the architecture diagram outward.
+
+### Key-Person Risk
+
+Every engineering org has people without whom the system becomes significantly harder to operate or evolve. In a small company, this is often the CTO or a founding engineer. In diligence, the risk is routinely disclosed ("oh, Mark knows that part of the system best") and then routinely underestimated.
+
+**How to assess it:** Ask the team, not leadership: "If [person] left tomorrow, what would you lose? Is that documented anywhere?" If the answer is "we'd figure it out" without specificity, the knowledge is undocumented. If the answer is a long pause followed by "a lot," the risk is real.
+
+**Retention risk amplifier:** Key engineers with unvested equity that accelerates on acquisition have no financial incentive to stay through the integration period. Model their post-close retention independently and factor it into the team assessment.
+
+### Licensing Time Bombs
+
+GPL and AGPL licenses can create copyleft obligations that are not immediately visible. A SaaS product that incorporates AGPL-licensed code (common in data tools and ML libraries) may have an obligation to release its source code under AGPL if any user can access the software over a network — even without distribution. This is often discovered post-close when legal reviews the dependency inventory for the first time.
+
+**How to surface them:** Request a full dependency inventory with license data. Many build systems can generate this. Review any AGPL or GPL v3 dependencies that are used in the product layer (not just development tooling). Engage IP counsel for any findings in this area — the engineering team may not understand the license implications.
+
+---
+
+## Part 6: Post-Close Integration Risk Register Template
+
+Built during diligence; handed off to the integration team at close.
+
+| Risk | Domain | Severity | Probability | Integration Impact | Mitigation | Owner |
+|---|---|---|---|---|---|---|
+| Key engineer (Alex, auth system) leaves post-close | Team & Culture | High | Medium | Auth system becomes unmaintainable without 3-month knowledge transfer | Retention agreement; pair Alex with acquiring-side engineer immediately post-close | Engineering Director |
+| GPL v2 dependency in payments module | IP & Licensing | High | Confirmed | May require codebase disclosure or module rewrite | Legal review; rewrite module to remove dependency (est. 6 weeks, 1 senior engineer) | Engineering + Legal |
+| No runbooks for database failover | Operational Maturity | Medium | Confirmed | First production incident will have extended TTR | Write runbooks in first 30 days post-close; acquiring team shadows target team on-call for 60 days | Site Reliability |
+| On-call burden unsustainable at 2 people | Team & Culture | Medium | High | Attrition risk if on-call is not redistributed | Expand on-call rotation to 5 people using acquiring team members by month 2 | Engineering Manager |
+| Infrastructure on custom bare-metal (not cloud) | Architecture | Medium | Confirmed | Cloud migration required before convergence with acquiring team's K8s platform (est. 12 months) | Parallel-run strategy; no forced migration in first 6 months | Platform Engineering |
+| CCPA deletion workflow is manual | Data Practices | Low | Confirmed | Compliance risk; 1–2 week remediation | Automate deletion workflow before customer data migration | Data Engineering |
+
+**Severity:** High (affects close decision or price), Medium (integration budget item), Low (operational task post-close)
+
+**Probability:** Confirmed (known finding), High (>70% likely to materialize), Medium (30–70%), Low (<30%)
+
+The risk register should be reviewed at 30, 60, and 90 days post-close in integration governance meetings. Risks that materialize should be tracked against their mitigation plans. Risks that resolve should be closed with a note on outcome.
+
+---
+
+## Implementation Checklist
+
+- [ ] Determine acquisition type (acqui-hire, product, technology) and apply the appropriate domain weights before starting diligence
+- [ ] Assign domain owners from the diligence team — one person per domain, accountable for artifacts, interviews, and scoring
+- [ ] Request all artifacts at kick-off; track what is provided vs. what is not (gaps in artifact provision are themselves a signal)
+- [ ] Schedule interviews with engineers without leadership present for at least one session
+- [ ] Run the code review against core business logic and authentication — not the cleanest code, the most important code
+- [ ] Build the dependency inventory with license data; flag all GPL, LGPL, and AGPL dependencies for legal review
+- [ ] Verify IP assignment agreements exist for all current and past contributors to core systems
+- [ ] Score all 8 domains; calculate weighted score; draft the executive summary before the full report
+- [ ] Build the post-close risk register during diligence — not after; information is freshest during active diligence
+- [ ] Identify top 3 findings that should affect deal terms and socialize them with M&A counsel before the report is finalized
+- [ ] Hand off the risk register to the integration team lead at close with a 90-day review cadence established
+
+---
+
+## What Does Not Work
+
+**Architecture-only diligence.** The most common failure is a technical diligence that spends 80% of its time on system architecture and 20% on everything else. Architecture is important, but it is also the easiest domain to assess and the easiest for a prepared target company to present well. Key-person risk, licensing obligations, and operational maturity are harder to assess and harder to fake.
+
+**Trusting the data room over interviews.** Artifacts are curated. The data room contains what the target company chose to show you. Interviews — especially with engineers without leadership present — surface what the data room does not.
+
+**Delivering a report that requires translation.** The technical diligence report serves two audiences: the engineering team driving integration planning, and the executive team making the final decision. Both audiences need their questions answered without translation. Write the executive summary first; if the engineering team lead cannot explain it to the CFO in 5 minutes without the appendix, the summary is not ready.
+
+**Treating post-close integration as someone else's problem.** The engineer who ran diligence knows where the bodies are buried. If that knowledge does not transfer to the integration team at close, the integration team will rediscover every risk register item the hard way. Build the handoff into the diligence process, not as an afterthought.

--- a/strategy/technical-strategy-template.md
+++ b/strategy/technical-strategy-template.md
@@ -1,0 +1,393 @@
+# Technical Strategy Template
+
+## Leadership Context
+
+A technical strategy document is the primary artifact through which an engineering leader translates business objectives into engineering investment. Without it, headcount decisions are negotiated on intuition, architectural investments compete with feature work on a quarter-by-quarter basis, and the engineering organization operates reactively. With it, there is a shared frame for what the engineering organization is trying to become and what it will and will not invest in to get there.
+
+The audience for a technical strategy is not primarily engineers — it is the executive team, the board, and the finance function that controls the budget. It must be legible to a CFO who wants to know why replatforming requires 6 headcount for 18 months, and to a CEO who wants to know how the technical investment connects to market position. Engineers read it too, and it must be credible to them — but optimizing the document for engineers at the expense of executive legibility is the most common failure mode.
+
+---
+
+## When to Use This
+
+| Trigger | What the document needs to do |
+|---------|-------------------------------|
+| New Director/Head of Engineering in first 90 days | Establish a baseline, demonstrate command of the technical situation, and signal where investment will go |
+| Annual planning cycle | Anchor engineering's budget request in a multi-year technical direction |
+| Major pivot or strategy change | Translate the new business direction into engineering implications and trade-offs |
+| Replatforming or major architectural investment | Frame the investment case — current state, target state, cost, risk, return |
+| Post-acquisition integration | Define which systems survive, which are sunset, and on what timeline |
+
+Do not write a technical strategy in response to a single incident or a short-term pressure. A strategy written under duress is a tactical plan mislabeled. A technical strategy should be the answer to a 12–36 month question, not a 60-day question.
+
+---
+
+## The Five Sections Every Technical Strategy Needs
+
+A technical strategy document that is missing any of these five sections is incomplete. Each section answers a different executive question.
+
+| Section | Executive question it answers |
+|---------|-------------------------------|
+| Current State Assessment | What is the situation we are starting from? |
+| Target State Vision | What does success look like in 1–3 years? |
+| Gap Analysis | What is standing between current and target? |
+| Investment Roadmap | What do we need to do, in what order, and at what cost? |
+| Success Metrics | How will we know if the strategy is working? |
+
+The sections are sequential. A strategy that jumps to Investment Roadmap without a rigorous Current State Assessment is not a strategy — it is a wishlist. The diagnosis validates the prescription.
+
+---
+
+## Section 1: Current State Assessment
+
+### What it needs to cover
+
+The current state assessment is a structured diagnosis of the engineering organization at the moment the strategy begins. It should be uncomfortable to write if the situation is not good. It should name the specific systems, teams, and practices that are constraining delivery — not describe them in generalities.
+
+**Technical debt inventory**
+
+A technical debt inventory is not a list of "things engineers wish they could refactor." It is a classification of debt by its impact on delivery, reliability, and the team's ability to change the system.
+
+Classify debt into three categories:
+
+| Category | Definition | Example |
+|----------|-----------|---------|
+| Delivery-blocking | Debt that directly slows new feature development or requires heroic effort to work around | A monolith with no seam points, requiring all 12 engineers to coordinate on every deployment |
+| Reliability-degrading | Debt that is causing or is likely to cause production incidents | An authentication service that was never designed for the current traffic volume and fails at load spikes |
+| Velocity-taxing | Debt that adds friction but is not acute | Test suite that takes 45 minutes to run, slowing the PR review cycle |
+
+Only category 1 and 2 debt belong in a technical strategy. Category 3 debt should be addressed in normal engineering operations without requiring executive attention.
+
+**DORA baseline**
+
+The current state assessment should include a DORA baseline so that the strategy has measurable starting points. Without this, progress claims are unverifiable.
+
+| Metric | Current | Tier |
+|--------|---------|------|
+| Deployment frequency | ? | ? |
+| Lead time for change | ? | ? |
+| Change failure rate | ? | ? |
+| MTTR | ? | ? |
+
+If you cannot fill in this table, instrumentation is part of the strategy.
+
+**Team topology audit**
+
+Map current team ownership against the target architecture to identify:
+- Services with no clear owner
+- Teams that own too many systems to maintain them well
+- Boundaries that require constant cross-team coordination
+
+See the Team Topology Framework playbook for the cognitive load audit methodology.
+
+**Dependency map**
+
+Identify critical external and internal dependencies:
+- Vendors or platforms with risk concentration (single vendor for infrastructure, payments, etc.)
+- Internal service dependencies that create coupling across team boundaries
+- Third-party integrations with poor reliability or vendor stability risk
+
+### Template: Current State Section
+
+```
+## Current State
+
+### What Is Working
+[2–3 specific strengths: capabilities the team has demonstrated, systems that are running well,
+practices that are ahead of where they would be expected to be. Be specific — name the systems.]
+
+### What Is Constraining Us
+[Categorized technical debt inventory. Use the delivery-blocking / reliability-degrading /
+velocity-taxing classification. For each item: name the system or practice, describe the
+constraint it creates, and estimate the cost in engineering capacity or business risk.]
+
+### DORA Baseline
+[Table: metric, current value, tier. If instrumentation does not exist yet, state that
+and include instrumentation as a strategy item.]
+
+### Team Topology
+[Brief description of current team structure. Identify ownership gaps and coupling problems.
+Reference the team topology audit results.]
+
+### Key Risks
+[3–5 specific risks the current state creates: reliability risks, delivery risks, competitive
+risks, team sustainability risks. Each risk should be falsifiable — it either materializes
+or it does not.]
+```
+
+---
+
+## Section 2: Target State Vision
+
+### What it needs to cover
+
+The target state vision describes what the engineering organization looks like in 1–3 years if the strategy succeeds. It should be specific enough to be falsifiable (you should be able to tell when you have arrived) without over-specifying implementation detail.
+
+**What to specify:**
+
+- The organizational capabilities the engineering team will have that it does not have today (e.g., "teams deploy independently to production without coordinating across service boundaries")
+- The reliability posture (e.g., "99.9% availability on all customer-facing APIs; MTTR under 60 minutes for P0 incidents")
+- The delivery throughput (e.g., "deployment frequency of 5+ per team per week; lead time under 2 days")
+- The architecture pattern (e.g., "domain-oriented services with defined API contracts; no shared databases between domains")
+- The platform capability (e.g., "self-service deployment pipeline that allows any team to provision a new service in under 4 hours without platform team involvement")
+
+**What not to specify:**
+
+- Specific technologies or vendors (unless choosing a technology is itself a strategic decision — e.g., "we are consolidating on AWS")
+- Implementation detail of individual services
+- Sprint-level delivery plans
+
+The target state vision should be stable across leadership transitions. If a new CTO would immediately rewrite your target state, the vision is too tactical.
+
+### Template: Target State Section
+
+```
+## Target State Vision
+
+By [DATE — 12–36 months from strategy start], the engineering organization will:
+
+**Delivery capability:**
+[Specific, measurable delivery capability: deployment frequency, lead time, independence
+between teams. Example: "Teams deploy to production independently, without cross-team
+coordination, at a frequency of 5+ times per week per team."]
+
+**Reliability posture:**
+[Specific reliability targets: SLOs, MTTR, incident frequency. Example: "All customer-facing
+services maintain 99.9% availability with an MTTR under 60 minutes for P0 incidents."]
+
+**Architecture pattern:**
+[High-level architecture direction: what the service ownership model looks like, what the
+platform abstraction provides, what the inter-team API contract model is.]
+
+**Team structure:**
+[What the team topology looks like — not individual team names, but the model: how many
+stream-aligned teams, whether a platform team exists, what the enabling capability looks like.]
+
+**What we will NOT do:**
+[Explicit exclusions. A strategy that tries to achieve everything achieves nothing. Name
+what is out of scope: technologies you are not adopting, architectural patterns you are
+explicitly rejecting, capability investments you are deferring.]
+```
+
+---
+
+## Section 3: Gap Analysis
+
+### What it needs to cover
+
+The gap analysis is the bridge between current state and target state. It names the specific gaps — technical, organizational, and capability gaps — that must be closed to achieve the target. Each gap becomes a candidate for the investment roadmap.
+
+**Categorize gaps by type:**
+
+| Gap type | Example |
+|----------|---------|
+| Technical | Monolithic architecture prevents independent team deployment |
+| Organizational | No platform team exists; each stream-aligned team is provisioning its own infrastructure |
+| Capability | Engineering org has no observability expertise; no one can interpret distributed traces |
+| Process | No SLO definition or monitoring; reliability posture is undefined |
+| Tooling | No deployment pipeline; engineers are manually deploying from local machines |
+
+**For each gap, estimate:**
+- Impact on the target state if the gap is not closed (high / medium / low)
+- Effort to close (engineering months; order of magnitude)
+- Dependencies: does closing this gap depend on closing another gap first?
+
+### Template: Gap Analysis Section
+
+```
+## Gap Analysis
+
+| Gap | Type | Impact if unaddressed | Estimated effort | Dependencies |
+|-----|------|-----------------------|-----------------|--------------|
+| [Gap 1] | [Technical / Org / Capability / Process / Tooling] | [High / Medium / Low] | [X engineer-months] | [None / Gap N] |
+| [Gap 2] | ... | ... | ... | ... |
+
+### Gap 1: [Name]
+**Current state:** [What exists today]
+**Target state:** [What needs to exist]
+**Why this gap matters:** [Business impact if unaddressed — connect to revenue, reliability, or
+team sustainability]
+**Closing the gap:** [High-level approach — not implementation detail, but architectural or
+organizational direction]
+```
+
+---
+
+## Section 4: Investment Roadmap
+
+### What it needs to cover
+
+The investment roadmap organizes the work required to close the gaps into a time-phased plan. Use a horizon model: 0–6 months (foundations), 6–18 months (core investment), 18–36 months (target state enablement). This framing is more durable than quarterly plans because it survives the inevitable schedule changes in years 2 and 3.
+
+**For each horizon:**
+- Name the specific investments (not epics — investment categories)
+- Quantify the resource requirement (headcount, quarters of capacity)
+- State the explicit trade-off: what does the org stop doing or delay to make this investment?
+- Define the outcome expected at the end of the horizon
+
+**The trade-off section is mandatory.** A strategy without explicit trade-offs is an aspiration. If you are asking for 3 engineer-years to build a platform team's self-service infrastructure, you need to say what that 3 engineer-years is not going towards — and that conversation must happen with the business, not be deferred.
+
+### Template: Investment Roadmap Section
+
+```
+## Investment Roadmap
+
+### Horizon 1: Foundations (0–6 months)
+
+**Goal:** [What must be true at the end of this horizon for Horizon 2 to succeed]
+
+**Investments:**
+
+| Investment | What it involves | Resource requirement | Trade-off |
+|------------|-----------------|---------------------|-----------|
+| [Investment 1] | [1–2 sentences: what we are building or changing] | [N engineer-months] | [What we are not doing to fund this] |
+| [Investment 2] | ... | ... | ... |
+
+**Exit criteria:** [Specific, measurable conditions that define when Horizon 1 is complete.
+Example: "DORA baseline instrumented; deployment pipeline gating on all required controls;
+platform team chartered and staffed."]
+
+---
+
+### Horizon 2: Core Investment (6–18 months)
+
+**Goal:** [What must be true at the end of this horizon for Horizon 3 to succeed]
+
+**Investments:**
+
+| Investment | What it involves | Resource requirement | Trade-off |
+|------------|-----------------|---------------------|-----------|
+| [Investment 1] | ... | ... | ... |
+
+**Exit criteria:** [Specific, measurable conditions]
+
+---
+
+### Horizon 3: Target State Enablement (18–36 months)
+
+**Goal:** [What the org looks like when the strategy is complete]
+
+**Investments:**
+
+| Investment | What it involves | Resource requirement | Trade-off |
+|------------|-----------------|---------------------|-----------|
+| [Investment 1] | ... | ... | ... |
+
+**Exit criteria:** [Matches the target state conditions from Section 2]
+
+---
+
+### Resource Summary
+
+| Horizon | Engineering headcount | Duration | Key outcomes |
+|---------|----------------------|----------|--------------|
+| Foundations | [N] | 0–6 months | [Exit criteria summary] |
+| Core Investment | [N] | 6–18 months | [Exit criteria summary] |
+| Target State Enablement | [N] | 18–36 months | [Target state conditions] |
+```
+
+---
+
+## Section 5: Success Metrics
+
+### What it needs to cover
+
+Success metrics close the loop between the strategy and the health scorecard. They define how leadership will know whether the strategy is working. They should be observable, not aspirational — you should be able to pull a report and see whether you are on track.
+
+**One metric per strategic goal.** If you have five strategic goals, you have five primary success metrics. Adding more than one metric per goal creates measurement overhead without additional clarity.
+
+**Include leading indicators.** Lagging indicators (deployment frequency, MTTR) tell you what happened. Leading indicators tell you whether you are on track before the outcome is final. For a platform investment, the leading indicator might be: percentage of teams that have adopted the new deployment interface.
+
+### Template: Success Metrics Section
+
+```
+## Success Metrics
+
+### Primary Metrics (by horizon)
+
+**Horizon 1 success if:**
+- [Metric 1]: [Target] by [date]
+- [Metric 2]: [Target] by [date]
+
+**Horizon 2 success if:**
+- [Metric 1]: [Target] by [date]
+- [Metric 2]: [Target] by [date]
+
+**Horizon 3 (strategy complete) success if:**
+- Deployment frequency: [target]
+- Lead time: [target]
+- SLO attainment: [target]
+- On-call load: [target]
+- [Org capability metric]: [target]
+
+### Leading Indicators (to track monthly)
+- [Leading indicator 1]: [what it measures, why it predicts the lagging outcome]
+- [Leading indicator 2]: ...
+```
+
+---
+
+## Communication Formats by Audience
+
+The strategy document is the source of record. It is not what you present to every audience. Adapt the format to the audience without changing the substance.
+
+**For engineers (full document, 10–20 pages):**
+- All five sections in full
+- Technical detail on current state: system names, specific debt items, architecture diagrams
+- Honest diagnosis of what is broken and why
+- Explicit trade-offs and sequencing rationale
+
+**For executive team (5-slide summary):**
+1. Current state: 3 bullets — biggest technical constraints on the business
+2. Target state: 3 bullets — what the engineering org will be capable of in 18–36 months
+3. Investment roadmap: one-page table by horizon — investment, headcount, outcome
+4. Success metrics: primary metrics with targets by horizon
+5. Risks: 2–3 execution risks and mitigation approaches
+
+**For board (verbal narrative, 5 minutes):**
+Focus on three things: (1) where the engineering org is relative to the scale demands of the business, (2) the one or two largest technical risks to business continuity, (3) the headline investment and expected return. Do not show the roadmap table; describe the direction. Have the detailed document ready for follow-up questions.
+
+**For finance / budget review:**
+Lead with the resource summary table. Connect each investment to a business outcome: "the platform investment reduces new feature time-to-production by 40%, which accelerates revenue growth by [N] months." If you cannot articulate the ROI of an engineering investment in business terms, you will not win the budget conversation.
+
+---
+
+## Common Failure Modes
+
+**Too much aspiration, too little diagnosis**
+
+A strategy that describes a beautiful target state without a credible current state assessment is not a strategy — it is a vision statement. Executives who have seen vision statements before (which is all of them) will not fund it. The diagnosis is what makes the investment case credible.
+
+*Fix:* Write the current state section first. If you cannot fill it in specifically, you do not know the current state well enough to write a strategy yet.
+
+**Strategy without resourcing**
+
+A strategy that identifies 12 major initiatives and does not specify how many engineers are required, or where they come from, is not actionable. "We will address technical debt in parallel with feature delivery" is not a resourcing plan.
+
+*Fix:* Every investment in the roadmap requires a headcount number and a trade-off statement. If you cannot name the trade-off, you are asking for unlimited resources, which is not a strategy.
+
+**Specificity trap: over-specifying implementation**
+
+A strategy that specifies "we will migrate from PostgreSQL to Aurora Serverless, move from Docker Compose to EKS, replace Kafka with Kinesis, and adopt GraphQL federation" is making decisions that belong to engineers, not to a strategy document. Technology choices at this level belong in Architecture Decision Records.
+
+*Fix:* The strategy specifies the capability (self-service deployment platform) and the constraint (teams must be able to deploy independently without platform team involvement). The team chooses the implementation.
+
+**Horizon 1 is too long**
+
+A Horizon 1 that lasts 12+ months is not foundations — it is the strategy itself. Horizon 1 should deliver observable outcomes within 6 months, or executive confidence will erode before any results appear.
+
+*Fix:* Horizon 1 exit criteria should be achievable in 3–6 months with the resources committed. If Horizon 1 requires 12 months, either the scope is too large or the resources are insufficient — and both of those are things the strategy should say explicitly.
+
+**Metrics that are not owned**
+
+Success metrics without a named owner do not get tracked. "Deployment frequency will reach 5/week" is not actionable unless someone is accountable for measuring it and reporting on it.
+
+*Fix:* Every metric has an owner. The owner is responsible for the instrumentation, the monthly report, and the escalation if the metric is trending in the wrong direction.
+
+---
+
+## Further Reading
+
+- Humble, Jez, Joanne Molesky, and Barry O'Reilly. *Lean Enterprise: How High Performance Organizations Innovate at Scale.* O'Reilly Media, 2015. Chapter 4 covers investment portfolio management for technology; directly applicable to the horizon model.
+- Forsgren, Nicole, Jez Humble, and Gene Kim. *Accelerate: The Science of Lean Software and DevOps.* IT Revolution Press, 2018. The empirical foundation for DORA metrics and their predictive relationship to organizational outcomes.
+- Larman, Craig, and Bas Vodde. *Scaling Lean & Agile Development: Thinking and Organizational Tools for Large-Scale Scrum.* Addison-Wesley, 2009. Chapter 2 on feature teams and the organizational dynamics that either enable or constrain technical strategy.


### PR DESCRIPTION
## Summary

- Adds 17 new playbooks covering org-level leadership work missing from the repo (previously all 6 playbooks were operational-layer only)
- Updates README to group all 21 playbooks by leadership domain (Org Design & Strategy, People Systems, Operating Cadence, Program Management, Operations, Compliance & Security, Technology Adoption)
- Adds a **Leadership context** block to each of the 6 existing playbooks connecting operational content to business outcomes

## New playbooks

**Org Design & Strategy** (Director/HoE)
- `org-design/team-topology-framework.md` — 4 team types, cognitive load thresholds, Inverse Conway Maneuver, reorg execution checklist
- `metrics/engineering-health-scorecard.md` — DORA + SLO + reliability + team health; QBR narrative; instrumentation guide
- `strategy/technical-strategy-template.md` — 5-section skeleton with audience-specific communication guidance
- `strategy/build-vs-buy-framework.md` — 3-way decision (build/buy/partner), weighted scoring matrix, 3 worked examples
- `strategy/ma-technical-due-diligence.md` — 8-domain assessment framework; 2-week diligence sprint; executive report format

**People Systems** (Director/HoE)
- `people/career-ladder-calibration.md` — L3–Staff definitions, calibration structure, 3 failure modes, appeals process
- `people/headcount-capacity-planning.md` — 4 capacity inputs, 1-page finance ask format, 12-month rolling model

**Operating Cadence** (Chief of Staff, Engineering)
- `operating-cadence/engineering-rhythm-of-business.md` — weekly/monthly/quarterly/annual cadence, DACI, meeting health audit
- `operating-cadence/engineering-okr-framework.md` — cascade mechanics, grading model, anti-patterns
- `operating-cadence/executive-communication-templates.md` — QBR, board update, incident summary, HC request (5 templates)
- `operating-cadence/cross-functional-alignment-playbook.md` — Eng × Product/Design/Legal/Finance/Sales; RACI template
- `operating-cadence/escalation-framework.md` — 3 trigger categories, 4 levels with SLAs, 5-sentence memo format

**Program Management** (TPM)
- `program-management/program-planning-playbook.md` — program brief, kickoff, milestone tracking, closure criteria
- `program-management/raid-dependency-tracking.md` — risk register, assumption log, dependency matrix, weekly ritual
- `program-management/launch-readiness-checklist.md` — 8 domains, blocker/waiver process, launch day runbook
- `program-management/stakeholder-communication-templates.md` — status report, escalation memo, stakeholder tier map
- `program-management/change-management-framework.md` — 5-phase model, resistance framework, rollback criteria

## Test plan

- [ ] All 21 markdown files render correctly on GitHub
- [ ] README links resolve to the correct files
- [ ] All new files open with a Leadership context block and a "When to use this" section

Closes #2
