### PR TITLE
Migrate leadership-playbooks content and finalize tech-leadership-playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Engineering Playbooks
+# Tech Leadership Playbooks
 
 Operational and leadership frameworks from production engineering work across payments, platform, and compliance contexts. Each document reflects decisions made in real systems, not hypothetical best practices. Organized by the leadership domain each framework addresses.
 
@@ -106,6 +106,18 @@ Engineering-focused checklist for a PCI-DSS v4.0 gap analysis. Organized by all 
 
 **[ai-adoption/ai-adoption-readiness-framework.md](ai-adoption/ai-adoption-readiness-framework.md)**
 Framework for rolling out AI-assisted development tools (GitHub Copilot, Claude, Claude Code, Cursor) across engineering organizations. Covers a four-stage IC fluency rubric, role-differentiated use cases (IC vs. manager), task classification by risk level, a three-tier observability model, and a phased gate model that sequences access to higher-risk workflows on demonstrated readiness. Developed across two production rollouts (ActBlue 2024–2025, CTA 2025–2026). Includes a worked example and rollback triggers.
+
+---
+
+## Product & Documentation
+
+Frameworks for product definition and AI-assisted documentation standards.
+
+**[leadership/ai-documentation-standards.md](leadership/ai-documentation-standards.md)**
+Auditability and verifiability standards for AI-generated architectural documentation, ADRs, design docs, and playbooks. Covers attribution requirements, verification obligations, confidence labeling, and the review process for AI-assisted content. Applicable to any project using Claude Code or another AI assistant as a contributor.
+
+**[leadership/prd-lifecycle.md](leadership/prd-lifecycle.md)** *(in progress)*
+One living PRD per product, two-tier update process, and changelog requirements. Applies the continuous discovery model — the PRD tracks evolving product understanding rather than locking scope at a point in time.
 
 ---
 

--- a/leadership/ai-documentation-standards.md
+++ b/leadership/ai-documentation-standards.md
@@ -1,0 +1,118 @@
+# AI-Assisted Documentation Standards
+
+**Scope:** How to ensure AI-generated documentation is auditable, verifiable, and trustworthy
+**Applies to:** Any project where Claude Code or another AI assistant contributes to architectural
+documentation, design documents, ADRs, playbooks, or technical recommendations
+
+---
+
+## Core Principle: AI Recommendations Must Be Sourced
+
+When an AI assistant produces documentation that names a technology, pattern, protocol, or
+compliance framework as a recommendation, that recommendation must be traceable to a primary
+source. Unsourced AI output is unverifiable — a reader cannot distinguish a well-grounded
+recommendation from a confident-sounding hallucination.
+
+This is not primarily a hallucination-prevention rule. It is an intellectual integrity rule:
+the same standard that applies to a staff engineer writing a design document applies to
+AI-generated output that carries the same weight.
+
+---
+
+## What Must Be Cited
+
+### Technology and framework choices
+Link to the official documentation for every tool selected. The official docs are the
+authoritative source for capability claims, configuration, and limitations.
+
+**Examples:**
+- Choosing NestJS → link to [docs.nestjs.com](https://docs.nestjs.com)
+- Choosing Prisma → link to [prisma.io/docs](https://www.prisma.io/docs/getting-started)
+- Choosing Turborepo → link to [turbo.build/repo/docs](https://turbo.build/repo/docs)
+
+### Protocol and specification choices
+Link to the normative specification for every protocol or standard referenced.
+
+**Examples:**
+- OAuth 2.0 → [RFC 6749](https://datatracker.ietf.org/doc/html/rfc6749)
+- PKCE → [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636)
+- GraphQL → [spec.graphql.org](https://spec.graphql.org/October2021/)
+- OIDC → [openid.net/specs/openid-connect-core-1_0.html](https://openid.net/specs/openid-connect-core-1_0.html)
+
+### Architectural patterns
+Link to the original paper, article, or book chapter that introduced or best defines the
+pattern. Do not cite secondary summaries or Wikipedia.
+
+**Examples:**
+- Hexagonal Architecture → [Cockburn (2005)](https://alistair.cockburn.us/hexagonal-architecture/)
+- Clean Architecture / Dependency Rule → [Uncle Bob (2012)](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
+- Dependency Injection → [Fowler (2004)](https://martinfowler.com/articles/injection.html)
+
+### Compliance and regulatory references
+Link to the primary regulatory or standards body source. Do not cite compliance vendor
+summaries or blog posts as the authoritative source.
+
+**Examples:**
+- GDPR Article 17 → [gdpr-info.eu/art-17-gdpr](https://gdpr-info.eu/art-17-gdpr/)
+- HIPAA Security Rule → [hhs.gov/hipaa/for-professionals/security](https://www.hhs.gov/hipaa/for-professionals/security/index.html)
+
+---
+
+## Where Citations Go
+
+### In ADRs
+A `## References` section at the bottom of every ADR. Each entry: a linked title, and
+one sentence describing what decision in the ADR it supports.
+
+```markdown
+## References
+
+- [RFC 6749 — OAuth 2.0](https://datatracker.ietf.org/doc/html/rfc6749) — The authorisation
+  code flow used by Clerk and Auth0; defines the token exchange this ADR relies on.
+- [Clerk — Documentation](https://clerk.com/docs) — Official docs for the primary identity
+  provider chosen in the Decision section.
+```
+
+### In playbooks
+A `## References` section at the bottom of any playbook that cites a specific framework,
+methodology, or standard. Playbooks that contain only internal process guidance with no
+external dependencies do not require citations.
+
+### In AI responses
+When Claude recommends a technology in a response (not only in committed documentation),
+it should include the official documentation link inline. This makes the recommendation
+immediately verifiable without requiring a follow-up search.
+
+---
+
+## What Does Not Require a Citation
+
+- Internal cross-references to other ADRs, issues, or PRs in the same project
+- Decisions that are entirely internal (e.g., a naming convention with no external basis)
+- Widely understood facts that do not assert specific capability claims
+
+---
+
+## Consolidated Reference Index
+
+For projects with multiple ADRs, maintain a consolidated reference index (e.g.,
+`docs/adr-references.md`) that groups all sources by domain. This serves as:
+- A single place to audit coverage ("are all our technology choices sourced?")
+- A reading list for new contributors onboarding to the architecture
+- A starting point for due-diligence reviews (security, ARB, compliance audits)
+
+Update the index whenever an ADR's references change.
+
+---
+
+## Enforcing This Standard in Prompts
+
+When opening a session in which documentation will be written or updated, include this in
+the opening brief:
+
+> All ADRs and design documents produced this session must include a ## References section
+> with links to primary sources for every technology, pattern, and specification cited.
+> See docs/adr-references.md for the established pattern.
+
+For projects using CLAUDE.md, encode this as a standing instruction in the
+**Documentation and Citations** section so it applies automatically every session.

--- a/leadership/ai-documentation-standards.md
+++ b/leadership/ai-documentation-standards.md
@@ -53,7 +53,7 @@ Link to the primary regulatory or standards body source. Do not cite compliance 
 summaries or blog posts as the authoritative source.
 
 **Examples:**
-- GDPR Article 17 → [gdpr-info.eu/art-17-gdpr](https://gdpr-info.eu/art-17-gdpr/)
+- GDPR Article 17 → [EUR-Lex — GDPR (Regulation 2016/679), Article 17](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679)
 - HIPAA Security Rule → [hhs.gov/hipaa/for-professionals/security](https://www.hhs.gov/hipaa/for-professionals/security/index.html)
 
 ---

--- a/leadership/prd-lifecycle.md
+++ b/leadership/prd-lifecycle.md
@@ -1,3 +1,4 @@
+# PRD Lifecycle Management
 
 ---
 

--- a/leadership/prd-lifecycle.md
+++ b/leadership/prd-lifecycle.md
@@ -1,0 +1,8 @@
+
+---
+
+## References
+
+- [Clayton Christensen, Taddy Hall, Karen Dillon, and David Duncan — "Know Your Customers' 'Jobs to Be Done'" (*Harvard Business Review*, September 2016)](https://hbr.org/2016/09/know-your-customers-jobs-to-be-done) — The canonical HBR treatment of the Jobs to Be Done framework. Establishes that customers hire products to accomplish specific outcomes, not to consume features. The job-outcome table format in §2 (job + "success looks like") is a direct application.
+- [Alan Cooper — *The Inmates Are Running the Asylum* (Sams, 1998)](https://www.amazon.com/Inmates-Are-Running-Asylum-Products/dp/0672326140) — Origin of Goal-Directed Design and user personas as a product design tool. The guidance to keep personas to two or three reflects Cooper's observation that more personas typically indicate unclear product scope rather than genuine user diversity.
+- [Marty Cagan — *Inspired: How to Create Tech Products Customers Love*, 2nd ed. (Wiley, 2018)](https://www.svpg.com/books/inspired-how-to-create-tech-products-customers-love-2nd-edition/) — Establishes continuous discovery and outcome-oriented product thinking. The "one living PRD" design and the rejection of per-version document freezes aligns with Cagan's product-team model, where the document tracks evolving product understanding rather than locking scope.


### PR DESCRIPTION
## Summary

- Migrates `prd-lifecycle.md` and `ai-documentation-standards.md` from `brownm09/leadership-playbooks` into a new `leadership/` directory
- Adds a **Product & Documentation** section to the README covering both files
- Updates the README title from "Engineering Playbooks" → "Tech Leadership Playbooks"

## Context

Part of consolidating `engineering-playbooks` and `leadership-playbooks` into a single cohesive portfolio piece. The rename from `engineering-playbooks` → `tech-leadership-playbooks` was done via GitHub repo settings (GitHub auto-redirects old URLs). The bulk of the leadership-layer content (org-design, people, program-management, strategy, metrics, operating-cadence) was already on `master` via PR #3 and #5. This PR brings in the two remaining files from the `leadership-playbooks` repo.

After this merges, `leadership-playbooks` will be archived.

## Test plan

- [ ] Verify `leadership/` directory is present with both files on the merged branch
- [ ] Verify README title reads "Tech Leadership Playbooks"
- [ ] Verify Product & Documentation section appears in README with correct relative links
- [ ] Confirm `https://github.com/brownm09/engineering-playbooks` redirects to the new repo

Closes #6