### PR TITLE
chore: playbook consistency cleanup

### DIFF
--- a/ai-adoption/ai-adoption-readiness-framework.md
+++ b/ai-adoption/ai-adoption-readiness-framework.md
@@ -1,6 +1,8 @@
 # AI Adoption Readiness Framework (AARF)
 
-> **Leadership context:** AI tooling adoption is a capability investment with a measurable ROI — and a risk surface if left ungoverned. The engineering leader's job is not to decide whether to adopt AI tools (that decision is effectively made), but to structure the rollout so that productivity gains are captured, quality does not regress, and the org does not develop a dependency on a tool no one fully understands. This framework treats adoption as a phased program with gates, not a one-time rollout.
+## Leadership Context
+
+AI tooling adoption is a capability investment with a measurable ROI — and a risk surface if left ungoverned. The engineering leader's job is not to decide whether to adopt AI tools (that decision is effectively made), but to structure the rollout so that productivity gains are captured, quality does not regress, and the org does not develop a dependency on a tool no one fully understands. This framework treats adoption as a phased program with gates, not a one-time rollout.
 
 > A practitioner's guide to rolling out AI-assisted development tools in engineering organizations — designed to accelerate leverage while preventing engineers from outsourcing judgment to the tool.
 

--- a/ci-cd/pipeline-governance-guide.md
+++ b/ci-cd/pipeline-governance-guide.md
@@ -1,6 +1,8 @@
 # CI/CD Pipeline Governance Guide
 
-> **Leadership context:** Pipeline governance is a delivery confidence problem, not a DevOps tooling problem. Without it, the org cannot answer basic questions that engineering leadership needs answered: what changed, who approved it, and could it have caused this incident? DORA metrics — the primary lens for executive-level delivery reporting — are only credible when the pipeline enforces the gates that make them meaningful.
+## Leadership Context
+
+Pipeline governance is a delivery confidence problem, not a DevOps tooling problem. Without it, the org cannot answer basic questions that engineering leadership needs answered: what changed, who approved it, and could it have caused this incident? DORA metrics — the primary lens for executive-level delivery reporting — are only credible when the pipeline enforces the gates that make them meaningful.
 
 ## Purpose
 

--- a/compliance/pci-dss-gap-analysis-checklist.md
+++ b/compliance/pci-dss-gap-analysis-checklist.md
@@ -1,6 +1,8 @@
 # PCI-DSS Gap Analysis Checklist
 
-> **Leadership context:** PCI-DSS compliance is not a legal checkbox — it is a trust prerequisite for any business that processes payments. For engineering leadership, the gap analysis is the artifact that translates compliance requirements into a prioritized engineering workplan. Arriving at a QSA assessment without having done this work first is expensive: remediation timelines measured in months, potential assessment failure, and the reputational cost of delayed card-brand certifications.
+## Leadership Context
+
+PCI-DSS compliance is not a legal checkbox — it is a trust prerequisite for any business that processes payments. For engineering leadership, the gap analysis is the artifact that translates compliance requirements into a prioritized engineering workplan. Arriving at a QSA assessment without having done this work first is expensive: remediation timelines measured in months, potential assessment failure, and the reputational cost of delayed card-brand certifications.
 
 ## Purpose
 

--- a/disaster-recovery/fire-drill-template.md
+++ b/disaster-recovery/fire-drill-template.md
@@ -1,6 +1,8 @@
 # Disaster Recovery Fire Drill Template
 
-> **Leadership context:** Untested DR plans are a liability, not an asset. Boards and enterprise customers increasingly ask for evidence of DR validation — a tabletop exercise log is the minimum viable answer. More importantly, fire drills surface the assumptions baked into recovery plans before an actual incident reveals them at cost: undocumented steps, single-person knowledge, and RTO commitments that no one has ever actually validated.
+## Leadership Context
+
+Untested DR plans are a liability, not an asset. Boards and enterprise customers increasingly ask for evidence of DR validation — a tabletop exercise log is the minimum viable answer. More importantly, fire drills surface the assumptions baked into recovery plans before an actual incident reveals them at cost: undocumented steps, single-person knowledge, and RTO commitments that no one has ever actually validated.
 
 ## Purpose
 

--- a/experimentation/launchdarkly-rollout-governance.md
+++ b/experimentation/launchdarkly-rollout-governance.md
@@ -1,6 +1,8 @@
 # LaunchDarkly Rollout Governance
 
-> **Leadership context:** Feature flags are the primary mechanism for decoupling deployment from release — which is what allows an engineering org to ship continuously without betting the business on each deploy. The governance question is not whether to use flags, but whether they remain a controlled instrument or become hidden complexity that slows delivery, obscures system behavior, and accumulates technical debt no one is willing to clean up.
+## Leadership Context
+
+Feature flags are the primary mechanism for decoupling deployment from release — which is what allows an engineering org to ship continuously without betting the business on each deploy. The governance question is not whether to use flags, but whether they remain a controlled instrument or become hidden complexity that slows delivery, obscures system behavior, and accumulates technical debt no one is willing to clean up.
 
 ## Purpose
 

--- a/incident-management/on-call-restructuring-framework.md
+++ b/incident-management/on-call-restructuring-framework.md
@@ -1,6 +1,8 @@
 # On-Call Restructuring Framework
 
-> **Leadership context:** On-call structure is a talent and delivery risk, not just an ops concern. Unsustainable rotation load drives attrition among your most experienced engineers, increases incident duration, and degrades the reliability signal that leadership depends on for investment decisions. A well-designed on-call program is an argument for trust — it demonstrates that the org can absorb failure without heroics.
+## Leadership Context
+
+On-call structure is a talent and delivery risk, not just an ops concern. Unsustainable rotation load drives attrition among your most experienced engineers, increases incident duration, and degrades the reliability signal that leadership depends on for investment decisions. A well-designed on-call program is an argument for trust — it demonstrates that the org can absorb failure without heroics.
 
 ## Problem Statement
 
@@ -66,7 +68,7 @@ The IC rotation is the role most likely to generate questions. Staff engineers a
 - [ ] Shift rotation window to midweek (Wed-Wed) to avoid weekend/holiday handoff problems
 - [ ] Run one full incident cycle before declaring the restructuring complete; adjust based on what breaks
 
-## What Does Not Work
+## Common Failure Modes
 
 **Paging the same team for everything:** It looks like a coverage guarantee but is actually a single point of failure. When the SRE team is unavailable or overwhelmed, incidents stall.
 

--- a/metrics/engineering-health-scorecard.md
+++ b/metrics/engineering-health-scorecard.md
@@ -310,3 +310,10 @@ Different metrics belong at different review cadences. Reviewing everything week
 | On-call load | PagerDuty | OpsGenie | Pages per engineer per week |
 | Cycle/lead time ratio | LinearB, Jira | Swarmia | Time in status per ticket type |
 | Attrition | HRIS (Workday, BambooHR) | HR reporting | Voluntary departure by role |
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| DORA metrics | Forsgren, Humble & Kim, *Accelerate* (IT Revolution Press, 2018) |
+| SRE observability | Google SRE Book — [Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) |

--- a/operating-cadence/cross-functional-alignment-playbook.md
+++ b/operating-cadence/cross-functional-alignment-playbook.md
@@ -287,3 +287,10 @@ Run this check quarterly, either in the engineering leadership retrospective or 
 5. **Is there any decision that engineering is currently delaying because the accountability is unclear?** Name it and assign it before leaving the room.
 
 If the answer to all five questions is "no, nothing notable," either alignment is working well or the check-in is not surfacing real information. The tie-breaker is to ask each function's leader separately whether they have any friction with engineering. If the answers differ from what engineering leadership reported, the problem is information flow, not alignment.
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| Conway's Law | Conway, "How Do Committees Invent?" *Datamation* (1968) |
+| Team structure and cross-functional alignment | Skelton & Pais, *Team Topologies* (IT Revolution Press, 2019) |

--- a/operating-cadence/engineering-okr-framework.md
+++ b/operating-cadence/engineering-okr-framework.md
@@ -209,7 +209,7 @@ At the end of each quarter, before setting next quarter's OKRs, run a 30-minute 
 
 ---
 
-## Anti-Patterns
+## Common Failure Modes
 
 ### Too Many OKRs
 
@@ -302,3 +302,10 @@ My call: [Whether I expect to be on track, at risk, or off track at quarter end,
 The OKR system only works if people believe that honest low scores will be treated as information, not as performance failures. An engineering director who responds to a 0.3 with criticism rather than curiosity will get inflated scores next quarter. The question when a KR scores low is: what does this tell us about what we planned vs. what was actually possible? That is a planning question, not a performance question — unless the pattern of low scores persists across multiple quarters with the same owner and the same explanations.
 
 Building that distinction into how you respond to scores is more important than any template in this document.
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| OKR methodology | Doerr, *Measure What Matters* (Portfolio/Penguin, 2018) |
+| OKRs in practice | Google re:Work — [Set Goals with OKRs](https://rework.withgoogle.com/guides/set-goals-with-okrs/) |

--- a/operating-cadence/engineering-rhythm-of-business.md
+++ b/operating-cadence/engineering-rhythm-of-business.md
@@ -429,3 +429,10 @@ Week 4
 **Run the cadence before adding new meetings.** Every org has too many meetings. Before adding anything from this playbook, audit what already exists. The goal is not to implement every tier at once; it is to replace whatever is broken with something that works.
 
 **Cadence debt compounds.** An org that skips the quarterly retrospective for two quarters, lets the metrics review become a status update, and stops publishing written updates will re-accumulate all the coordination failures this cadence is designed to prevent. The meetings are not the mechanism; the discipline of maintaining them is.
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| Management operating cadence | Grove, *High Output Management* (Vintage, 1995) |
+| Goal-setting and measurement | Doerr, *Measure What Matters* (Portfolio/Penguin, 2018) |

--- a/operating-cadence/escalation-framework.md
+++ b/operating-cadence/escalation-framework.md
@@ -258,3 +258,10 @@ The response that builds escalation culture: "Thank you for surfacing this early
 The response that kills escalation culture: "Why is this the first I'm hearing about this? This should have been caught earlier."
 
 Both responses may be accurate. Only one of them builds the behavior you need.
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| Difficult conversations and escalation communication | Patterson et al., *Crucial Conversations* (McGraw-Hill, 2021) |
+| Management escalation structures | Grove, *High Output Management* (Vintage, 1995) |

--- a/operating-cadence/executive-communication-templates.md
+++ b/operating-cadence/executive-communication-templates.md
@@ -338,7 +338,7 @@ additional fraud losses in Q1 while we wait."
 
 ---
 
-## Common Pitfalls
+## Common Failure Modes
 
 ### Too Much Technical Detail
 
@@ -369,3 +369,9 @@ Surface risks early, frame them constructively, and bring a mitigation plan. Tha
 Executives cannot act on information they receive after the window to act has closed. A headcount request that arrives two weeks before the hiring freeze goes up is too late. An incident summary that lands 12 hours after the incident is resolved is too late for the CEO to have context for the customer conversation they already had.
 
 The timing of upward communication matters as much as the content. When in doubt, communicate earlier and with less polish than later and perfectly formatted.
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| Structured executive communication | Minto, *The Pyramid Principle* (Pearson, 2009) |

--- a/people/career-ladder-calibration.md
+++ b/people/career-ladder-calibration.md
@@ -337,4 +337,4 @@ The check-in is not a mini-performance review. It is a calibration conversation 
 | Topic | Resource |
 |---|---|
 | Career ladders and engineering management | Fournier, *The Manager's Path* (O'Reilly, 2017) |
-| Engineering org design and leveling | Larson & Reilly, *An Elegant Puzzle* (Stripe Press, 2019) |
+| Engineering org design and leveling | Larson, *An Elegant Puzzle* (Stripe Press, 2019) |

--- a/people/career-ladder-calibration.md
+++ b/people/career-ladder-calibration.md
@@ -322,7 +322,7 @@ The check-in is not a mini-performance review. It is a calibration conversation 
 
 ---
 
-## What Does Not Work
+## Common Failure Modes
 
 **Publishing a ladder and not using it.** The ladder only has value if calibration decisions reference it explicitly. If managers are not citing level definitions during calibration, the ladder is a document, not a system.
 
@@ -331,3 +331,10 @@ The check-in is not a mini-performance review. It is a calibration conversation 
 **Skipping calibration for years.** Level drift accumulates silently. Two years without calibration produces a distribution where some teams have been promoting aggressively and others have not, and the discrepancy is invisible until someone's lateral transfer exposes it.
 
 **Using the ladder only for promotions.** The level definitions should be the anchor for growth conversations in every 1:1 at every level. If an L4 engineer cannot tell you what L5 looks like in practice, the ladder is not doing its job.
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| Career ladders and engineering management | Fournier, *The Manager's Path* (O'Reilly, 2017) |
+| Engineering org design and leveling | Larson & Reilly, *An Elegant Puzzle* (Stripe Press, 2019) |

--- a/people/headcount-capacity-planning.md
+++ b/people/headcount-capacity-planning.md
@@ -243,7 +243,7 @@ This framing answers the board's actual questions: Is this a good investment? Wh
 
 ---
 
-## What Does Not Work
+## Common Failure Modes
 
 **Headcount as a negotiating anchor.** Asking for 20 engineers expecting to get 12 trains finance to discount every request. If your model supports 12, ask for 12. If the model supports 20 and you believe it, defend 20.
 
@@ -252,3 +252,10 @@ This framing answers the board's actual questions: Is this a good investment? Wh
 **Planning for headcount without planning for onboarding.** Every new hire requires bandwidth from the existing team to ramp — code review, pairing, architecture walkthroughs. If the team is already at capacity, adding two new hires in the same month will reduce total output before it increases it.
 
 **The "we just need one more person" trap.** When a team is struggling to deliver, the instinct is to add headcount. The more likely cause is scope that is not properly bounded, technical debt that is consuming untracked time, or unclear priorities. Headcount does not fix unclear priorities — it amplifies them. Diagnose before you hire.
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| Staffing philosophy | Marquet, *Turn the Ship Around!* (Portfolio/Penguin, 2013) |
+| Capacity and leverage framing | Grove, *High Output Management* (Vintage, 1995) |

--- a/program-management/change-management-framework.md
+++ b/program-management/change-management-framework.md
@@ -272,3 +272,10 @@ This single-question survey takes 10 seconds to answer, produces actionable sign
 **The support that does not get delivered.** The change plan committed to office hours, champions, and training. The office hours had low attendance after week 2, so they were cancelled. The champions program was never actually resourced. The training was a one-time session that is no longer discoverable. Support commitments that are not delivered signal that the commitment was performative — and erode trust in the next change process.
 
 **Measuring the wrong thing.** Tracking completion ("the migration is 80% done") instead of adoption ("80% of teams are operating in the new state"). A migration that is technically 80% complete but has 30% adoption is failing in the metric that matters. Adoption is the outcome; completion is a leading indicator.
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| Change management methodology | Kotter, *Leading Change* (Harvard Business Review Press, 1996) |
+| Individual change adoption (ADKAR) | Prosci ADKAR Model (Prosci, 2006) |

--- a/program-management/launch-readiness-checklist.md
+++ b/program-management/launch-readiness-checklist.md
@@ -287,3 +287,10 @@ Attendees: full domain owner group. 60 minutes.
 **Operations readiness treated as post-launch work.** "We'll add proper monitoring after we see how it behaves in production." This is not a plan — it is an intention to operate blind and learn from failures rather than from metrics. Monitoring and alerting are launch requirements, not follow-on items.
 
 **The readiness gate that is really a status broadcast.** Domain owners show up, report green across all domains, and the meeting ends in 10 minutes. No one asked hard questions. The gate is serving as a ceremony, not as a real control. A well-run gate asks: what could still go wrong, who would know first, and what would we do about it? If the answer to all three is clear, the gate is doing its job.
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| Release readiness and continuous delivery | Humble & Farley, *Continuous Delivery* (Addison-Wesley, 2010) |
+| Release engineering practices | Google SRE Book — [Release Engineering](https://sre.google/sre-book/release-engineering/) |

--- a/program-management/program-planning-playbook.md
+++ b/program-management/program-planning-playbook.md
@@ -273,3 +273,9 @@ Categories:
 **Milestone date anchoring.** Dates set in the program brief based on a desired outcome, not on a bottoms-up estimate from the teams doing the work. The earliest symptom is that no team can explain how the milestone date was derived. The fix is to build the milestone schedule from team-level estimates, then have the conversation about the gap between what teams can realistically deliver and what leadership wants — not paper over it.
 
 **The program that is really three projects.** Three separate efforts packaged under a shared banner for executive visibility, but without genuine interdependencies or shared outcomes. These do not benefit from program-level coordination — they benefit from three separate project plans and a shared reporting roll-up. Running them as a program adds overhead without adding value. Dissolve these when you identify them.
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| Program planning methodology | PMI, *A Guide to the Project Management Body of Knowledge (PMBOK Guide)*, 7th ed. (PMI, 2021) |

--- a/program-management/raid-dependency-tracking.md
+++ b/program-management/raid-dependency-tracking.md
@@ -235,3 +235,10 @@ For programs with 5+ workstreams, the RAID log becomes unwieldy if all items are
 **Separate vendor/external dependencies.** External dependencies have different management paths — you cannot directly resolve them. Create a dedicated section or tab for vendor and third-party dependencies and manage them through a relationship owner rather than the standard workstream lead path.
 
 **Link to source systems.** Where a risk or issue has a corresponding Jira ticket, engineering incident, or legal review document, link directly from the RAID log entry. This reduces the double-maintenance burden and makes it easier for leads to update status where they are already working.
+
+## Further Reading
+
+| Topic | Resource |
+|---|---|
+| RAID management methodology | PMI, *PMBOK Guide*, 7th ed. (PMI, 2021) |
+| Risk and team dynamics | DeMarco & Lister, *Peopleware* (Dorset House, 1987) |

--- a/program-management/stakeholder-communication-templates.md
+++ b/program-management/stakeholder-communication-templates.md
@@ -124,65 +124,7 @@ A weekly status report that consistently contains no risks, no asks, and only mi
 
 ## Escalation Memo
 
-The weekly status report covers normal program operations. The escalation memo is for situations where the weekly cadence is not fast enough — where a decision is needed before next week's update.
-
-Use the escalation memo when:
-- A milestone will slip unless a decision is made in the next 48–72 hours
-- A blocker has appeared that the program team cannot resolve without executive action
-- A risk has materialized into an issue that materially changes the program outlook
-
-### Format
-
-**Subject:** `[ESCALATION] [Program Name] — [One-sentence description of the issue]`
-
----
-
-**Situation**
-
-*[2–3 sentences. What happened? When did it happen? What is the current state?]*
-
-The compliance vendor (Acme Compliance) has notified us that they cannot complete the pen test before May 15 — two weeks later than the May 1 audit-readiness milestone requires. We learned this on April 9. This puts the SOC 2 Type II audit timeline at risk.
-
----
-
-**Timeline**
-
-- **April 9:** Received vendor notification of capacity constraint
-- **May 1:** Current audit-readiness milestone (pen test completion required)
-- **May 15:** Earliest vendor availability
-- **June 1:** SOC 2 audit window opens — this is the hard external deadline
-
----
-
-**Options**
-
-*[2–3 options, each with the key tradeoff stated in one sentence. Do not advocate in this section — present objectively.]*
-
-**Option A — Use alternative vendor (Beta Security):** Beta Security can complete the pen test by April 28. Beta Security has not tested our stack before, which means a 1-week onboarding period is required and the scope may differ from the original. Cost: $45K (vs. $30K with Acme). Deadline maintained.
-
-**Option B — Reduce pen test scope:** Acme can complete a scoped test (payments and auth systems only, excluding admin tooling) by May 1. This means admin tooling is excluded from the SOC 2 audit scope, which requires legal confirmation that this scope is acceptable. Timeline maintained; scope risk.
-
-**Option C — Accept the delay:** Proceed with Acme on their May 15 timeline and assess whether the June 1 audit window can be adjusted with the audit firm. This requires outreach to the audit firm immediately to determine flexibility. Risk: if the audit window is fixed, we miss it.
-
----
-
-**Recommendation**
-
-*[One paragraph. State which option you recommend and why. Be direct. You are the person with context; make the call and let the exec confirm or override.]*
-
-Recommend Option A. The $15K cost delta is modest relative to the cost of an audit timeline slip. Beta Security's onboarding period is manageable — Priya will schedule a scope kickoff call the week of April 12. The alternative vendor risk is lower than either scope reduction or timeline delay.
-
----
-
-**Decision Needed By**
-
-April 11, 5pm. We need to execute a contract with Beta Security by April 12 to start onboarding on April 13. A decision after April 11 makes Option A unavailable without schedule impact.
-
----
-
-**Contact**
-
-Priya Agarwal (Security Lead), Marcus Webb (Program Lead). Available by Slack or phone for questions before April 11.
+Use the canonical escalation memo format defined in the [Escalation Framework](../operating-cadence/escalation-framework.md). That document covers trigger criteria, severity levels, and the full 5-field memo template (Situation / Impact / Options / Recommendation / By when).
 
 ---
 
@@ -270,7 +212,7 @@ Marcus Webb, Sarah Chen
 
 ---
 
-## Common Pitfalls
+## Common Failure Modes
 
 **Status updates that read as activity reports.** "This week the team completed X, Y, and Z" with no evaluation of whether that is good, bad, or concerning. The reader cannot tell if the program is healthy. Every update needs an explicit status judgment, not just a list of completed work.
 

--- a/strategy/ma-technical-due-diligence.md
+++ b/strategy/ma-technical-due-diligence.md
@@ -435,7 +435,7 @@ The risk register should be reviewed at 30, 60, and 90 days post-close in integr
 
 ---
 
-## What Does Not Work
+## Common Failure Modes
 
 **Architecture-only diligence.** The most common failure is a technical diligence that spends 80% of its time on system architecture and 20% on everything else. Architecture is important, but it is also the easiest domain to assess and the easiest for a prepared target company to present well. Key-person risk, licensing obligations, and operational maturity are harder to assess and harder to fake.
 


### PR DESCRIPTION
## Summary

- Converts Leadership context blockquotes to `## Leadership Context` H2 sections in the 6 existing playbooks, matching the format used by all 17 new playbooks
- Consolidates duplicate escalation memo templates: stakeholder-communication-templates.md now cross-references escalation-framework.md as the canonical source
- Standardizes closing-section headings to `## Common Failure Modes` across all new playbooks
- Adds `## Further Reading` with 1–3 primary-source citations to the 12 new playbooks that were missing them

## Test plan

- [ ] All modified files render valid markdown (no unclosed fences, no broken relative links)
- [ ] All 6 existing playbooks now open with `## Leadership Context` as an H2
- [ ] No remaining `## Common Pitfalls`, `## What Does Not Work`, or `## Anti-Patterns` H2 headings in any playbook
- [ ] `program-management/stakeholder-communication-templates.md` escalation section cross-references rather than redefines the template

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsFV6wiynxsWJZgRStRbdx)_