### PR TITLE
Add work history provenance to all playbooks

### DIFF
--- a/ORIGINS.md
+++ b/ORIGINS.md
@@ -1,0 +1,91 @@
+# Origins — Where These Frameworks Come From
+
+Every framework in this repo was developed from real work, not synthesized from best practices. This document traces each playbook back to the specific engagement, problem, and outcome that produced it, and provides first-person framing that grounds each framework as lived experience.
+
+**Columns:**
+- **Engagement** — employer and timeframe
+- **Origin** — the specific problem or program that produced the framework
+- **Outcome** — measurable result where available
+- **In my own words** — safe first-person framing for how to describe this work
+
+---
+
+## Org Design & Strategy
+
+| Framework | Engagement | Origin | Outcome | In my own words |
+|---|---|---|---|---|
+| [Team Topology Framework](org-design/team-topology-framework.md) | ActBlue Technical Services (2022–2024) | Chartering DevEx, Payments Architecture, and Database Platform teams to address ownership gaps | Eliminated cross-team dependency bottlenecks; established domain ownership | "I identified the ownership gaps, defined team scope, built hiring processes with recruiting, made the hiring decisions, and onboarded the teams." |
+| [Engineering Health Scorecard](metrics/engineering-health-scorecard.md) | ActBlue Technical Services (2024–2025) | Jellyfish rollout and org-wide engineering health reporting for a 6-team platform directorate | Org-wide adoption; managers and ICs trained on delivery metrics framework | "I led the rollout, owned engineering health reporting, and trained managers and ICs on the metrics framework." |
+| [Technical Strategy Template](strategy/technical-strategy-template.md) | ActBlue Technical Services (2024–2025) → Community Tech Alliance (2025–2026) | Multi-year platform directorate technical vision (ActBlue); 12-month technical investment roadmap (CTA) | Set direction for 6-team directorate; at CTA, prioritized DR posture and dependency management | "I developed the vision and presented roadmaps to the VP of Engineering and Head of Product. At CTA I designed and wrote the roadmap entirely." |
+| [Build vs. Buy Framework](strategy/build-vs-buy-framework.md) | ActBlue Technical Services (2022–2025) | Heroku→Kubernetes on AWS migration decision; payment processor migration to Stripe | $64K/year infrastructure savings (K8s); 2,600+ accounts migrated; 7,000+ lines of code removed (Stripe) | "I identified the priority, built the business case, and cleared the organizational path for both programs." |
+| [M&A Technical Due Diligence Framework](strategy/ma-technical-due-diligence.md) | ActBlue Technical Services (2022–2025) | Synthesized from PCI environment deprecation, multi-regional infrastructure, monolith decomposition, and DR validation | N/A — framework synthesized from cross-domain platform and compliance experience | "This framework synthesizes the diligence posture developed across multi-year platform, compliance, and DR programs in regulated environments." |
+
+---
+
+## People Systems
+
+| Framework | Engagement | Origin | Outcome | In my own words |
+|---|---|---|---|---|
+| [Career Ladder and Calibration Playbook](people/career-ladder-calibration.md) | ActBlue Technical Services (2022–2025) | Three IC promotions in three years; Engineering Management Community of Practice | Two SE2→SSE2 double promotions; one SSE→SSE2 promotion; CoP systematized talent development | "I drove three promotions within three years through deliberate project placement, calibration preparation, and sustained advocacy. Two were double promotions from SE2 to SSE2." |
+| [Headcount and Capacity Planning Playbook](people/headcount-capacity-planning.md) | ActBlue Technical Services (2024–2025) | HC modeling for a multi-year 6-team platform directorate | HC sequenced against roadmap; finance alignment achieved across two planning cycles | "I developed the platform directorate technical vision and translated it into headcount requirements across 6 teams, presenting to the VP of Engineering and Head of Product." |
+
+---
+
+## Operating Cadence
+
+| Framework | Engagement | Origin | Outcome | In my own words |
+|---|---|---|---|---|
+| [Engineering Rhythm of Business](operating-cadence/engineering-rhythm-of-business.md) | ActBlue Technical Services (2024–2025) | Operating cadence design for ~50 engineers across 6 teams | Sustained delivery rhythm across the directorate; structured weekly/monthly/quarterly decision cadence | "I set and ran the operating cadence for the platform directorate as Senior Engineering Manager." |
+| [Engineering OKR Framework](operating-cadence/engineering-okr-framework.md) | ActBlue Technical Services (2024–2025) | OKR setting and cascading for the multi-year platform directorate | Aligned 2024–2025 initiatives across 6 teams; cascaded from company objectives to team-level work | "I developed the multi-year platform directorate technical vision and translated it into objectives aligned across the directorate." |
+| [Executive Communication Templates](operating-cadence/executive-communication-templates.md) | ActBlue Technical Services (2022–2025) | Presenting roadmaps to VP Eng and Head of Product; PCI deprecation business cases to Legal, Finance, and Product leadership | Executive alignment maintained across multi-year programs; headcount and investment approved | "I presented roadmap and business case to Legal, Finance, and Product leadership for a multi-year, cross-team program." |
+| [Cross-Functional Alignment Playbook](operating-cadence/cross-functional-alignment-playbook.md) | ActBlue Technical Services (2022–2025) | PCI environment deprecation coordination across product, compliance, legal, finance, and account operations | Full deprecation; 2,600+ accounts migrated; alignment held across 4–5 teams and external audit deadlines | "I owned the program — the vision, the business case, the executive alignment, and the cross-team coordination." |
+| [Escalation Framework](operating-cadence/escalation-framework.md) | ActBlue Technical Services (2022–2025) | Escalation patterns from PCI deprecation and Heroku→K8s cross-functional programs | On-track delivery against compliance deadlines; executive visibility maintained | "The trigger categories and levels here reflect what actually kept multi-year programs on track under compliance pressure." |
+
+---
+
+## Program Management
+
+| Framework | Engagement | Origin | Outcome | In my own words |
+|---|---|---|---|---|
+| [Program Planning Playbook](program-management/program-planning-playbook.md) | ActBlue Technical Services (2022–2025) | PCI environment deprecation — multi-year program owned from vision through full completion | Full deprecation; 30% codebase reduction; 2,600+ accounts migrated | "I owned the program — the vision, the business case, the executive alignment, and the cross-team coordination. Engineering execution was distributed across my teams." |
+| [RAID Log and Dependency Tracking](program-management/raid-dependency-tracking.md) | ActBlue Technical Services (2022–2025) | PCI deprecation and payment processor migration cross-team dependency tracking | 4–5 engineering teams coordinated against compliance and internal milestones | "I owned the cross-team coordination for programs running across 4–5 teams with compliance deadlines, finance dependencies, and vendor relationships in play simultaneously." |
+| [Launch Readiness Checklist](program-management/launch-readiness-checklist.md) | ActBlue Technical Services (2022–2025) | Payment processor migration to Stripe launch readiness; monolith decomposition service releases | 2,600+ accounts migrated; payments codebase shrunk by 7,000+ lines | "I led the program and defined scope and sequencing. My team executed the migration." |
+| [Stakeholder Communication Templates](program-management/stakeholder-communication-templates.md) | ActBlue Technical Services (2022–2025) | PCI deprecation communications to Legal, Finance, Product, and Account Ops | Executive alignment maintained across full multi-year program lifecycle | "I presented roadmap and business case to Legal, Finance, and Product leadership across a multi-year program running against external audit deadlines." |
+| [Change Management Framework](program-management/change-management-framework.md) | Raytheon / NASA EED/2 (2018–2019) → ActBlue Technical Services (2022–2024) | Waterfall→Kanban→SAFe transition (Raytheon); LaunchDarkly rollout and on-call restructuring (ActBlue) | 20+ personnel transitioned to new process model (Raytheon); adoption achieved across resistant teams (ActBlue) | "I led the Waterfall-to-Agile transition at Raytheon and applied the same change management posture to tooling rollout and structural change at ActBlue." |
+
+---
+
+## Operations
+
+| Framework | Engagement | Origin | Outcome | In my own words |
+|---|---|---|---|---|
+| [On-Call Restructuring Framework](incident-management/on-call-restructuring-framework.md) | ActBlue Technical Services (2022–2024) | IC/responder split; per-team rotation design; alert centralization | Reduced friction; improved stakeholder resolution clarity | "I redesigned the cross-team incident handover process and redefined responder roles." |
+| [DR Fire Drill Template](disaster-recovery/fire-drill-template.md) | ActBlue Technical Services (2022–2024) | Disaster recovery fire drills introduced to validate payment continuity under failure scenarios | Improved incident preparedness; DR posture validated before a real event | "I designed the fire drill structure and ran the drills." |
+| [CI/CD Pipeline Governance Guide](ci-cd/pipeline-governance-guide.md) | Capital One (2019–2022) → ActBlue Technical Services (2022–2024) | CI/CD pipeline standardization across multiple engineering departments (Capital One); DevEx team ownership of application-level delivery tooling (ActBlue) | Saved 300 engineering hours per team (Capital One); application-level delivery tooling owned and governed (ActBlue) | "I led the migration planning at Capital One. At ActBlue, I chartered the DevEx team that owned application-level CI/CD." |
+| [LaunchDarkly Rollout Governance](experimentation/launchdarkly-rollout-governance.md) | ActBlue Technical Services (2022–2024) | End-to-end LaunchDarkly rollout: vendor relationship, proof-of-concept, cross-team adoption | First customer-facing flag in production within 4 months; several teams adopted | "I managed the vendor relationship, designed the proof-of-concept, and drove cross-team adoption." |
+
+---
+
+## Compliance & Security
+
+| Framework | Engagement | Origin | Outcome | In my own words |
+|---|---|---|---|---|
+| [PCI-DSS Gap Analysis Checklist](compliance/pci-dss-gap-analysis-checklist.md) | ActBlue Technical Services (2022–2024) | PCI-DSS gap analysis and remediation roadmap, preceding full PCI environment deprecation | Gap analysis complete; remediation roadmap executed; full deprecation achieved | "I led the analysis and owned the roadmap. The team executed against it." |
+
+---
+
+## AI Adoption & Leadership
+
+| Framework | Engagement | Origin | Outcome | In my own words |
+|---|---|---|---|---|
+| [AI Adoption Readiness Framework](ai-adoption/ai-adoption-readiness-framework.md) | ActBlue Technical Services (2024–2025) → Community Tech Alliance (2025–2026) | GitHub Copilot + Claude pilot (ActBlue); Claude Code integration initiative with phased rollout, IC/manager use cases, and evaluation rubric (CTA) | Observability built into rollout at ActBlue; structured framework with separate use cases and rubric developed at CTA | "I designed the ActBlue pilot and built observability into it. The structured framework — separate use cases, evaluation rubric, and phased rollout — came together at CTA." |
+| [AI-Assisted Documentation Standards](leadership/ai-documentation-standards.md) | Community Tech Alliance (2025–2026) | Claude Code + Claude integration initiative — auditability standards for AI-generated documentation | Framework designed; did not advance to implementation before departure | "I designed the initiative and the sequencing, including separate use cases for engineers and managers and a structured evaluation rubric." |
+| [PRD Lifecycle Management](leadership/prd-lifecycle.md) | Community Tech Alliance (2025–2026) | Feature lifecycle and roadmapping process revision | Reduced planning debt; improved IC alignment; shifted emphasis to outcomes | "I designed and drove the process changes. The team adopted them." |
+
+---
+
+## Notes
+
+The framings in "In my own words" accurately reflect personal ownership — they describe what was personally designed, owned, or driven, not what teams executed. For the full operational context behind each decision, see the playbooks themselves.
+
+The M&A diligence framework is the one exception: it does not derive from a single acquisition engagement. It synthesizes the technical assessment posture developed across multi-year platform, compliance, and DR programs that required the same rigor as a formal diligence sprint.

--- a/ORIGINS.md
+++ b/ORIGINS.md
@@ -39,7 +39,7 @@ Every framework in this repo was developed from real work, not synthesized from 
 | [Engineering OKR Framework](operating-cadence/engineering-okr-framework.md) | ActBlue Technical Services (2024–2025) | OKR setting and cascading for the multi-year platform directorate | Aligned 2024–2025 initiatives across 6 teams; cascaded from company objectives to team-level work | "I developed the multi-year platform directorate technical vision and translated it into objectives aligned across the directorate." |
 | [Executive Communication Templates](operating-cadence/executive-communication-templates.md) | ActBlue Technical Services (2022–2025) | Presenting roadmaps to VP Eng and Head of Product; PCI deprecation business cases to Legal, Finance, and Product leadership | Executive alignment maintained across multi-year programs; headcount and investment approved | "I presented roadmap and business case to Legal, Finance, and Product leadership for a multi-year, cross-team program." |
 | [Cross-Functional Alignment Playbook](operating-cadence/cross-functional-alignment-playbook.md) | ActBlue Technical Services (2022–2025) | PCI environment deprecation coordination across product, compliance, legal, finance, and account operations | Full deprecation; 2,600+ accounts migrated; alignment held across 4–5 teams and external audit deadlines | "I owned the program — the vision, the business case, the executive alignment, and the cross-team coordination." |
-| [Escalation Framework](operating-cadence/escalation-framework.md) | ActBlue Technical Services (2022–2025) | Escalation patterns from PCI deprecation and Heroku→K8s cross-functional programs | On-track delivery against compliance deadlines; executive visibility maintained | "The trigger categories and levels here reflect what actually kept multi-year programs on track under compliance pressure." |
+| [Escalation Framework](operating-cadence/escalation-framework.md) | ActBlue Technical Services (2022–2025) | Escalation patterns from PCI deprecation and Heroku→K8s cross-functional programs | On-track delivery against compliance deadlines; executive visibility maintained | "I developed and applied the escalation model across multi-year programs running against compliance deadlines. The trigger categories and levels here are what kept those programs on track." |
 
 ---
 
@@ -74,11 +74,18 @@ Every framework in this repo was developed from real work, not synthesized from 
 
 ---
 
-## AI Adoption & Leadership
+## Technology Adoption
 
 | Framework | Engagement | Origin | Outcome | In my own words |
 |---|---|---|---|---|
 | [AI Adoption Readiness Framework](ai-adoption/ai-adoption-readiness-framework.md) | ActBlue Technical Services (2024–2025) → Community Tech Alliance (2025–2026) | GitHub Copilot + Claude pilot (ActBlue); Claude Code integration initiative with phased rollout, IC/manager use cases, and evaluation rubric (CTA) | Observability built into rollout at ActBlue; structured framework with separate use cases and rubric developed at CTA | "I designed the ActBlue pilot and built observability into it. The structured framework — separate use cases, evaluation rubric, and phased rollout — came together at CTA." |
+
+---
+
+## Product & Documentation
+
+| Framework | Engagement | Origin | Outcome | In my own words |
+|---|---|---|---|---|
 | [AI-Assisted Documentation Standards](leadership/ai-documentation-standards.md) | Community Tech Alliance (2025–2026) | Claude Code + Claude integration initiative — auditability standards for AI-generated documentation | Framework designed; did not advance to implementation before departure | "I designed the initiative and the sequencing, including separate use cases for engineers and managers and a structured evaluation rubric." |
 | [PRD Lifecycle Management](leadership/prd-lifecycle.md) | Community Tech Alliance (2025–2026) | Feature lifecycle and roadmapping process revision | Reduced planning debt; improved IC alignment; shifted emphasis to outcomes | "I designed and drove the process changes. The team adopted them." |
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Operational and leadership frameworks from production engineering work across payments, platform, and compliance contexts. Each document reflects decisions made in real systems, not hypothetical best practices. Organized by the leadership domain each framework addresses.
 
+**[ORIGINS.md](ORIGINS.md)** traces each framework back to the specific engagement, program, and outcome that produced it, with first-person framing for each.
+
 ## Org Design & Strategy
 
 Frameworks for how a Director or Head of Engineering structures the organization, sets technical direction, and makes investment decisions.

--- a/ci-cd/pipeline-governance-guide.md
+++ b/ci-cd/pipeline-governance-guide.md
@@ -10,6 +10,14 @@ This guide covers the decisions and controls that determine whether a CI/CD pipe
 
 A pipeline with no governance is a deployment mechanism. A pipeline with governance is part of the software supply chain, with accountability to match.
 
+## Background and Motivation
+
+This framework draws from two deployments:
+
+1. **Capital One (2019–2022):** I led the standardization of CI/CD pipelines across multiple engineering departments, completing the migration two months ahead of schedule. Outcome: 300 engineering hours saved per team.
+
+2. **ActBlue Technical Services (2022–2024):** I chartered the DevEx team, which owned application-level delivery tooling — CI/CD pipelines, the internal developer platform, and deployment scaffolding. The cloud infrastructure layer was owned by a separate team outside my direct management.
+
 ## Pipeline Ownership Model
 
 Every pipeline should have a clearly assigned owner. Pipelines without owners accumulate configuration drift and are the last to get updated when security requirements change.

--- a/compliance/pci-dss-gap-analysis-checklist.md
+++ b/compliance/pci-dss-gap-analysis-checklist.md
@@ -10,6 +10,10 @@ This checklist supports an initial gap analysis against PCI-DSS v4.0 requirement
 
 The checklist is organized by the 12 PCI-DSS requirement domains. For each domain, the focus is on the controls that engineering teams are most likely to own or partially own. Compliance, legal, and security teams own some of these; the gaps that cause engineering orgs the most trouble are the ones that sit at the boundary.
 
+## Background and Motivation
+
+This checklist was developed from the PCI-DSS gap analysis I led at ActBlue Technical Services (2022–2024), conducted in preparation for a formal QSA assessment. I led the analysis and owned the remediation roadmap; the team executed against it. The gap analysis directly preceded and informed the multi-year PCI environment deprecation program — ultimately migrating 2,600+ entity accounts to Stripe and reducing the payments codebase by 30%.
+
 ## Scope Definition (Do This First)
 
 Before running the checklist, define CDE scope. Scope creep is the most common source of unnecessary remediation work.

--- a/disaster-recovery/fire-drill-template.md
+++ b/disaster-recovery/fire-drill-template.md
@@ -10,9 +10,9 @@ This template formalizes the tabletop exercise format used to stress-test disast
 
 Tabletop exercises prioritize catastrophic failure scenarios first (full failover, data loss, regional outage) and work down to lesser issues in subsequent runs. Starting with the worst case ensures that recovery of critical functions is validated before teams spend time on lower-severity paths.
 
-## Background
+## Background and Motivation
 
-At ActBlue, no formal DR drill process existed. The exercise was introduced to validate that the platform could continue receiving payments during a disaster scenario, which is the single most critical function of the system. Exercises were modeled after the TREX (Threat and Risk Exercise) format used at Capital One, adapted for a payments-focused engineering org.
+At ActBlue Technical Services (2022–2024), no formal DR drill process existed. I designed the fire drill structure and ran the drills. The exercise was introduced to validate that the platform could continue receiving payments during a disaster scenario — the single most critical function of the system. The format was modeled after the TREX (Threat and Risk Exercise) approach used at Capital One, adapted for a payments-focused engineering org. Outcome: improved incident preparedness; DR posture validated before a real event.
 
 The first exercise exposed a standardization gap: user-facing components were hosted on Heroku rather than the standard AWS/Kubernetes stack. During the tabletop, engineers working through failover procedures immediately hit friction because Heroku recovery paths were unfamiliar and underdocumented compared to the rest of the platform. This led to a migration of those components to AWS/Kubernetes, eliminating $64K/year in infrastructure costs and removing the operational outlier from DR scope.
 

--- a/experimentation/launchdarkly-rollout-governance.md
+++ b/experimentation/launchdarkly-rollout-governance.md
@@ -8,6 +8,10 @@ Feature flags are the primary mechanism for decoupling deployment from release â
 
 Feature flags without governance become permanent conditionals that no one understands and no one removes. This guide covers the policies and practices that keep a LaunchDarkly implementation useful over time: flag naming, lifecycle management, targeting rules, rollout sequencing, and the cleanup process that prevents flag debt from accumulating.
 
+## Background and Motivation
+
+This governance framework was developed from the LaunchDarkly rollout at ActBlue Technical Services (2022â€“2024). I managed the vendor relationship, designed the proof-of-concept, and drove cross-team adoption across teams inside and outside my direct management. The platform team built the proof-of-concept; product engineering teams participated in rollout. The first customer-facing flag reached production within 4 months of the program mandate.
+
 ## Flag Taxonomy
 
 Flags serve different purposes and should be managed differently. The most useful distinction:

--- a/incident-management/on-call-restructuring-framework.md
+++ b/incident-management/on-call-restructuring-framework.md
@@ -4,6 +4,10 @@
 
 On-call structure is a talent and delivery risk, not just an ops concern. Unsustainable rotation load drives attrition among your most experienced engineers, increases incident duration, and degrades the reliability signal that leadership depends on for investment decisions. A well-designed on-call program is an argument for trust — it demonstrates that the org can absorb failure without heroics.
 
+## Background and Motivation
+
+This framework was developed from the on-call restructuring at ActBlue Technical Services (2022–2024). I redesigned the cross-team incident handover process and redefined responder roles across a 5-person SRE team that was absorbing every incident in the organization. The structural changes — separating coordination from resolution, introducing per-team rotations, and centralizing alert instrumentation — reduced friction and improved stakeholder resolution clarity.
+
 ## Problem Statement
 
 A common failure mode in on-call programs: a small team gets paged for everything, regardless of who actually owns the problem or can fix it. Alerts are not standardized, so some issues surface only when an engineer notices something is wrong, not when a monitor fires. There is no mechanism for recording incident start and end times, so the org has no data on frequency, duration, or trend.

--- a/leadership/ai-documentation-standards.md
+++ b/leadership/ai-documentation-standards.md
@@ -6,6 +6,12 @@ documentation, design documents, ADRs, playbooks, or technical recommendations
 
 ---
 
+## Background and Motivation
+
+These standards were developed from the Claude Code and Claude integration initiative at Community Tech Alliance (2025–2026). I designed the phased rollout plan with separate use cases for engineers and managers and developed a structured evaluation rubric for measuring impact. The auditability requirements here emerged from the recognition that AI-generated documentation lacks the same provenance chain as human-authored documentation — and that for regulated environments and portfolio-quality work, that gap needs to be closed explicitly.
+
+---
+
 ## Core Principle: AI Recommendations Must Be Sourced
 
 When an AI assistant produces documentation that names a technology, pattern, protocol, or

--- a/leadership/prd-lifecycle.md
+++ b/leadership/prd-lifecycle.md
@@ -2,6 +2,12 @@
 
 ---
 
+## Background and Motivation
+
+This lifecycle model was developed from the feature lifecycle and roadmapping process revision at Community Tech Alliance (2025–2026). I designed and drove the process changes; the team adopted them. The revision shifted emphasis from scope-locked product specifications to outcome-oriented living documents — a change that reduced planning debt and improved IC alignment with the problems the engineering org was actually trying to solve.
+
+---
+
 ## References
 
 - [Clayton Christensen, Taddy Hall, Karen Dillon, and David Duncan — "Know Your Customers' 'Jobs to Be Done'" (*Harvard Business Review*, September 2016)](https://hbr.org/2016/09/know-your-customers-jobs-to-be-done) — The canonical HBR treatment of the Jobs to Be Done framework. Establishes that customers hire products to accomplish specific outcomes, not to consume features. The job-outcome table format in §2 (job + "success looks like") is a direct application.

--- a/metrics/engineering-health-scorecard.md
+++ b/metrics/engineering-health-scorecard.md
@@ -6,6 +6,10 @@ A Director or Head of Engineering who cannot quantify the health of the engineer
 
 This is not a dashboard for engineers. Engineers need granular telemetry. The health scorecard is a leadership communication artifact: 8–12 metrics, organized by domain, that answer the questions a non-technical executive will ask about engineering capability, reliability, and sustainability.
 
+## Background and Motivation
+
+This scorecard format was developed from the Jellyfish rollout and org-wide engineering health reporting work at ActBlue Technical Services (2024–2025). I led the rollout, owned engineering health reporting for the platform directorate, defined the metrics framework, and trained managers and ICs across six teams. The scorecard is the artifact that translates raw delivery data into the format a VP of Engineering can use in a QBR or board presentation.
+
 ---
 
 ## When to Use This

--- a/operating-cadence/cross-functional-alignment-playbook.md
+++ b/operating-cadence/cross-functional-alignment-playbook.md
@@ -4,6 +4,10 @@
 
 Engineering organizations that cannot align effectively with product, design, legal, finance, and sales do not just deliver slower — they deliver the wrong things, at the wrong time, with last-minute surprises that erode trust with every function they depend on. Cross-functional alignment is not a soft skill; it is an operational capability that determines whether engineering can make and keep commitments. The cost of misalignment compounds: a legal review that starts three weeks too late delays a launch by a quarter; a sales commitment made without engineering input creates a customer expectation no one can meet; a finance model built on the wrong headcount assumptions generates budget fights mid-year. This playbook establishes the decision authorities, rituals, and interfaces that keep engineering in alignment with every function it touches.
 
+## Background and Motivation
+
+This playbook was developed from the cross-functional coordination work on the PCI environment deprecation program at ActBlue Technical Services (2022–2025). I owned the program — the vision, the business case, the executive alignment, and the cross-team coordination across product, compliance, legal, finance, and account operations. The program ran against both external audit deadlines and internal milestones, requiring active alignment across stakeholders with different timelines and incentives. Outcome: full deprecation; 2,600+ accounts migrated; 30% codebase reduction.
+
 ## When to Use This
 
 - A new engineering leader is onboarding and needs to understand how engineering relates to its cross-functional partners

--- a/operating-cadence/engineering-okr-framework.md
+++ b/operating-cadence/engineering-okr-framework.md
@@ -4,6 +4,10 @@
 
 OKRs are one of the most frequently adopted and most frequently broken planning tools in engineering organizations. When they work, they create a direct line from an IC's quarterly work to a company-level outcome, make accountability legible at every level of the org, and give engineering leaders a credible answer when executives ask "what is engineering doing and why does it matter?" When they fail — which is most of the time — they become a performance theater exercise that consumes three weeks of Q1 planning and is forgotten by April. This playbook covers the mechanics and judgment calls that determine which outcome you get.
 
+## Background and Motivation
+
+This framework was developed from the OKR setting and cascading work at ActBlue Technical Services (2024–2025). I developed the multi-year platform directorate technical vision and translated it into objectives aligned across 6 teams. The two failure modes documented here — activity OKRs and unmeasurable aspirations — are patterns I encountered and corrected in practice.
+
 ## When to Use This
 
 - Annual or quarterly planning cycle is underway and OKRs need to be set, refined, or re-anchored to company priorities

--- a/operating-cadence/engineering-rhythm-of-business.md
+++ b/operating-cadence/engineering-rhythm-of-business.md
@@ -4,6 +4,10 @@
 
 An engineering org without a defined operating cadence makes decisions at the wrong level, at the wrong time, or not at all. The result is predictable: strategy set in Q1 is invisible by Q2, engineering managers spend their 1:1s on status updates instead of development, and the VP learns about a critical platform risk in the same meeting where the CTO does. This playbook defines the meeting and ritual structure that reduces decision latency, keeps leadership bandwidth focused on the right problems, and creates the coordination surface that cross-functional partners can depend on. When the cadence is working, surprises shrink and trust grows — both inside the engineering org and with the business.
 
+## Background and Motivation
+
+This playbook was developed from the operating cadence work at ActBlue Technical Services (2024–2025), where I set and ran the meeting and ritual structure for a platform directorate of approximately 50 engineers across 6 teams. The cadence described here reflects what sustained delivery rhythm looks like in practice at that scale — not in theory.
+
 ## When to Use This
 
 - A new VP or Director is stepping into an existing org and needs to understand what cadence is already in place (and what is broken)

--- a/operating-cadence/escalation-framework.md
+++ b/operating-cadence/escalation-framework.md
@@ -4,6 +4,10 @@
 
 Escalation failure is one of the most expensive and least discussed problems in engineering organizations. When escalation works, problems surface early enough that they can be managed — a delivery risk is caught in week 3 of a 12-week project, not in week 10; a personnel situation is addressed before it affects the team; a reputational risk reaches the CTO before it reaches the press. When escalation fails, the organization pays the compound interest on every day the problem was visible to someone below the decision-making level but not above it. This playbook covers when to escalate, to whom, in what format, and how to do it without blame or alarm — and how to distinguish the situations that require escalation from the ones that should be handled at the team level without surfacing upward.
 
+## Background and Motivation
+
+The escalation patterns in this framework were developed across multi-team programs at ActBlue Technical Services (2022–2025) — particularly the PCI environment deprecation and Heroku→Kubernetes migration, both of which ran against compliance deadlines and required sustained executive visibility over multiple years. The trigger categories and escalation levels here reflect what actually kept those programs on track, not a generic model.
+
 ## When to Use This
 
 - A new IC or engineering manager is onboarding and needs to understand what "good escalation behavior" looks like in this org

--- a/operating-cadence/executive-communication-templates.md
+++ b/operating-cadence/executive-communication-templates.md
@@ -4,6 +4,10 @@
 
 An engineering leader's ability to communicate upward is a direct multiplier on the team's impact. If the CTO, CEO, or board cannot quickly understand what engineering has delivered, what it needs, and what risks it is managing, they will make resourcing and priority decisions with incomplete information — and engineering will consistently lose those decisions to functions that communicate better. This playbook covers the written artifacts that engineering leaders produce for executive and board audiences: the formats, the principles, and the failure modes to avoid. Getting these right is not about polish; it is about building the executive trust that translates into headcount, runway, and the ability to make consequential technical bets.
 
+## Background and Motivation
+
+These templates were developed from repeated upward communication at ActBlue Technical Services (2022–2025): presenting roadmaps and program status to the VP of Engineering and Head of Product, presenting the PCI deprecation business case to Legal, Finance, and Product leadership, and making headcount and investment requests through multiple planning cycles. The formats here are the ones that produced alignment — not approximations of what good communication looks like in theory.
+
 ## When to Use This
 
 - Preparing for a QBR, board presentation, or investor due diligence session where engineering will have a dedicated slot

--- a/org-design/team-topology-framework.md
+++ b/org-design/team-topology-framework.md
@@ -6,6 +6,10 @@ How you structure your engineering organization determines what your software ar
 
 This playbook treats org structure as a first-class engineering decision with measurable outcomes: deployment frequency, time to detect and recover from incidents, and the percentage of sprint capacity spent on coordination rather than delivery. Designed for Directors and Heads of Engineering who are inheriting a structure, scaling through a growth inflection, or rationalizing after an acquisition.
 
+## Background and Motivation
+
+This framework was developed from the org design work at ActBlue Technical Services (2022–2024). I identified ownership gaps across the platform, defined team scope for three new teams — DevEx, Payments Architecture, and Database Platform — built hiring processes with recruiting, made the hiring decisions, and onboarded the engineers and managers. The chartering work eliminated cross-team dependency bottlenecks and established domain ownership that had been ambiguous under the previous structure.
+
 ---
 
 ## When to Use This

--- a/people/career-ladder-calibration.md
+++ b/people/career-ladder-calibration.md
@@ -6,6 +6,10 @@ A career ladder is not an HR artifact — it is the primary mechanism by which a
 
 The business outcome is straightforward: equitable promotion decisions reduce regrettable attrition, reduce the cost of external hiring (replacing a mid-level engineer typically runs 0.5–1x their annual salary in recruiting and ramp costs), and give managers a shared vocabulary for growth conversations that do not depend on a single person's judgment.
 
+## Background and Motivation
+
+This playbook was developed from the talent development work at ActBlue Technical Services (2022–2025). I drove three engineer promotions within three years through deliberate project placement, calibration preparation, and sustained advocacy — two from SE2 to SSE2 (a double promotion) and one from SSE to SSE2. I also founded and ran the Engineering Management Community of Practice, which systematized calibration coaching, talent development, and recruiting partnership across the manager group.
+
 ## When to Use This
 
 **First career ladder.** The org has been making level decisions informally — "Senior" means whatever the hiring manager decided at offer time, and there is no shared standard for what promotion requires.

--- a/people/headcount-capacity-planning.md
+++ b/people/headcount-capacity-planning.md
@@ -6,6 +6,10 @@ Headcount planning is where engineering leadership earns or loses credibility wi
 
 The business outcome: accurate headcount modeling increases delivery confidence (teams are not perpetually understaffed), reduces time-to-hire pressure (you know when you need the person before it is urgent), and builds the kind of exec trust that translates into more headcount authority over time. Engineering leaders who consistently hit their delivery commitments get more headcount the next cycle. Leaders who miss because they failed to account for attrition, ramp time, or toil do not.
 
+## Background and Motivation
+
+This playbook was developed from the headcount modeling work for the platform directorate at ActBlue Technical Services (2024–2025). I developed the multi-year platform directorate technical vision and translated it into headcount requirements across 6 teams, presenting to the VP of Engineering and Head of Product across multiple planning cycles.
+
 ## When to Use This
 
 **Annual planning.** The org is setting headcount targets and budget for the next fiscal year. Engineering needs to translate a product roadmap into an FTE model that finance can evaluate.

--- a/program-management/change-management-framework.md
+++ b/program-management/change-management-framework.md
@@ -4,6 +4,14 @@
 
 The most common reason technical and organizational changes fail is not technical — it is that people do not know why the change is happening, do not trust the process, or cannot see what the change means for them. A migration that is technically complete but operationally unused has not succeeded. A reorg that was announced but never reinforced reverts within a quarter. This framework applies to the transitions that engineering leaders must manage at the org level: infrastructure migrations, process overhauls, tooling consolidations, and organizational restructuring. The business outcomes at stake are adoption rate (does the change actually stick?), rollback risk (do we have to undo it?), and people trust during uncertainty (do teams remain productive through the transition?). All three are leadership problems before they are technical ones.
 
+## Background and Motivation
+
+This framework was developed from two change management deployments:
+
+1. **Raytheon / NASA EED/2 (2018–2019):** I led a Waterfall→Kanban→SAFe transition for a team of 20+ personnel. I conducted working groups, adapted ceremonies for the team's context, and built the JIRA migration tooling to replace the legacy Waterfall tooling.
+
+2. **ActBlue Technical Services (2022–2024):** I applied the same change management posture to the LaunchDarkly rollout — driving cross-team adoption from zero to first customer-facing flag in production within 4 months — and to the on-call restructuring, which required redesigning roles and handover processes across multiple teams simultaneously.
+
 ## When to Use This
 
 Apply this framework when:

--- a/program-management/launch-readiness-checklist.md
+++ b/program-management/launch-readiness-checklist.md
@@ -4,6 +4,10 @@
 
 The decision to launch is a leadership decision, not an engineering decision — and the quality of that decision depends on the quality of the information provided. Unstructured go/no-go conversations produce launches that slip because no one owned the call, launches that proceed when they should not because the relevant concern was never surfaced, and launches that generate on-call crises because operational readiness was assumed rather than verified. This playbook establishes a structured gate framework that gives the person making the go/no-go call a complete picture across eight readiness domains, a documented record of who accepted which risks, and a launch day sequence with explicit decision points. When a launch fails, the gate record answers the question executives will ask: what did we know, and what did we decide?
 
+## Background and Motivation
+
+This checklist was developed from the launch readiness work on the payment processor migration to Stripe at ActBlue Technical Services (2022–2025). I led the program and defined scope and sequencing; my team executed the migration. Outcome: 2,600+ entity accounts migrated; payments codebase shrunk by 7,000+ lines. The eight readiness domains reflect the failure modes that payment-path releases expose — surfaced through hands-on launch management rather than derived from a template.
+
 ## When to Use This
 
 Apply this launch gate framework for:

--- a/program-management/program-planning-playbook.md
+++ b/program-management/program-planning-playbook.md
@@ -4,6 +4,10 @@
 
 Multi-team technical programs are where engineering leadership makes or breaks delivery credibility with the business. When a program slips, the root cause is almost never a technical problem — it is a planning problem: scope that was never agreed to, dependencies that were invisible until they were blocking, and milestone dates that were set to satisfy a deadline rather than reflect actual sequencing. This playbook documents how to scope, launch, and run a program in a way that gives executives accurate visibility and gives engineers clear ownership. The output is not a Gantt chart — it is a shared understanding of what "done" means and what it will take to get there.
 
+## Background and Motivation
+
+This playbook was developed from the PCI environment deprecation program at ActBlue Technical Services (2022–2025) — a multi-year initiative I owned from vision through full completion. I owned the vision, the business case, the executive alignment, and the cross-team coordination across 4–5 engineering teams with stakeholders in product, compliance, legal, finance, and account operations. Outcome: full deprecation; 2,600+ accounts migrated to Stripe; 30% codebase reduction.
+
 ## When to Use This
 
 Apply program-level treatment when:

--- a/program-management/raid-dependency-tracking.md
+++ b/program-management/raid-dependency-tracking.md
@@ -4,6 +4,10 @@
 
 The RAID log is the artifact that separates programs that surface problems early from programs that discover them when they are already blocking. Every multi-team program accumulates risks, makes assumptions, generates issues, and creates dependencies — the question is whether they are tracked in a structured format that enables proactive management, or scattered across Slack threads and meeting notes where they become invisible until they cause damage. A maintained RAID log is also the primary input for board-level or executive program reporting: when a VP asks "what are our biggest risks heading into Q4?", the RAID log should produce that answer in minutes, not require a frantic synthesis session the night before.
 
+## Background and Motivation
+
+This framework was developed from the dependency tracking work on the PCI environment deprecation and payment processor migration programs at ActBlue Technical Services (2022–2025). I owned cross-team coordination across 4–5 engineering teams running against both external audit deadlines and internal milestones. The RAID format here is the one that surfaced dependencies early enough to manage them — not after they were blocking.
+
 ## When to Use This
 
 Apply RAID tracking from the day the program brief is signed through program closure when:

--- a/program-management/stakeholder-communication-templates.md
+++ b/program-management/stakeholder-communication-templates.md
@@ -4,6 +4,10 @@
 
 The highest-leverage thing a TPM or engineering leader does is give stakeholders accurate information at the right frequency. Bad program communication produces one of two failure modes: stakeholders who are constantly surprised because they did not know things were going wrong, or stakeholders who are overwhelmed and stop reading updates because the signal-to-noise ratio is too low. Both failure modes erode trust and slow decision-making. The templates in this playbook exist to remove the weekly cost of deciding how to communicate — so the work becomes choosing the right facts to surface, not structuring them from scratch each time.
 
+## Background and Motivation
+
+These templates were developed from the stakeholder communication work on the PCI environment deprecation program at ActBlue Technical Services (2022–2025). I presented roadmap and business case to Legal, Finance, Product, and Account Ops stakeholders across a multi-year program running against external audit deadlines. The weekly status, escalation memo, and milestone announcement formats here are the ones that maintained executive alignment through a 3-year program.
+
 ## When to Use This
 
 Apply these templates for any program with:

--- a/strategy/build-vs-buy-framework.md
+++ b/strategy/build-vs-buy-framework.md
@@ -6,6 +6,14 @@ The build-vs-buy decision is one of the highest-leverage calls an engineering le
 
 The failure mode is not choosing wrong. The failure mode is choosing without a framework — following instinct, optimizing for the wrong dimension (usually initial cost), or letting the decision get made by whoever is most vocal in the architecture meeting. This playbook provides a structured, repeatable approach to build-vs-buy decisions that produces a documented rationale, surfaces the trade-offs explicitly, and creates an audit trail for post-decision review.
 
+## Background and Motivation
+
+This framework was developed from two high-stakes build-vs-buy decisions at ActBlue Technical Services:
+
+1. **Heroku → Kubernetes on AWS (2022–2024):** I identified the migration priority from incident data, built the business case, and cleared the organizational path. The DevEx team handled application-level delivery; the cloud platform team owned the infrastructure layer. Outcome: $64K/year infrastructure savings and simplified incident management.
+
+2. **Payment processor migration to Stripe (2022–2025):** I led the program and defined scope and sequencing. My team executed the migration. Outcome: 2,600+ entity accounts migrated; payments codebase shrunk by 7,000+ lines.
+
 ---
 
 ## When to Use This

--- a/strategy/ma-technical-due-diligence.md
+++ b/strategy/ma-technical-due-diligence.md
@@ -6,6 +6,10 @@ Technical due diligence is the moment when an engineering leader's judgment most
 
 The business outcome: thorough technical diligence reduces integration risk, produces defensible inputs to purchase price adjustments, and gives the post-close engineering leadership team a credible integration plan on day one rather than day 60.
 
+## Background and Motivation
+
+This framework was synthesized from multi-year platform and compliance work in regulated environments at ActBlue Technical Services (2022–2025), spanning PCI environment deprecation, multi-regional infrastructure deployment, monolith decomposition, and disaster recovery validation. It does not derive from a single M&A diligence engagement — it represents the technical assessment posture developed across programs that required the same rigor: what would you need to know to take on this system, and what would it cost to fix what you found?
+
 ## When to Use This
 
 The diligence emphasis changes based on acquisition type. Use this framework to select and weight domains, not to run every domain at full depth for every acquisition.

--- a/strategy/technical-strategy-template.md
+++ b/strategy/technical-strategy-template.md
@@ -6,6 +6,14 @@ A technical strategy document is the primary artifact through which an engineeri
 
 The audience for a technical strategy is not primarily engineers — it is the executive team, the board, and the finance function that controls the budget. It must be legible to a CFO who wants to know why replatforming requires 6 headcount for 18 months, and to a CEO who wants to know how the technical investment connects to market position. Engineers read it too, and it must be credible to them — but optimizing the document for engineers at the expense of executive legibility is the most common failure mode.
 
+## Background and Motivation
+
+This template was developed from two successive technical strategy engagements:
+
+1. **ActBlue Technical Services (2024–2025):** I developed the multi-year platform directorate technical vision, set direction for a 6-team directorate, and presented roadmaps and program status to the VP of Engineering and Head of Product.
+
+2. **Community Tech Alliance (2025–2026):** I designed and wrote a 12-month technical investment roadmap entirely, prioritizing DR posture, dependency management, and release confidence for a lean GCP-based engineering org.
+
 ---
 
 ## When to Use This


### PR DESCRIPTION
## Summary

- Creates `ORIGINS.md` at repo root — a companion mapping document tracing all 25 frameworks back to the specific engagement, program, and outcome that produced them, with first-person framing for each
- Adds `## Background and Motivation` sections to 24 playbooks (the AI adoption framework already had one), using the consistent style established there
- Updates `README.md` with a one-line reference to `ORIGINS.md`

All framings draw from `career-playbook/context/accomplishments.md` safe-to-say language. No overclaiming.

## Test plan

- [ ] Read `ORIGINS.md` end-to-end: confirm every row uses safe-to-say framing, no overclaiming
- [ ] Spot-check 3–4 playbooks to confirm `## Background and Motivation` is present, correctly attributed, and matches the AI adoption framework's voice/length
- [ ] Confirm no safe framing contradicts the "Commonly Misattributed Claims" section of `accomplishments.md`

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)