### PR TITLE
Add LINKING.md and backfill system-legibility playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,13 @@
-# engineering-playbooks — Claude Code Configuration
+# tech-leadership-reference — Claude Code Configuration
 
 ## Repo Purpose
 
-Reference playbooks for engineering leadership, incident management, and operational practice.
+Reference frameworks for engineering leadership, incident management, and operational practice.
 All content is Markdown; there is no compiled code.
+
+## Linking conventions
+
+See [LINKING.md](LINKING.md) for when and how to cross-reference the `lifting-logbook` repo as a demonstration sandbox.
 
 ## Testing
 

--- a/LINKING.md
+++ b/LINKING.md
@@ -1,0 +1,89 @@
+# Linking Conventions
+
+This repo (`tech-leadership-reference`) is a reference library for engineering leadership
+frameworks. Some frameworks describe practices the author has shipped at production scale —
+those are documented in [ORIGINS.md](ORIGINS.md) with the engagement, program, and outcome.
+
+Other frameworks describe practices that a reader can only evaluate by inspecting a working
+system. For those, this repo links out to [`lifting-logbook`](https://github.com/brownm09/lifting-logbook) —
+a personal-project monorepo (NestJS + GCP Cloud Run + Kubernetes + Terraform) that serves as
+a demonstration substrate.
+
+This file defines when to link out, how to label the link, and how to keep the links durable.
+
+---
+
+## When to link out to `lifting-logbook`
+
+Link out only when **both** are true:
+
+1. The framework makes a claim about practice (telemetry posture, runbook structure,
+   IaC governance, on-call diagnostic flow, AI-assisted development workflow, etc.)
+   that benefits from an inspectable artifact.
+2. `ORIGINS.md` and `career-playbook` do **not** already attest to the practice from
+   production experience.
+
+When `ORIGINS.md` already grounds the framework in production (e.g., the on-call
+restructuring case study), `lifting-logbook` plays a complementary role at most — the
+production attribution remains primary, and a sandbox link is a "for the curious" footnote.
+
+Do not link out when the framework's claims cannot be credibly demonstrated by a
+personal-scale stack — e.g., PCI-DSS controls, M&A diligence, multi-team org design.
+A forced link weakens the framing.
+
+---
+
+## Labeling convention
+
+Every cross-link from this repo into `lifting-logbook` must carry a visible callout
+distinguishing it from production attribution:
+
+> **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook)
+> is a personal-project monorepo, not a production system at scale. The artifact linked
+> here illustrates the technique; production-scale application of the same technique is
+> documented in [ORIGINS.md](ORIGINS.md) where applicable.
+
+Place the callout once per page, near the first cross-link. Subsequent links on the
+same page do not need to repeat it.
+
+---
+
+## Link stability
+
+Two patterns, one rule each:
+
+- **Citation links** ("this is the choice I made and the reasoning") — pin to a commit
+  SHA or tagged release. These should not change underneath the reference doc.
+  Format: `https://github.com/brownm09/lifting-logbook/blob/<SHA>/path/to/file#Lstart-Lend`
+
+- **Live-state links** ("this is the current configuration") — link to `main`. These are
+  expected to drift; the framework doc should say so.
+  Format: `https://github.com/brownm09/lifting-logbook/blob/main/path/to/file`
+
+If a link rots (file moved, deleted, refactored), prefer **removing the link** over
+chasing the new path. The framework's argument should never depend on a working link.
+
+---
+
+## Footnote, not body prose
+
+Cross-links go in footnotes or end-of-section "Further reading" blocks, not inline in
+load-bearing paragraphs. The framework's argument must remain coherent if every link is
+removed. Treat sandbox links as evidence a curious reader can verify, not as the
+substance of the claim.
+
+---
+
+## Initial backfill targets (in priority order)
+
+1. [`incident-management/system-legibility-and-diagnostic-playbook.md`](incident-management/system-legibility-and-diagnostic-playbook.md) —
+   highest ROI; pair the high-cardinality telemetry argument with the actual telemetry
+   choices made in the lifting-logbook stack.
+2. [`ai-adoption/ai-adoption-readiness-framework.md`](ai-adoption/ai-adoption-readiness-framework.md) —
+   the `.claude/` scaffolding (hooks, skills, settings) is itself the demonstration artifact.
+3. [`incident-management/on-call-restructuring-framework.md`](incident-management/on-call-restructuring-framework.md) —
+   complementary to the production case study; show the IaC + alerting config that
+   makes a single-operator rotation tractable.
+
+Other frameworks are linked opportunistically as content evolves. Do not backfill
+exhaustively; link only where the link adds evaluative power.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Operational and leadership frameworks from production engineering work across pa
 
 **[ORIGINS.md](ORIGINS.md)** traces each framework back to the specific engagement, program, and outcome that produced it, with first-person framing for each.
 
+**[LINKING.md](LINKING.md)** documents the convention for cross-references to [lifting-logbook](https://github.com/brownm09/lifting-logbook) as a demonstration sandbox for frameworks where production experience is not the basis of the claim.
+
 ## Org Design & Strategy
 
 Frameworks for how a Director or Head of Engineering structures the organization, sets technical direction, and makes investment decisions.

--- a/ai-adoption/ai-adoption-readiness-framework.md
+++ b/ai-adoption/ai-adoption-readiness-framework.md
@@ -289,6 +289,28 @@ The Stage 2 behavior is not because this engineer is smarter — it's because th
 
 ---
 
+## Appendix C: Demonstration artifacts
+
+> **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook) is a personal-project monorepo, not a production system at scale. The artifacts below illustrate the framework's mechanisms against an inspectable stack — they do not substitute for the production rollout experience documented in [ORIGINS.md](../ORIGINS.md). See [LINKING.md](../LINKING.md) for the full convention.
+
+The personal-project rollout is the inverse of the org-scale rollouts described above: a single operator, no calibration cohort, no observability dashboard. The framework still applies — gate model collapses to "self-gate against the rubric," and the observability layer collapses to the artifacts a future reader could audit. Citation links pin to commit [`413f8a6`](https://github.com/brownm09/lifting-logbook/tree/413f8a62f43f12fa200be3e3307da7ef72c7b446); live-state links to `main`.
+
+### On policy-as-code and project-level AI configuration
+
+- **Project AI scaffolding** — [`CLAUDE.md`](https://github.com/brownm09/lifting-logbook/blob/main/CLAUDE.md) (live state). Project-local Claude Code configuration: platform constraints (Windows + Git Bash, no `jq`, npm workspaces), repo layout, and the testing command the global "Test before PR" rule depends on. Demonstrates the framework's Part 4 instrumentation principle at the smallest scale: every project carries the context an AI agent needs in version control, not in a human's head.
+- **Project automation hooks** — [`.claude/hook-config.json`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/.claude/hook-config.json) (citation, SHA-pinned) and [`.claude/propose.json`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/.claude/propose.json) (citation, SHA-pinned). Wire the project to its GitHub Project (epics + milestones) and to the proposal-scaffolding skill that drafts ADRs and design proposals against the repo's roadmap. Demonstrates the Gate 2 → Gate 3 prerequisite — agentic write workflows are only safe when the destination structure is itself codified.
+
+### On the gate model and rollback discipline
+
+- **Architecture decision record series** — [`docs/adr/`](https://github.com/brownm09/lifting-logbook/tree/main/docs/adr) (live state). Every architectural decision the AI participated in scaffolding is captured as an ADR with an alternatives-considered section. Demonstrates the framework's Stage 4 "outsourcing judgment" test at the artifact level: the rationale for each AI-assisted decision is durably recorded and re-readable, not lost to chat history.
+- **Proposal lifecycle** — [`docs/proposals/`](https://github.com/brownm09/lifting-logbook/tree/main/docs/proposals) (live state). Each proposal is drafted with AI assistance, marked through `proposed → accepted → shipped` states, and linked from the implementing PR. Demonstrates the Gate 1 → Gate 2 prerequisite — medium-risk AI-assisted work requires a paper trail, even on a single-operator project.
+
+### What is missing — and what that demonstrates
+
+The personal-scale stack has no team-level pulse survey, no cross-team variance dashboard, no calibration cohort. That absence is itself a demonstration: the framework's org-level mechanisms (Part 4 *Organization Level*, Part 5 *Gate 3 sustained*) only cohere at organizational scale. A reader evaluating whether to apply this framework should treat the lifting-logbook artifacts as evidence of the per-engineer mechanics, and the [ORIGINS.md](../ORIGINS.md) entries (ActBlue, CTA) as the basis for the org-level claims.
+
+---
+
 ## Changelog
 
 | Version | Date | Notes |

--- a/incident-management/on-call-restructuring-framework.md
+++ b/incident-management/on-call-restructuring-framework.md
@@ -81,3 +81,29 @@ The IC rotation is the role most likely to generate questions. Staff engineers a
 **No postmortem process:** TTR and frequency data without retrospectives identifies that problems exist but not why. Jeli-style postmortems with timeline reconstruction surface the systemic causes.
 
 **Mon-Mon rotations:** Weekend and holiday handoffs create gaps that are predictable and preventable. Move the boundary to Wednesday.
+
+---
+
+## Further reading: demonstration artifacts
+
+> **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook) is a personal-project monorepo, not a production system at scale. The framework above is grounded in the ActBlue restructuring documented in [ORIGINS.md](../ORIGINS.md); the artifacts below are complementary — they show the diagnostic infrastructure that makes any rotation tractable, including a rotation of one. See [LINKING.md](../LINKING.md) for the full convention.
+
+A single-operator on-call posture is the worst case for the framework's *separate coordination from resolution* split — there is no second person to take either role. The compensating mechanism is making the system legible enough that the same operator can fall back to the runbook rather than reasoning from first principles under pressure. Citation links pin to commit [`413f8a6`](https://github.com/brownm09/lifting-logbook/tree/413f8a62f43f12fa200be3e3307da7ef72c7b446).
+
+### On the operational contract
+
+- **On-call ops doc** — citation: [`docs/operations/on-call.md` at `413f8a6`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/operations/on-call.md); live state: [same path on `main`](https://github.com/brownm09/lifting-logbook/blob/main/docs/operations/on-call.md). Defines severity tiers (SEV1–3), alert-to-severity mapping, escalation paths (15-min page for SEV1, DM for SEV2), and the postmortem template. Demonstrates the framework's Implementation Checklist as an artifact: every item the checklist names has a corresponding line in this doc.
+- **On-call readiness proposal** — [`docs/proposals/2026-05-08-on-call-readiness.md`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/proposals/2026-05-08-on-call-readiness.md) (citation, SHA-pinned). Captures the problem framing and sequencing — runbooks, SLOs, and incident response are deliberately staged after the observability stack lands, not before. Demonstrates the framework's claim that on-call structure depends on detection infrastructure being in place first.
+
+### On reliability targets and burn-rate alerting
+
+- **SLO definitions** — citation: [`docs/operations/slo.md` at `413f8a6`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/operations/slo.md); live state: [same path on `main`](https://github.com/brownm09/lifting-logbook/blob/main/docs/operations/slo.md). 99.5% availability, p95 latency < 1s, 28-day rolling window, error budget = 3.36h, burn-rate thresholds (14×, 6×, 3×). Defines the contract that determines whether a page is warranted. Demonstrates the framework's Metrics and Tooling section: incident frequency and TTR are only meaningful against an explicit reliability target.
+- **SLO methodology rationale** — [ADR-019: SLO Methodology at `413f8a6`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/adr/ADR-019-slo-methodology.md) (citation, SHA-pinned). Records the choice to adopt burn-rate alerting over simple threshold alerts, with a deferral until production traffic exists for calibration.
+
+### On alert ownership and routing
+
+- **Prometheus alert rules** — [`infra/observability/alerts/api.yaml`](https://github.com/brownm09/lifting-logbook/blob/main/infra/observability/alerts/api.yaml) (live state). Three rules (`APIHighErrorRate` > 1% for 5m, `APIHighP95Latency` > 1s for 5m, `APINoRequests`); each carries a `runbook_url` annotation linking to a specific runbook. Demonstrates the *Alerts without owners* failure mode at the artifact level: every alert in this file has an explicit destination *and* a documented response path, which is the minimum bar before any rotation is sustainable.
+
+### What is missing — and what that demonstrates
+
+The single-operator rotation has no IC/responder split, no per-team rotation, no Wed-Wed handoff cadence. Those mechanisms only have meaning at organizational scale. The lifting-logbook artifacts show the diagnostic substrate the framework's structural changes depend on — they are not a substitute for the organizational restructuring documented in ORIGINS.md.

--- a/incident-management/system-legibility-and-diagnostic-playbook.md
+++ b/incident-management/system-legibility-and-diagnostic-playbook.md
@@ -258,11 +258,30 @@ byproduct.
 
 > **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook) is a personal-project monorepo, not a production system at scale. The artifacts below illustrate techniques described in this playbook against an inspectable stack. See [LINKING.md](../LINKING.md) for the full convention.
 
-- **High-cardinality telemetry choices** — [TODO: link to specific instrumentation file in lifting-logbook on `main` once selected]
-- **Runbook authored against an inspectable system** — [TODO: link to runbook file]
-- **SLO definitions** — [TODO: link to SLO config]
+The citation links below pin to commit [`413f8a6`](https://github.com/brownm09/lifting-logbook/tree/413f8a62f43f12fa200be3e3307da7ef72c7b446) per the LINKING.md SHA-pinning rule. Where the artifact is intended to evolve as the stack does, a `main` link is provided alongside.
 
-These links will be filled in when the corresponding lifting-logbook artifacts stabilize. Per [LINKING.md](../LINKING.md), citation links pin to commit SHAs; live-state links use `main`.
+### On runtime legibility and high-cardinality telemetry
+
+- **Backend selection rationale** — [ADR-018: Observability Stack](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/adr/ADR-018-observability-stack.md). Records the OpenTelemetry + Grafana Cloud (Tempo / Mimir / Loki) decision, the GKE DaemonSet collector topology, the Prisma instrumentation choice, and the head-based 100% sampling stance until production traffic exists. The alternatives-considered section is the part most worth reading: it makes explicit why Honeycomb, Datadog, and self-hosting were rejected for this project's constraints — illustrating the playbook's claim that "the right backend" is a function of traffic shape, vendor lock-in tolerance, and what the team needs to query, not a context-free best practice.
+- **Local development verification path** — [Observability Runbook](https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/observability.md) (live state). Documents the docker-compose stack (OTel Collector + Tempo + Loki + Prometheus + Grafana) that mirrors the production topology, plus the trace-by-`trace_id` lookup flow and log↔trace correlation queries. Demonstrates the playbook's argument that runtime legibility must be verifiable on a developer's laptop, not only in production.
+
+### On runbook structure and symptom-first authoring
+
+- **Runbook index** — [`docs/runbooks/README.md`](https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/README.md) (live state).
+- **Worked runbooks** — [`api-5xx-surge.md`](https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/api-5xx-surge.md), [`auth-provider-outage.md`](https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/auth-provider-outage.md), [`database-unreachable.md`](https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/database-unreachable.md), [`deploy-regression-rollback.md`](https://github.com/brownm09/lifting-logbook/blob/main/docs/runbooks/deploy-regression-rollback.md). Each is organized around the symptom a responder sees, not the component an architect would name. They demonstrate the playbook's claim that legibility artifacts must be authored from the responder's frame of reference, not the designer's.
+
+### On SLOs as legibility infrastructure
+
+- **SLO definitions** — citation: [`docs/operations/slo.md` at 413f8a6](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/operations/slo.md); live state: [same path on `main`](https://github.com/brownm09/lifting-logbook/blob/main/docs/operations/slo.md). Defines availability and p95 latency SLOs for `apps/api` with explicit PromQL expressions, the 28-day rolling window, and the deliberate exclusion of 4xx responses from the bad-request count. Demonstrates that an SLO is only legible if its definition is precise enough to argue about — and that the argument is the point.
+- **SLO methodology rationale** — [ADR-019: SLO Methodology](https://github.com/brownm09/lifting-logbook/blob/main/docs/adr/ADR-019-slo-methodology.md) (live state). Records why these specific definitions, why these targets, and why recording rules over ad-hoc range vector queries.
+
+### On on-call posture for the responder
+
+- **On-call ops doc** — [`docs/operations/on-call.md`](https://github.com/brownm09/lifting-logbook/blob/main/docs/operations/on-call.md) (live state). Shows how the posture described in the [On-Call Restructuring Framework](on-call-restructuring-framework.md) collapses to a single-operator project: the diagnostic infrastructure (telemetry, runbooks, SLOs) is what makes any rotation workable, including a rotation of one.
+
+---
+
+These artifacts are not exhaustive. Per [LINKING.md](../LINKING.md), additional cross-references are added only where they add evaluative power — not as breadth for its own sake.
 
 ---
 

--- a/incident-management/system-legibility-and-diagnostic-playbook.md
+++ b/incident-management/system-legibility-and-diagnostic-playbook.md
@@ -13,6 +13,11 @@ on-call programs, service ownership standards, and onboarding design. It complem
 structure and incident coordination; this playbook covers the underlying diagnostic
 infrastructure that makes a rotation sustainable.
 
+> **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook)
+> is a personal-project monorepo, not a production system at scale. The artifact linked
+> here illustrates the technique; production-scale application of the same technique is
+> documented in [ORIGINS.md](../ORIGINS.md) where applicable.
+
 ---
 
 ## The Core Problem: Two Kinds of Legibility
@@ -244,6 +249,20 @@ this produce that enable correct inference by someone with no priors, under pres
 that question concretely — with a service catalog entry, a trace, a runbook that starts with
 symptoms, and error messages that point toward causes — and onboarding legibility follows as a
 byproduct.
+
+---
+
+---
+
+## Further reading: demonstration artifacts
+
+> **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook) is a personal-project monorepo, not a production system at scale. The artifacts below illustrate techniques described in this playbook against an inspectable stack. See [LINKING.md](../LINKING.md) for the full convention.
+
+- **High-cardinality telemetry choices** — [TODO: link to specific instrumentation file in lifting-logbook on `main` once selected]
+- **Runbook authored against an inspectable system** — [TODO: link to runbook file]
+- **SLO definitions** — [TODO: link to SLO config]
+
+These links will be filled in when the corresponding lifting-logbook artifacts stabilize. Per [LINKING.md](../LINKING.md), citation links pin to commit SHAs; live-state links use `main`.
 
 ---
 

--- a/incident-management/system-legibility-and-diagnostic-playbook.md
+++ b/incident-management/system-legibility-and-diagnostic-playbook.md
@@ -252,13 +252,9 @@ byproduct.
 
 ---
 
----
-
 ## Further reading: demonstration artifacts
 
-> **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook) is a personal-project monorepo, not a production system at scale. The artifacts below illustrate techniques described in this playbook against an inspectable stack. See [LINKING.md](../LINKING.md) for the full convention.
-
-The citation links below pin to commit [`413f8a6`](https://github.com/brownm09/lifting-logbook/tree/413f8a62f43f12fa200be3e3307da7ef72c7b446) per the LINKING.md SHA-pinning rule. Where the artifact is intended to evolve as the stack does, a `main` link is provided alongside.
+The artifacts below illustrate the techniques described in this playbook against the demonstration sandbox introduced after the Purpose section. See [LINKING.md](../LINKING.md) for the full convention. Citation links pin to commit [`413f8a6`](https://github.com/brownm09/lifting-logbook/tree/413f8a62f43f12fa200be3e3307da7ef72c7b446) per the LINKING.md SHA-pinning rule. Where an artifact is intended to evolve as the stack does, a `main` link is provided alongside.
 
 ### On runtime legibility and high-cardinality telemetry
 
@@ -273,7 +269,7 @@ The citation links below pin to commit [`413f8a6`](https://github.com/brownm09/l
 ### On SLOs as legibility infrastructure
 
 - **SLO definitions** — citation: [`docs/operations/slo.md` at 413f8a6](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/operations/slo.md); live state: [same path on `main`](https://github.com/brownm09/lifting-logbook/blob/main/docs/operations/slo.md). Defines availability and p95 latency SLOs for `apps/api` with explicit PromQL expressions, the 28-day rolling window, and the deliberate exclusion of 4xx responses from the bad-request count. Demonstrates that an SLO is only legible if its definition is precise enough to argue about — and that the argument is the point.
-- **SLO methodology rationale** — [ADR-019: SLO Methodology](https://github.com/brownm09/lifting-logbook/blob/main/docs/adr/ADR-019-slo-methodology.md) (live state). Records why these specific definitions, why these targets, and why recording rules over ad-hoc range vector queries.
+- **SLO methodology rationale** — citation: [ADR-019: SLO Methodology at `413f8a6`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/adr/ADR-019-slo-methodology.md); live state: [same path on `main`](https://github.com/brownm09/lifting-logbook/blob/main/docs/adr/ADR-019-slo-methodology.md). Records why these specific definitions, why these targets, and why burn-rate alerting (Workbook methodology) over simple threshold alerts.
 
 ### On on-call posture for the responder
 


### PR DESCRIPTION
Establish the convention for cross-references to lifting-logbook (demonstration sandbox) and apply it to the system-legibility playbook as the pattern-setting example.

## Testing (Documentation)

Manually verified:
1. LINKING.md renders correctly with proper Markdown formatting and links resolve
2. New callout in system-legibility playbook is placed after Purpose section
3. Further reading section added at end with TODO placeholders
4. Internal cross-references to LINKING.md and ORIGINS.md resolve correctly
5. CLAUDE.md and README.md updated with pointers to LINKING.md