### PR TITLE
Backfill lifting-logbook sandbox cross-references (issue #23)

### DIFF
--- a/ci-cd/pipeline-governance-guide.md
+++ b/ci-cd/pipeline-governance-guide.md
@@ -129,3 +129,31 @@ Pipeline configuration is infrastructure. Treat it accordingly.
 **No rollback test:** Rollback procedures are defined but have not been executed since the pipeline was built. Test rollback before you need it.
 
 **Drift between environments:** Staging and production pipelines diverge over time because fixes go to production first and are not backported. The staging pipeline stops being representative. Run the same pipeline config across all environments; parameterize what needs to differ.
+
+---
+
+## Further reading: demonstration artifacts
+
+> **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook)
+> is a personal-project monorepo, not a production system at scale. The artifact linked
+> here illustrates the technique; production-scale application of the same technique is
+> documented in [ORIGINS.md](../ORIGINS.md) where applicable.
+
+The artifacts below illustrate the techniques described in this guide against the demonstration sandbox. See [LINKING.md](../LINKING.md) for the full convention. Citation links pin to commit [`413f8a6`](https://github.com/brownm09/lifting-logbook/tree/413f8a62f43f12fa200be3e3307da7ef72c7b446) per the LINKING.md SHA-pinning rule. Where an artifact is intended to evolve as the stack does, a `main` link is provided alongside.
+
+### On pipeline ownership and shared template configuration
+
+- **Monorepo and pipeline structure decision** — citation: [ADR-001: Monorepo Structure](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/adr/ADR-001-monorepo-structure.md); live state: [same path on `main`](https://github.com/brownm09/lifting-logbook/blob/main/docs/adr/ADR-001-monorepo-structure.md). Records the Turborepo + npm workspaces decision. The `turbo.json` task graph is the mechanism by which a platform team defines the required pipeline steps — build dependencies, caching contracts, test ordering — that all application packages inherit. Demonstrates the shared-template ownership model: the platform team sets the structure; teams configure application-specific inputs and outputs within it.
+
+### On required gates and sequential environment promotion
+
+- **CI pipeline** — citation: [`.github/workflows/ci.yml` at `413f8a6`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/.github/workflows/ci.yml); live state: [same path on `main`](https://github.com/brownm09/lifting-logbook/blob/main/.github/workflows/ci.yml). The Lint & Test job runs `npx turbo run lint test` with Turborepo caching, enforces Prisma client generation, and validates the analytics taxonomy schema. All gates block the PR — they are not advisory. Demonstrates that the required-gate checklist from this guide translates to enforced pipeline steps, not just documentation.
+- **Deploy pipeline** — citation: [`.github/workflows/deploy.yml` at `413f8a6`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/.github/workflows/deploy.yml); live state: [same path on `main`](https://github.com/brownm09/lifting-logbook/blob/main/.github/workflows/deploy.yml). Multi-stage promotion: CI must pass before staging deploy runs; production deploy requires a manual approval gate. The deploy pipeline is the place where "environment promotion is sequential" becomes enforceable rather than advisory.
+
+### On secret management (OIDC over long-lived credentials)
+
+- **Workload Identity Federation** — citation: [`.github/workflows/deploy.yml` at `413f8a6`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/.github/workflows/deploy.yml) (same artifact as above). The deploy pipeline uses GCP Workload Identity Federation (`GCP_STAGING_WORKLOAD_IDENTITY_PROVIDER`, `GCP_PROD_WORKLOAD_IDENTITY_PROVIDER`) rather than stored long-lived service account keys. Each pipeline run receives a short-lived credential federated from GitHub's OIDC token — illustrating the "OIDC over long-lived credentials" rule from this guide's Secret Management section in practice.
+
+---
+
+These artifacts are not exhaustive. Per [LINKING.md](../LINKING.md), additional cross-references are added only where they add evaluative power — not as breadth for its own sake.

--- a/leadership/ai-documentation-standards.md
+++ b/leadership/ai-documentation-standards.md
@@ -122,3 +122,28 @@ the opening brief:
 
 For projects using CLAUDE.md, encode this as a standing instruction in the
 **Documentation and Citations** section so it applies automatically every session.
+
+---
+
+## Further reading: demonstration artifacts
+
+> **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook)
+> is a personal-project monorepo, not a production system at scale. The artifact linked
+> here illustrates the technique; production-scale application of the same technique is
+> documented in [ORIGINS.md](../ORIGINS.md) where applicable.
+
+The artifacts below illustrate the techniques described in this document against the demonstration sandbox. See [LINKING.md](../LINKING.md) for the full convention. Citation links pin to commit [`413f8a6`](https://github.com/brownm09/lifting-logbook/tree/413f8a62f43f12fa200be3e3307da7ef72c7b446) per the LINKING.md SHA-pinning rule.
+
+### On ADR citation practice
+
+- **Worked ADR with a full References section** — citation: [ADR-016: Cycle Planning Agent](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/adr/ADR-016-cycle-planning-agent.md). A production ADR whose `## References` section demonstrates this document's citation requirements: the Anthropic Tool Use guide (for the technology chosen), the Anthropic Node SDK (for the integration library), the Hexagonal Architecture primary source (for the architectural pattern governing the port boundary), and prior ADRs in the same series (for internal cross-references). Each entry includes the one-sentence explanation of what decision it supports — the format this document prescribes for ADR References sections.
+
+### On AI attribution and workflow provenance
+
+- **Workflow-level attribution via `/propose`** — citation: [`.claude/propose.json` at `413f8a6`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/.claude/propose.json). The skill configuration file for the `/propose` command, which scaffolds proposals with AI assistance, creates linked GitHub issues, and adds ROADMAP entries. Every commit produced by this skill carries the `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` footer, implementing attribution at the workflow level rather than relying on per-session author discipline. This demonstrates the document's core premise: provenance is a workflow property, not a post-hoc annotation.
+
+**What is missing:** The repo does not yet have a `docs/adr-references.md` consolidated reference index (as this document recommends in the "Consolidated Reference Index" section). That is a candidate for a future round once the ADR series reaches the scale where per-domain grouping adds navigation value.
+
+---
+
+These artifacts are not exhaustive. Per [LINKING.md](../LINKING.md), additional cross-references are added only where they add evaluative power — not as breadth for its own sake.

--- a/leadership/prd-lifecycle.md
+++ b/leadership/prd-lifecycle.md
@@ -159,6 +159,30 @@ This lifecycle model was developed from the feature lifecycle and roadmapping pr
 
 ---
 
+## Further reading: demonstration artifacts
+
+> **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook)
+> is a personal-project monorepo, not a production system at scale. The artifact linked
+> here illustrates the technique; production-scale application of the same technique is
+> documented in [ORIGINS.md](../ORIGINS.md) where applicable.
+
+The artifacts below illustrate the techniques described in this playbook against the demonstration sandbox. See [LINKING.md](../LINKING.md) for the full convention. Citation links pin to commit [`413f8a6`](https://github.com/brownm09/lifting-logbook/tree/413f8a62f43f12fa200be3e3307da7ef72c7b446) per the LINKING.md SHA-pinning rule. Where an artifact is intended to evolve as the stack does, a `main` link is provided alongside.
+
+### On the proposal lifecycle state machine
+
+- **Proposal lifecycle and automation** — [`docs/proposals/README.md`](https://github.com/brownm09/lifting-logbook/blob/main/docs/proposals/README.md) (live state). Documents the `draft → accepted → shipped → declined` state machine and the `/propose` skill that automates proposal creation, issue linking, and ROADMAP entry. The four statuses map structurally onto the playbook's four lifecycle stages (Discovery → Alignment → Delivery → Shipped). The key difference from this playbook's model: the proposal lifecycle is scope-definition, not outcome-tracking — there is no equivalent of the Hypothesis and Bets section or falsifiable success metrics. The proposals are the gate-to-Delivery artifact; the PRD extends that into outcome accountability.
+- **Lifecycle tooling configuration** — citation: [`.claude/propose.json` at `413f8a6`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/.claude/propose.json). The skill configuration file that wires the `/propose` skill to the repo's proposals directory, GitHub project, milestones, and epics. Demonstrates that lifecycle tooling can be operationalized at the individual-project level — the state machine is not just documented but enforced by the scaffolding that creates every proposal.
+
+### On a worked end-to-end proposal
+
+- **On-call readiness proposal** — citation: [`docs/proposals/2026-05-08-on-call-readiness.md` at `413f8a6`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/proposals/2026-05-08-on-call-readiness.md). Shows a proposal moving through the full lifecycle in a single file: problem statement, proposed solution with three scoped work items, acceptance criteria, linked GitHub issue, ROADMAP milestone placement, and a final `Status: shipped`. The one-living-document structure — where the file accumulates through discovery, alignment, and delivery without being duplicated or forked — is the direct analog to this playbook's one-living-PRD principle.
+
+---
+
+These artifacts are not exhaustive. Per [LINKING.md](../LINKING.md), additional cross-references are added only where they add evaluative power — not as breadth for its own sake.
+
+---
+
 ## References
 
 - [Clayton Christensen, Taddy Hall, Karen Dillon, and David Duncan — "Know Your Customers' 'Jobs to Be Done'" (*Harvard Business Review*, September 2016)](https://hbr.org/2016/09/know-your-customers-jobs-to-be-done) — The canonical HBR treatment of the Jobs to Be Done framework. Establishes that customers hire products to accomplish specific outcomes, not to consume features. The job-outcome table format in §2 (job + "success looks like") is a direct application.

--- a/strategy/build-vs-buy-framework.md
+++ b/strategy/build-vs-buy-framework.md
@@ -392,6 +392,8 @@ If the regret score is high: document what data would have changed the decision 
 
 **Decision:** Buy (Auth0). The startup weight on strategic differentiation (auth is not differentiated) and team velocity (3 months on auth is a startup-killer at this stage) makes this clear. The 12-month assumption: at $23K/year, Auth0 pricing is manageable; if the company grows to the tier requiring $150K+/year, evaluate Keycloak migration at that point.
 
+For an additional worked evaluation against the five dimensions in a sandbox context, see the observability stack decision in the demonstration sandbox.[^ll-observability]
+
 ---
 
 ## Further Reading
@@ -399,3 +401,5 @@ If the regret score is high: document what data would have changed the decision 
 - Christensen, Clayton M. *The Innovator's Dilemma.* Harvard Business Review Press, 1997. The original framework for distinguishing core, differentiating capability from commodity capability — foundational to the strategic differentiation dimension.
 - Fowler, Martin. "Make or Buy?" *martinfowler.com*, 2018. https://martinfowler.com/bliki/MakeOrBuy.html. A concise primary-source treatment of the decision from an architecture perspective; covers the false binary and introduces the concept of integration as its own cost category.
 - CNCF. *Cloud Native Computing Foundation Landscape.* https://landscape.cncf.io/. The authoritative map of the open-source ecosystem for infrastructure and platform categories — essential reference when evaluating the partner option for DevOps and data platform decisions.
+
+[^ll-observability]: **Demonstration sandbox** ([lifting-logbook](https://github.com/brownm09/lifting-logbook) — personal-project monorepo, not a production system at scale): [ADR-018: Observability Stack](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/docs/adr/ADR-018-observability-stack.md) (citation: commit `413f8a6`) contains an alternatives-considered section that evaluates Honeycomb, Datadog, Grafana Cloud, and self-hosted Tempo/Loki/Mimir against vendor lock-in tolerance, per-event pricing risk, operational burden, and TCO — a worked evaluation against four of this framework's five dimensions. The only dimension not scored explicitly is strategic differentiation (observability is not a competitive differentiator at any company scale, making that dimension trivially low and not contested). See [ORIGINS.md](../ORIGINS.md) for production-scale build-vs-buy decisions.


### PR DESCRIPTION
## Summary

Adds the second batch of lifting-logbook sandbox cross-references, per issue #23 and the LINKING.md "both conditions true" test:

- **`ci-cd/pipeline-governance-guide.md`** — full Further-reading block: ADR-001 (shared template model), `ci.yml` (required gates), `deploy.yml` (sequential promotion + OIDC secret management)
- **`leadership/prd-lifecycle.md`** — full Further-reading block: `docs/proposals/README.md` (state machine), `.claude/propose.json` (lifecycle tooling), `2026-05-08-on-call-readiness.md` (worked end-to-end proposal)
- **`leadership/ai-documentation-standards.md`** — full Further-reading block: ADR-016 (worked ADR with full References section), `.claude/propose.json` (workflow-level attribution via `Co-Authored-By` footer)
- **`strategy/build-vs-buy-framework.md`** — single footnote: ADR-018 alternatives-considered section as a worked five-dimension evaluation

All SHA-pinned links use commit `413f8a6` (lifting-logbook `origin/main`), consistent with the system-legibility playbook backfill in #22.

## Test plan

- [ ] All four modified files render correctly in Markdown preview (headers, blockquotes, footnote)
- [ ] SHA-pinned links resolve (known-good: same SHA used in system-legibility playbook)
- [ ] No sandbox link appears in body prose — all links in Further-reading blocks or footnote only
- [ ] Single sandbox callout per page (no duplicates)
- [ ] Footnote marker `[^ll-observability]` in build-vs-buy matches its definition at the bottom

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)