### PR TITLE
Draft PRD Lifecycle Management body

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Frameworks for product definition and AI-assisted documentation standards.
 **[leadership/ai-documentation-standards.md](leadership/ai-documentation-standards.md)**
 Auditability and verifiability standards for AI-generated architectural documentation, ADRs, design docs, and playbooks. Covers attribution requirements, verification obligations, confidence labeling, and the review process for AI-assisted content. Applicable to any project using Claude Code or another AI assistant as a contributor.
 
-**[leadership/prd-lifecycle.md](leadership/prd-lifecycle.md)** *(in progress)*
-One living PRD per product, two-tier update process, and changelog requirements. Applies the continuous discovery model — the PRD tracks evolving product understanding rather than locking scope at a point in time.
+**[leadership/prd-lifecycle.md](leadership/prd-lifecycle.md)**
+One living PRD per product. Covers PRD structure (job-outcome table, personas, hypothesis and bets, append-only changelog), two-tier update process (minor vs. major changes), lifecycle stages with gates (Discovery → Alignment → Delivery → Shipped), ownership model, and common failure modes including the frozen PRD, PRD-as-contract, and solution PRD anti-patterns.
 
 ---
 

--- a/leadership/prd-lifecycle.md
+++ b/leadership/prd-lifecycle.md
@@ -1,5 +1,156 @@
 # PRD Lifecycle Management
 
+> **Leadership context:** The PRD is the most abused document in product engineering. It gets frozen at kick-off, accumulates stale assumptions, and becomes something engineers route around rather than reference. The engineering leader's job is not to own the PRD — that's the PM's job — but to set the standard for how it evolves, enforce its use as a working document, and make sure the team is building against current understanding, not the snapshot from last quarter's planning session.
+
+## Purpose
+
+This playbook defines how a PRD is structured, how it evolves over the life of a product, and what "done" means at each stage. It applies the continuous discovery model: the PRD tracks evolving product understanding rather than locking scope. One living PRD per product; version history is in git, not in a frozen "v1.3 Final (2)" document.
+
+---
+
+## The One Living PRD Principle
+
+The most common PRD failure mode is treating it as a contract. You write it during discovery, lock it at kick-off, and then run a separate change-control process for every deviation. This produces:
+- Engineers building against stale requirements because updating the PRD is bureaucratic
+- PMs maintaining two sources of truth (the PRD and the Jira description where the real decisions happen)
+- Post-mortems where "we built what the PRD said" is treated as an absolution
+
+The one living PRD model inverts this. The document always reflects current intent. The history is in version control. The changelog (see below) is how you communicate what changed and why — not a separate document, a section of the same one.
+
+**The test:** Any engineer joining the team mid-project should be able to read the PRD and get accurate context about what is being built, why, and for whom. If that isn't true, the document has drifted.
+
+---
+
+## PRD Structure
+
+Every PRD has five required sections. Sections 1–3 are set during discovery and rarely change. Sections 4–5 evolve continuously.
+
+### Section 1 — Problem Statement
+
+One paragraph. What is the user unable to do, or doing poorly, because this product does not exist? Written as a job-to-be-done: *"When [situation], users want to [goal], but [obstacle] prevents them. The cost of this is [outcome]."*
+
+Avoid solution language in this section. "Users need a dashboard" is not a problem statement.
+
+### Section 2 — User Job and Outcome Table
+
+| User type | Job to be done | Success looks like | Current workaround |
+|-----------|----------------|-------------------|-------------------|
+| (e.g.) Product manager | Monitor experiment results across multiple flag variants without switching tools | One view, no manual aggregation, results available within 24h of flag creation | Exporting from LaunchDarkly, joining in a spreadsheet |
+
+Fill one row per distinct user type with a meaningfully different job. Two or three rows is normal. More than four typically indicates unclear product scope, not genuine user diversity.
+
+### Section 3 — Personas
+
+Two or three personas, maximum. Each persona is a named, specific person — not a demographic. Use Cooper's persona format: a name, a role, one sentence on what they're trying to accomplish in their work, and one sentence on where this product fits in their day.
+
+Personas are not market segments. A persona is "Maria, a senior PM who runs 8–10 concurrent experiments and needs to brief the CPO weekly on business impact." Not "data-driven PMs at mid-market SaaS companies."
+
+### Section 4 — Hypothesis and Bets
+
+The specific bets this product makes. Written as falsifiable hypotheses: *"We believe [action] will produce [outcome] for [persona]. We will know this worked when [metric] moves by [amount] within [timeframe]."*
+
+This section is updated when bets change. If a bet is invalidated by discovery or user research, it is not deleted — it is struck through with a one-line explanation and a changelog entry (see Section 5).
+
+### Section 5 — Changelog
+
+Append-only log of substantive changes to this document. Format:
+
+```
+## Changelog
+
+### 2026-03-15 — Scope reduction: dropped async notifications
+**What changed:** Removed async email notification feature from v1 scope.
+**Why:** User interviews (n=8) showed in-app visibility was sufficient for the primary persona. Async adds two weeks; the bet doesn't require it.
+**Impact:** Engineers on notification service unblocked for other work. Revisit in v2 if retention data shows re-engagement gap.
+
+### 2026-02-28 — Hypothesis updated: engagement metric changed
+**What changed:** Success metric changed from DAU to experiment-start rate.
+**Why:** DAU is affected by marketing campaigns we don't control. Experiment-start rate isolates product value.
+**Impact:** None to scope; affects how the data team instruments the event.
+```
+
+---
+
+## Two-Tier Update Process
+
+Not all changes to the PRD are equal. Use two tiers to reduce change-control friction for minor updates while keeping major changes visible.
+
+### Tier 1 — Minor (update and log, no approval required)
+
+- Clarifications that don't change scope or success criteria
+- Updated metrics or targets based on baseline data
+- Persona refinements from user interviews
+- Removing features deferred to a later version (log the reason)
+- Copy edits and format fixes
+
+**Process:** Edit the document, add a changelog entry, notify the team in the project Slack channel.
+
+### Tier 2 — Major (requires PM + EM alignment before update)
+
+- Changes to the core problem statement
+- Adding new user types with distinct jobs
+- Changing a success metric after development has begun
+- Scope additions that affect timeline or team allocation
+- Invalidating a hypothesis (the bet was wrong)
+
+**Process:** PM and EM discuss async or sync (depending on urgency), align on the change and its rationale, then update the document together. Add a changelog entry. If the change affects delivery commitments, communicate upstream before updating the document.
+
+---
+
+## Lifecycle Stages
+
+The PRD exists across four stages. What's expected in each:
+
+### Discovery
+
+The PRD is a working hypothesis. Sections 1–3 are drafts. Section 4 has at least one hypothesis. Section 5 is empty.
+
+**Gate to Alignment:** Problem statement is crisp, job-outcome table has ≥1 validated row, at least one persona has been confirmed with a real user, and the PM can articulate the primary bet in one sentence.
+
+### Alignment
+
+The PRD is being reviewed and socialized. Engineering is scoping, design is exploring. The document is updated frequently as assumptions surface.
+
+**Gate to Delivery:** PM and EM have signed off on Section 4. Engineering has estimated. Dependencies are identified. No open "TBD" in Sections 1–3.
+
+### Delivery
+
+The PRD is a reference document. Minor updates are expected as implementation surfaces edge cases. Major changes require Tier 2 process.
+
+**In-flight discipline:** If an engineer can't reconcile a decision with the PRD, that's a signal the PRD is wrong — update it, don't paper over it in the code.
+
+**Gate to Shipped:** Feature is in production, instrumentation is live, the team can observe the success metrics in Section 4.
+
+### Shipped
+
+The PRD is archived (read-only). The outcomes are documented in a brief post-ship retrospective appended to the changelog: what the metrics showed, whether the bets were validated, and what was learned.
+
+---
+
+## Ownership and Collaboration
+
+**PM owns the PRD.** The PM is the author, the final decision-maker on content, and the person responsible for keeping it current.
+
+**EM is the accountability partner.** The EM's job is to flag when the document has drifted from reality, push back on hypotheses that aren't falsifiable, and ensure engineers can reference the PRD to resolve implementation ambiguity.
+
+**Engineers read and flag.** Any engineer who can't reconcile a decision with the PRD should flag it to the PM within one working day — not route around it.
+
+**Design owns the persona depth.** Design research should feed Sections 2 and 3. If personas are being written without user contact, that's a process gap to fix, not a PRD problem.
+
+---
+
+## Common Failure Modes
+
+**The frozen PRD.** The document is correct at kick-off and stale six weeks later. Engineers stop consulting it. Fix: make PRD review a standing agenda item in the weekly team sync — five minutes to ask "is this still accurate?"
+
+**The PRD-as-contract.** The PM treats deviation from the PRD as a process violation. Engineers treat "it's in the PRD" as a reason not to raise concerns. Fix: Tier 2 process should take hours, not days. The cost of a slow change process is undocumented drift.
+
+**The solution PRD.** The document describes what will be built, not why. Section 1 says "Build a real-time dashboard" instead of describing the user's problem. Fix: ban solution language from Sections 1–3. If the problem statement could have been written after the solution was decided, it was.
+
+**The thousand-page PRD.** The document grows to cover every edge case and specification, duplicating what should live in design files and tickets. Fix: the PRD answers why and for whom. It does not answer how. Technical specs, API contracts, and edge case handling live in linked documents.
+
+**The invisible changelog.** Changes happen but aren't logged. Two months in, no one remembers why the scope changed. Fix: make the changelog append-only and treat entries the same way you treat commit messages — they're permanent, they explain reasoning, and they're written for someone who wasn't in the room.
+
 ---
 
 ## References

--- a/leadership/prd-lifecycle.md
+++ b/leadership/prd-lifecycle.md
@@ -80,10 +80,10 @@ Not all changes to the PRD are equal. Use two tiers to reduce change-control fri
 - Clarifications that don't change scope or success criteria
 - Updated metrics or targets based on baseline data
 - Persona refinements from user interviews
-- Removing features deferred to a later version (log the reason)
+- Removing features deferred to a later version (log the reason; if the cut affects team allocation or delivery commitments, use Tier 2 instead)
 - Copy edits and format fixes
 
-**Process:** Edit the document, add a changelog entry, notify the team in the project Slack channel.
+**Process:** Edit the document, add a changelog entry, notify the team in the project communication channel.
 
 ### Tier 2 — Major (requires PM + EM alignment before update)
 


### PR DESCRIPTION
## Summary

Drafts the full body for `leadership/prd-lifecycle.md`, which previously contained only a title and References section.

**Content added:**
- Leadership context callout
- The One Living PRD Principle (why frozen PRDs fail)
- Five-section PRD structure: problem statement, job-outcome table, personas, hypothesis and bets, changelog
- Two-tier update process (Tier 1 minor / Tier 2 major with process for each)
- Four lifecycle stages with explicit gates: Discovery → Alignment → Delivery → Shipped
- Ownership and collaboration model (PM owns, EM is accountability partner)
- Five common failure modes: frozen PRD, PRD-as-contract, solution PRD, thousand-page PRD, invisible changelog

**README:** Removes `*(in progress)*` marker, expands description to reflect full content.

## Test plan

- [ ] Read `leadership/prd-lifecycle.md` — verify five sections, two-tier process, lifecycle stages, and failure modes are present
- [ ] Verify README description matches document content and has no *(in progress)* marker
- [ ] Verify References section is intact and unchanged

Closes #8