### PR TITLE
Add wave-1 engineering leadership gap artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Operational and leadership frameworks from production engineering work across pa
 
 ## Transitions & New Leader Toolkit
 
-Frameworks for the first 90–360 days in a new engineering leadership role. Start here.
+Frameworks for the first 90–360 days in a new engineering leadership role. Start here. (Additional docs — inheriting a team, reorg execution — are forthcoming in wave 2.)
 
 **[transitions/new-leader-30-60-90.md](transitions/new-leader-30-60-90.md)**
 Phased framework for an engineering leader joining a new org. Covers the listening tour (days 1–30), diagnosis and early action (days 31–60), and committing to a direction (days 61–90). Includes a 90-180-360 extension for larger orgs or turnaround situations, anti-patterns, and reusable templates for the listening tour 1:1 and the 90-day written assessment. Grounded in the ActBlue platform directorate ramp and the CTA technical leadership onboarding.
@@ -50,7 +50,7 @@ How to build or inherit a career ladder and run calibration. Covers IC vs. manag
 How to model HC needs, build the finance ask, and sequence hiring against roadmap risk. Covers the four capacity inputs, initiative-level modeling with worked examples, the one-page HC request format, backfill vs. new headcount criteria, common planning errors, and a 12-month rolling model template.
 
 **[people/one-on-one-coaching-framework.md](people/one-on-one-coaching-framework.md)**
-How to run 1:1s as a coaching instrument, not a status meeting. Covers agenda structure, note-taking discipline, and the coaching arc across four career stages: new hire, growing IC, senior/leveling out, and manager development. Includes the growth conversation framework, promotion readiness conversations, stretch assignment mechanics, the SBI feedback model, and the questions engineers won't raise unless asked directly. Grounded in three promoted engineers over three years, including two double-jump promotions.
+How to run 1:1s as a coaching instrument, not a status meeting. Covers agenda structure, note-taking discipline, and the coaching arc across four career stages: new hire, growing IC, senior/leveling out, and manager development. Includes the growth conversation framework, promotion readiness conversations, stretch assignment mechanics, the SBI feedback model, and the questions engineers won't raise unless asked directly. Grounded in five promotions across three engineers over three years.
 
 **[people/difficult-conversations-framework.md](people/difficult-conversations-framework.md)**
 How to prepare for and deliver the four most common difficult conversations in engineering management: underperformance (early-signal and pre-formal), role mismatch, team conflict, and leveling disagreements. Covers SBI structure, pre-conversation preparation, follow-through cadence, documentation discipline, and when to escalate to HR. Grounded in calibration advocacy and leveling dispute conversations at ActBlue.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ Operational and leadership frameworks from production engineering work across pa
 
 **[LINKING.md](LINKING.md)** documents the convention for cross-references to [lifting-logbook](https://github.com/brownm09/lifting-logbook) as a demonstration sandbox for frameworks where production experience is not the basis of the claim.
 
+## Transitions & New Leader Toolkit
+
+Frameworks for the first 90–360 days in a new engineering leadership role. Start here.
+
+**[transitions/new-leader-30-60-90.md](transitions/new-leader-30-60-90.md)**
+Phased framework for an engineering leader joining a new org. Covers the listening tour (days 1–30), diagnosis and early action (days 31–60), and committing to a direction (days 61–90). Includes a 90-180-360 extension for larger orgs or turnaround situations, anti-patterns, and reusable templates for the listening tour 1:1 and the 90-day written assessment. Grounded in the ActBlue platform directorate ramp and the CTA technical leadership onboarding.
+
+---
+
 ## Org Design & Strategy
 
 Frameworks for how a Director or Head of Engineering structures the organization, sets technical direction, and makes investment decisions.
@@ -25,17 +34,26 @@ Three-way decision framework (build / buy / partner) across five scored dimensio
 **[strategy/ma-technical-due-diligence.md](strategy/ma-technical-due-diligence.md)**
 Engineering assessment framework for acquisitions. Covers 8 domains (architecture, technical debt, security, team, operational maturity, data practices, IP/licensing, integration complexity) with artifacts to request, interview questions, and red/yellow flags per domain. Includes a 2-week diligence sprint structure and executive report format.
 
+**[strategy/technical-debt-prioritization.md](strategy/technical-debt-prioritization.md)**
+Framework for classifying, communicating, and sequencing technical debt work. Introduces a four-class model (load-bearing, risk, velocity, cosmetic) with guidance on translating each class into business language for roadmap conversations. Covers the debt inventory process, a 15–20% capacity reservation model, the refactor-alongside-feature pattern, and common failure modes including the infinite backlog and the big bang rewrite. Grounded in the PCI environment deprecation (30% codebase reduction, 7,000+ lines eliminated) and Heroku→Kubernetes migration at ActBlue.
+
 ---
 
 ## People Systems
 
-Frameworks for managing engineering talent: defining expectations clearly, running promotions fairly, and planning the headcount required to deliver on commitments.
+Frameworks for managing engineering talent: defining expectations clearly, running promotions fairly, having the difficult conversations, and planning the headcount required to deliver on commitments.
 
 **[people/career-ladder-calibration.md](people/career-ladder-calibration.md)**
 How to build or inherit a career ladder and run calibration. Covers IC vs. manager track design, a four-axis level definition format (impact scope, decision autonomy, execution, collaboration), full L3–Staff worked definitions, calibration session structure, the three failure modes (grade inflation, recency bias, proximity bias), and a documented appeals process.
 
 **[people/headcount-capacity-planning.md](people/headcount-capacity-planning.md)**
 How to model HC needs, build the finance ask, and sequence hiring against roadmap risk. Covers the four capacity inputs, initiative-level modeling with worked examples, the one-page HC request format, backfill vs. new headcount criteria, common planning errors, and a 12-month rolling model template.
+
+**[people/one-on-one-coaching-framework.md](people/one-on-one-coaching-framework.md)**
+How to run 1:1s as a coaching instrument, not a status meeting. Covers agenda structure, note-taking discipline, and the coaching arc across four career stages: new hire, growing IC, senior/leveling out, and manager development. Includes the growth conversation framework, promotion readiness conversations, stretch assignment mechanics, the SBI feedback model, and the questions engineers won't raise unless asked directly. Grounded in three promoted engineers over three years, including two double-jump promotions.
+
+**[people/difficult-conversations-framework.md](people/difficult-conversations-framework.md)**
+How to prepare for and deliver the four most common difficult conversations in engineering management: underperformance (early-signal and pre-formal), role mismatch, team conflict, and leveling disagreements. Covers SBI structure, pre-conversation preparation, follow-through cadence, documentation discipline, and when to escalate to HR. Grounded in calibration advocacy and leveling dispute conversations at ActBlue.
 
 ---
 
@@ -57,6 +75,9 @@ How engineering works with product, design, legal, finance, and sales. Covers de
 
 **[operating-cadence/escalation-framework.md](operating-cadence/escalation-framework.md)**
 When and how to escalate issues at the leadership layer (distinct from on-call escalation). Covers the three trigger categories (delivery risk, people risk, reputational/external risk), four escalation levels with response SLAs, the 5-sentence escalation memo format, and anti-patterns.
+
+**[operating-cadence/managing-up-across-playbook.md](operating-cadence/managing-up-across-playbook.md)**
+The mechanics of managing up (exec relationships, skip-level dynamics, absorb vs. escalate decisions, protecting team capacity) and managing across (peer manager relationships, cross-functional partnership with product/legal/finance, dependency navigation). Covers the trust account model, framing trade-offs for executive audiences, and when to escalate a cross-team issue vs. resolve it directly. Grounded in the PCI environment deprecation program, VP Engineering roadmap presentations, and sustained finance/legal alignment at ActBlue.
 
 ---
 

--- a/operating-cadence/managing-up-across-playbook.md
+++ b/operating-cadence/managing-up-across-playbook.md
@@ -8,7 +8,7 @@ Both relationships are skills. They have mechanics, failure modes, and a practic
 
 ## Background and Motivation
 
-This framework was developed from the cross-functional program work at ActBlue Technical Services (2022–2025), where I owned a multi-year PCI environment deprecation program that required sustained alignment across engineering, legal, finance, product, and account operations — and simultaneous management of a platform directorate with six teams and approximately fifty engineers. The challenges of managing up (maintaining executive visibility and trust through a multi-year program with shifting compliance deadlines) and across (coordinating four to five engineering teams, external audit timelines, and non-technical stakeholders with different incentives) were parallel and interdependent. Mismanaging either created cascading problems in the other.
+This framework was developed from the cross-functional program work at ActBlue Technical Services (2022–2025), where I owned a multi-year PCI environment deprecation program that required sustained alignment across engineering, legal, finance, product, and account operations — and simultaneous management of a platform directorate with six teams and approximately fifty engineers. The challenges of managing up (maintaining executive visibility and trust through a multi-year program with shifting compliance deadlines) and across (coordinating four to five of those teams on the PCI program directly, along with external audit timelines and non-technical stakeholders with different incentives) were parallel and interdependent. Mismanaging either created cascading problems in the other.
 
 ---
 
@@ -29,6 +29,8 @@ Three practices that build exec relationships reliably:
 1. **Lead with the conclusion.** Executives do not have time to reconstruct your reasoning. State the conclusion first, then offer the reasoning. "We should delay the migration by one quarter. Here's why: [two sentences]." Not: "So I've been looking at the migration timeline and there are a few factors to consider..."
 
 2. **Name trade-offs, not problems.** A problem requires someone else to solve it. A trade-off requires a decision. "The payment processor migration is on track, but accelerating it to meet Q2 creates risk to the fraud detection refactor in the same sprint. I can handle either, but not both at the original timeline. Which do you want me to protect?" This frames you as the person managing the tension, not surfacing it.
+
+   In practice: during the PCI deprecation at ActBlue, an external compliance deadline shifted six weeks mid-program. The framing to the VP of Engineering was not "the timeline changed" — it was: "We can hit the new compliance date, but it means the payment processor integration slips to Q3. The compliance date is non-negotiable from a regulatory standpoint; the integration date is a business decision. Which risk do you want me to protect?" That framing put the decision in the right hands and produced a resolution in the same conversation.
 
 3. **Give them something to say.** Your skip will talk about your team's work in contexts you are not in. Give them the two or three talking points that make your team's work legible to that audience. If they have to reconstruct your team's value proposition from memory, the version they communicate will not be the version you would choose.
 
@@ -103,6 +105,8 @@ Legal and compliance are often treated as obstacles. They are more accurately de
 The key insight: legal and compliance teams almost always have a workable path — they just need to understand what you are trying to do and why before they can help you find it. Going to them with a completed design and asking for approval is a losing approach. Going to them at the problem statement stage and asking "what constraints should we design around?" produces a very different conversation.
 
 For compliance-adjacent programs (PCI, GDPR, SOC 2): own the relationship, not just the deliverables. Know your compliance lead by name. Know their concerns and timeline pressures. When the audit is approaching, they should be calling you, not the other way around.
+
+In practice: during the PCI deprecation at ActBlue, rather than arriving at the compliance team with a completed scope reduction design and asking for sign-off, the conversation started with: "We are planning to decommission the legacy cardholder data environment. What constraints do we need to design around?" That question produced a requirement about data retention timing that would have required costly late-stage rework if surfaced at the approval stage instead of the design stage.
 
 ### Cross-Functional Partnership: Finance
 

--- a/operating-cadence/managing-up-across-playbook.md
+++ b/operating-cadence/managing-up-across-playbook.md
@@ -1,0 +1,150 @@
+# Managing Up and Across Playbook
+
+## Leadership Context
+
+Engineering leaders who are technically strong and operationally disciplined often stall at the senior manager or director level for one reason: they treat the relationships above and beside them as administrative overhead rather than as the actual work. Managing up is not politics — it is how you get your team the resources, air cover, and strategic alignment they need to operate. Managing across is not coordination — it is how you prevent your org from becoming a local optimization machine that creates drag for every team that depends on you.
+
+Both relationships are skills. They have mechanics, failure modes, and a practice regimen. This playbook covers both.
+
+## Background and Motivation
+
+This framework was developed from the cross-functional program work at ActBlue Technical Services (2022–2025), where I owned a multi-year PCI environment deprecation program that required sustained alignment across engineering, legal, finance, product, and account operations — and simultaneous management of a platform directorate with six teams and approximately fifty engineers. The challenges of managing up (maintaining executive visibility and trust through a multi-year program with shifting compliance deadlines) and across (coordinating four to five engineering teams, external audit timelines, and non-technical stakeholders with different incentives) were parallel and interdependent. Mismanaging either created cascading problems in the other.
+
+---
+
+## Part 1: Managing Up
+
+### The Trust Account Model
+
+Your relationship with your skip-level (the person above your manager) and with your manager is a trust account. You make deposits through: delivering on commitments, surfacing problems early rather than late, communicating clearly without over-engineering every message, and making their job easier. You make withdrawals every time they are surprised by something they should have known, every time they have to re-explain your team's work to someone else because they did not fully understand it, and every time a decision that should have stayed at your level lands on their desk.
+
+The goal is not a high balance — it is a steady deposit habit. Most of the withdrawals in a healthy relationship are small and expected. A single large surprise withdrawal can take months of deposits to recover from.
+
+### Building the Exec Relationship
+
+Do not wait for formal check-ins to build the relationship with your skip. The formal check-in is where you report on things; the relationship is built in the informal moments — a brief Slack message when something important lands, a 5-minute walk between meetings, a direct note after a difficult decision.
+
+Three practices that build exec relationships reliably:
+
+1. **Lead with the conclusion.** Executives do not have time to reconstruct your reasoning. State the conclusion first, then offer the reasoning. "We should delay the migration by one quarter. Here's why: [two sentences]." Not: "So I've been looking at the migration timeline and there are a few factors to consider..."
+
+2. **Name trade-offs, not problems.** A problem requires someone else to solve it. A trade-off requires a decision. "The payment processor migration is on track, but accelerating it to meet Q2 creates risk to the fraud detection refactor in the same sprint. I can handle either, but not both at the original timeline. Which do you want me to protect?" This frames you as the person managing the tension, not surfacing it.
+
+3. **Give them something to say.** Your skip will talk about your team's work in contexts you are not in. Give them the two or three talking points that make your team's work legible to that audience. If they have to reconstruct your team's value proposition from memory, the version they communicate will not be the version you would choose.
+
+### Skip-Level Relationships
+
+Your skip-level is not an ally or an authority — they are a stakeholder. Manage the relationship accordingly:
+
+- **Request time when you have something to bring**, not just to check in. Skips who routinely have 30-minute 1:1s with every sub-org leader will have those compressed or canceled. Come with a question, a decision that needs them, or an update that is genuinely useful to them.
+- **Do not go around your manager.** If you have a concern about your manager, address it with your manager first. Going directly to the skip without exhausting the direct conversation is a relationship withdrawal against both accounts simultaneously.
+- **Know their priorities.** What is the skip-level worried about right now? What is the board asking about? What metric are they under pressure on? Your team's work is more legible when it is framed in terms of what is already on their mind.
+
+### Absorb vs. Escalate
+
+Most decisions that could go up should not. The escalation test is: does this decision require authority, relationships, or information that I genuinely do not have? If yes, escalate. If it requires time, discomfort, or a hard trade-off that I am trying to avoid, do not escalate — absorb it.
+
+Common decisions that should be absorbed, not escalated:
+- Whether to delay a feature to address technical debt (you have the information to make this call)
+- Whether to extend a sprint due to unexpected complexity (same)
+- Personnel performance issues that are in early stages (handle them at your level until they require formal process)
+- Cross-team prioritization conflicts that you can resolve directly with the other manager
+
+Common decisions that warrant escalation:
+- A commitment that will be missed, when the miss affects a stakeholder relationship your manager owns
+- A personnel situation where HR process is required
+- A strategic trade-off where two or more senior leaders' priorities are in direct conflict and only someone above them can adjudicate
+- Any decision that, if wrong, would be irreversible and whose consequences extend beyond your scope
+
+When you escalate, escalate with a recommendation. "I don't know what to do here" is a request for your manager to do your job. "Here's what I recommend, here's the alternative, here's the risk of each, and here's my ask" is an escalation that respects their time and positions you correctly.
+
+### Protecting Your Team's Capacity
+
+One of the clearest signals of a leader who manages up well is that their team does not feel the chaos from above. Cross-functional requests, executive whims, and urgent-but-not-important asks arrive constantly. Your job is to be the filter.
+
+Practical mechanics:
+- **Run a weekly intake process.** New requests go into a queue rather than directly to the team. Review the queue weekly against the roadmap and capacity. Most of the urgent requests will have resolved themselves by the time you review them.
+- **Name the trade-off explicitly.** When a new request genuinely must be prioritized, do not just absorb it silently — communicate what moves. "We can take this on, but it means the fraud detection refactor moves to Q3. Is that the trade you want?" This keeps leadership accountable for the trade-offs they are implicitly making when they add scope.
+- **Do not let your team be the cushion.** Sprint extensions, weekend work, and heroics are sometimes necessary. They are never a substitute for adequate scope management at the leadership level.
+
+---
+
+## Part 2: Managing Across
+
+### The Peer Manager Relationship
+
+Your peer engineering managers are not competitors, but they are not automatically allies either. Peer relationships are built on reciprocity: you help them when they need it, you are honest with them when their work creates problems for you, and you do not go over or around them in a way that makes them look bad to their team.
+
+Common failure modes in peer manager relationships:
+- **Scope creep without negotiation.** Your team starts owning work that bleeds into another team's domain without an explicit conversation.
+- **Public disagreement.** Raising concerns about a peer's team or decisions in a forum where their team is present, rather than directly.
+- **Asymmetric information.** Being in a planning conversation that affects a peer's team without including them, then presenting the decision as fait accompli.
+
+Practices that maintain healthy peer relationships:
+- **Direct channels first.** If a peer's team creates a problem for yours, message the manager directly before raising it in a shared forum. This is almost always faster and preserves the relationship.
+- **Shared language for cross-team issues.** When two teams have a dependency or a conflict, agree on a shared framing before it goes to leadership. "Team A needs X from Team B by Y date for Z reason" is more useful than two competing stories about the same situation.
+- **Credit generously.** When cross-team work goes well, make the other manager's contribution visible to their manager and your shared skip. This costs you nothing and builds significant trust.
+
+### Cross-Functional Partnership: Product
+
+The engineering/product relationship is the most consequential cross-functional relationship in most tech orgs, and the most frequently damaged.
+
+The structural tension: product manages outcomes (what gets built and when), engineering manages execution (how and at what cost). In a healthy relationship, these two functions inform each other continuously. In an unhealthy one, product delivers requirements and engineering delivers dates, and both parties are surprised when neither is met.
+
+Mechanics that work:
+- **Joint roadmap ownership.** Engineering should have a seat in roadmap planning, not just roadmap review. The cost of a feature is not just the sprint points — it is the opportunity cost, the technical debt incurred, and the on-call implications. Engineering is the only party who can accurately represent those costs.
+- **Early technical input on specs.** When product is writing a PRD, engineering input during the spec phase (not after) prevents the "we built the wrong thing" problem. A two-hour technical consultation at spec time is worth ten sprint days of rework.
+- **No surprises on timeline.** When a commitment is at risk, tell the product manager before it slips, not after. The earlier the warning, the more options they have to adjust scope, timeline, or priority.
+
+### Cross-Functional Partnership: Legal and Compliance
+
+Legal and compliance are often treated as obstacles. They are more accurately described as early-warning systems who have organizational authority to block things and prefer not to.
+
+The key insight: legal and compliance teams almost always have a workable path — they just need to understand what you are trying to do and why before they can help you find it. Going to them with a completed design and asking for approval is a losing approach. Going to them at the problem statement stage and asking "what constraints should we design around?" produces a very different conversation.
+
+For compliance-adjacent programs (PCI, GDPR, SOC 2): own the relationship, not just the deliverables. Know your compliance lead by name. Know their concerns and timeline pressures. When the audit is approaching, they should be calling you, not the other way around.
+
+### Cross-Functional Partnership: Finance
+
+Finance cares about two things: accuracy and surprise avoidance. Your job in the finance relationship is to give them accurate numbers and early warning when those numbers are changing.
+
+The headcount request, the infrastructure cost estimate, and the vendor contract renewal are all documents that finance will scrutinize. The ones that survive scrutiny have: a clear business case (what problem does this solve), a cost model (not just the sticker price, but the total cost of the decision), and a plan for what happens if the approved number is not available.
+
+Do not go to finance with a number you made up and hope they do not ask questions. They will ask questions. Go with a range, a methodology, and an acknowledgment of the assumptions baked in.
+
+### Dependency Navigation
+
+When your team has a dependency on another team (or another team has a dependency on yours), the default failure mode is that both teams treat the dependency as the other team's problem. The dependency sits unresolved until it blocks someone, at which point both teams are surprised and resentful.
+
+The practice:
+- **Name the dependency in writing at the time it is created.** Who owns what, by when, and what blocks it. Not in a meeting — in a RAID log, a ticket, or a shared document that both managers can see.
+- **Weekly dependency check.** During whatever stand-up or sync runs across the teams, explicitly review blockers and dependencies. Treat an unresolved dependency as a blocker, not a nice-to-have follow-up.
+- **Escalate early, not late.** If a dependency is not moving and the deadline is real, escalate before the deadline — not after it. The earlier the escalation, the more options exist for resolution.
+
+### When to Escalate a Cross-Team Issue vs. Solve It Yourself
+
+Escalate when:
+- The other manager and you have reached an impasse and the decision requires authority above both of you
+- The timeline impact of the unresolved issue will affect a commitment that leadership owns
+- The issue involves a resource or priority that two orgs are competing for and only one person can adjudicate
+
+Solve it yourself when:
+- You have not yet tried a direct conversation with the peer manager
+- The issue can be resolved by changing scope, timeline, or priority at the team level without affecting shared commitments
+- Escalation would involve burning relationship capital with shared leadership for a problem that is solvable locally
+
+Most cross-team issues that get escalated did not need to be. Most that were never escalated needed to be.
+
+---
+
+## Anti-Patterns
+
+**The Status Theater Update.** Sending detailed weekly updates to your manager that communicate a lot of information and very little understanding. Updates should be curated: here is what matters, here is what changed, here is what I need.
+
+**Managing Down Instead of Up.** Spending all available energy on team-facing work and treating the exec relationship as secondary. This is comfortable and feels productive; it is also a cap on how much your team can accomplish, because the resourcing, prioritization, and air cover they need comes from the relationship you are not investing in.
+
+**The Peer Escalation Bypass.** Going to your shared manager about a peer's team before trying to resolve it directly. Even if your concern is valid, this approach damages the peer relationship and signals to leadership that you cannot handle lateral problems.
+
+**Alignment Theater.** Scheduling cross-functional syncs that do not surface the real tensions. The real tensions get resolved in the hallway (or Slack) by the people who are actually willing to name them, and the sync becomes a performance of alignment. Run syncs where the agenda explicitly includes: what is blocking us, what do we disagree about, what needs a decision.
+
+**The Invisible Trade-Off.** Absorbing a cross-functional request without naming what moved to accommodate it. When you absorb scope silently, you give leadership no information about the cost, and the same pattern repeats. Name the trade-off every time.

--- a/people/career-ladder-calibration.md
+++ b/people/career-ladder-calibration.md
@@ -8,7 +8,7 @@ The business outcome is straightforward: equitable promotion decisions reduce re
 
 ## Background and Motivation
 
-This playbook was developed from the talent development work at ActBlue Technical Services (2022–2025). I drove three engineer promotions within three years through deliberate project placement, calibration preparation, and sustained advocacy — two from SE2 to SSE2 (a double promotion) and one from SSE to SSE2. I also founded and ran the Engineering Management Community of Practice, which systematized calibration coaching, talent development, and recruiting partnership across the manager group.
+This playbook was developed from the talent development work at ActBlue Technical Services (2022–2025). I drove five engineer promotions across three engineers within three years through deliberate project placement, calibration preparation, and sustained advocacy — two engineers who advanced from SE2 to SSE2 through back-to-back promotions (SE2→SSE1→SSE2), and one from SSE1 to SSE2. I also founded and ran the Engineering Management Community of Practice, which systematized calibration coaching, talent development, and recruiting partnership across the manager group.
 
 ## When to Use This
 

--- a/people/difficult-conversations-framework.md
+++ b/people/difficult-conversations-framework.md
@@ -36,6 +36,8 @@ Example: "In the all-hands on Thursday [situation], you responded to [product ma
 
 The SBI structure makes it harder to argue with the observation and easier to focus the conversation on the impact and the path forward.
 
+SBI is also the feedback model used in regular 1:1s — see the [1:1 Coaching Framework](one-on-one-coaching-framework.md) for how it integrates into the weekly feedback cadence rather than high-stakes conversations only.
+
 ### When Not to Have the Conversation
 
 **Do not have a difficult conversation:**
@@ -98,6 +100,8 @@ Team conflict between two engineers, or between an engineer and another team, is
 - Treating the conversation as the end. A behavioral agreement reached in one conversation needs follow-through — check in on whether the agreement is holding.
 
 ### Leveling Disagreements / Calibration
+
+The calibration session structure, level definition format, and failure modes (grade inflation, recency bias, proximity bias) are covered in [career-ladder-calibration.md](career-ladder-calibration.md). This section covers the conversation practice that operates within that process.
 
 Leveling disagreements are difficult because they combine two elements that rarely go well together: a consequential decision (compensation, title, promotion) and a subjective assessment that the person being assessed almost always sees differently than the assessor.
 

--- a/people/difficult-conversations-framework.md
+++ b/people/difficult-conversations-framework.md
@@ -1,0 +1,160 @@
+# Difficult Conversations Framework
+
+## Leadership Context
+
+A manager who avoids difficult conversations is not being kind — they are being negligent. The engineer who is underperforming and never told clearly is not given the opportunity to improve. The team watching the performance problem go unaddressed concludes that the manager will not hold standards. The high performer who shares a team with someone carrying a performance gap experiences that gap as an unfairness, and eventually leaves. The avoidance that felt like compassion produces the worst outcomes for everyone involved.
+
+This playbook covers the mechanics of the four most common difficult conversations in engineering management: underperformance, role mismatch, team conflict, and leveling disagreements. It does not cover HR process — that is jurisdiction-specific and owned by your People team. It covers the conversation that has to happen before the process does.
+
+## Background and Motivation
+
+The most direct context for this framework is calibration and career development work at ActBlue Technical Services (2022–2025): three engineer promotions over three years, including two where the conversation required sustained advocacy against calibration pressure, and one where the conversation required honesty about a leveling dispute that the engineer did not initially agree with. The latter involved naming clearly, and with evidence, the gap between the engineer's self-assessment and the calibration panel's read. That conversation was uncomfortable and necessary; the alternative — deferring the feedback to avoid the discomfort — would have produced a delayed and more damaging version of the same conversation at the next cycle.
+
+---
+
+## Part 1: Before the Conversation
+
+### Three Things to Clarify First
+
+Every difficult conversation should have answers to three questions before you schedule it:
+
+1. **What specific behavior or situation are you addressing?** Not the label ("your performance is declining") — the evidence. "In the last three sprints, two commitments were missed without early warning, and the code review feedback I gave in [specific PR] has not been reflected in the subsequent work." The more specific the evidence, the less room for misinterpretation and the less room for a defensive pivot to "that's just your opinion."
+
+2. **What do you want to be different after this conversation?** A conversation without a change goal is a complaint, not a feedback session. The goal might be a behavior change ("I want you to surface blockers by Thursday of each sprint week, not in the Monday retrospective"), a role adjustment, or a shared acknowledgment that a problem exists. Name it before you enter the room.
+
+3. **What does the person in this conversation need from you?** Not agreement — but to feel heard and to understand what the path forward looks like. A conversation that leaves the engineer confused about what happens next, or what success looks like, has not landed.
+
+### SBI: Situation, Behavior, Impact
+
+Use SBI as the structure for delivering the core observation:
+
+- **Situation:** When and where? Specific enough to be incontestable.
+- **Behavior:** What was observed? Behavior only — not intent, not inference, not character.
+- **Impact:** What was the effect on the team, the system, or the relationship?
+
+Example: "In the all-hands on Thursday [situation], you responded to [product manager]'s question about the timeline by saying 'that's not how software works' and ending the conversation [behavior]. She came to me afterward and said she felt dismissed and was not sure the team was invested in the launch [impact]."
+
+The SBI structure makes it harder to argue with the observation and easier to focus the conversation on the impact and the path forward.
+
+### When Not to Have the Conversation
+
+**Do not have a difficult conversation:**
+- In the heat of the moment (your own or theirs). If you are activated, wait.
+- In public or in a group setting. Feedback that involves performance or behavior belongs in a private 1:1.
+- When you do not have enough evidence. One incident is an observation; a pattern is a conversation. If you have one data point, name it as an observation in the next 1:1, not as a performance issue.
+- When the timing creates an unfair context (end of a high-stress sprint, day of an incident, during a personal crisis you know about). The conversation will not land and you will need to have it again.
+
+---
+
+## Part 2: Conversation Types
+
+### Underperformance
+
+**The two modes:** Early-signal underperformance is handled in 1:1s, directly and informally, before it becomes a formal situation. Formal underperformance (a Performance Improvement Plan or equivalent) is a last resort with HR involvement, a documented plan, and a defined evaluation window. The conversation in this playbook covers early-signal — the moment you recognize a problem and before it becomes formal.
+
+**The structure:**
+
+1. **Name the pattern clearly.** "I want to talk about something I have been seeing over the last [timeframe]. [SBI description of the pattern.]"
+2. **Check your read.** "Is there something going on that I don't have context on?" This is not a rhetorical question. There are legitimate reasons for performance dips — burnout, personal circumstances, unclear expectations — and understanding the cause changes the conversation.
+3. **Name the stakes.** "If this continues through [next cycle/sprint/quarter], it will affect your standing in calibration. I do not want that outcome — that is why we are having this conversation now." Be direct about the stakes. Engineers who find out at calibration that a performance problem was visible for months without being named to them have a legitimate grievance.
+4. **Agree on next steps.** Specific, measurable, time-bounded. "By [date], I want to see [specific behavior change]." Write it down. The shared 1:1 doc is the right place.
+5. **Follow up at the agreed interval.** Not at the performance cycle — at the timeframe you named. Feedback that is not followed up on is not taken seriously.
+
+**Common mistakes:**
+- Softening the message so much that the engineer does not understand there is a problem ("I just wanted to check in on how things are going")
+- Naming the problem but not the stakes ("just something to think about")
+- Having the conversation once and considering it handled
+
+### Role Mismatch
+
+Role mismatch is distinct from underperformance: the engineer may be doing their current job adequately, but the job has changed (or is changing) in a direction that does not match their skills, interests, or trajectory. The conversation is about fit, not performance.
+
+Common scenarios:
+- A team's technical complexity has grown beyond what an engineer can follow with their current skill level
+- A role that started as individual contribution has shifted to require significant cross-team coordination the engineer is not suited for
+- An engineer who was hired for one kind of work is consistently gravitating toward different work, suggesting a genuine mismatch of the role to the person
+
+**The structure:**
+
+1. **Name the gap without blame.** "I want to talk about the direction this role is evolving and whether it is the right fit for where you want to go." This framing puts the conversation on trajectory, not fault.
+2. **Share your read.** "What I am seeing is [specific observation about the gap]. I want to understand whether that matches your experience."
+3. **Explore options.** A role mismatch does not have one resolution. Options include: adjusting the role to better fit the person (if the work allows it), finding a different internal role, and an honest conversation about whether the org is the right fit at all. The engineer should participate in identifying the path.
+4. **Do not force the conclusion.** This conversation rarely resolves in one meeting. Give the engineer time to process and come back with their read.
+
+### Team Conflict
+
+Team conflict between two engineers, or between an engineer and another team, is among the most difficult conversations because it often involves competing valid perspectives. The manager's job is not to adjudicate who is right — it is to restore the conditions for collaborative work.
+
+**The structure for a peer conflict:**
+
+1. **Have separate conversations first.** Talk to each party individually before bringing them together. Understand each person's experience of the conflict before trying to resolve it. Do not share what one person said with the other in a way that escalates the conflict.
+2. **Name the behavior, not the person.** "I have heard [specific behavior that is creating friction]" rather than "I have heard you are difficult to work with."
+3. **Name the impact on the team.** "The current situation is affecting [sprint velocity / code review culture / the team's ability to collaborate on X]. That is the problem I need to solve."
+4. **Bring the parties together with a specific agenda.** Not "let's talk about the conflict" — "I want to agree on how we are going to handle [specific recurring situation] going forward." The conversation should produce a behavioral agreement, not a feelings resolution.
+
+**What managers get wrong in team conflict:**
+- Picking a side. Even if one person is clearly more at fault, declaring a winner creates a permanent alliance and opposition within the team.
+- Waiting too long. A team conflict that is visible to the rest of the team and is not being addressed will be interpreted as management tolerance of the behavior.
+- Treating the conversation as the end. A behavioral agreement reached in one conversation needs follow-through — check in on whether the agreement is holding.
+
+### Leveling Disagreements / Calibration
+
+Leveling disagreements are difficult because they combine two elements that rarely go well together: a consequential decision (compensation, title, promotion) and a subjective assessment that the person being assessed almost always sees differently than the assessor.
+
+**Before calibration:**
+The most effective leveling conversation is the one that happens before calibration, not after. If an engineer believes they are at the next level and calibration is likely to disagree, have the conversation in advance:
+
+1. **Share your read, with evidence.** "I want to give you my honest read on where I think calibration will land this cycle, and why." Then share the specific evidence for why you believe the next level has or has not been demonstrated.
+2. **Give the engineer's case a hearing.** "Walk me through how you see it." Listen — not to be persuaded against evidence, but to understand whether there is evidence you have missed.
+3. **Name the gap specifically.** If the disagreement is real, be direct: "The gap I see is [specific]. Here is what addressing it would look like. I think it is closable, and I want to work with you on it."
+
+**After calibration:**
+If calibration produces an outcome the engineer disagrees with, the conversation requires the manager to hold two things at once: advocacy for the engineer (you can share what you argued for) and honesty about the calibration outcome (you cannot pretend the decision was wrong when you will need the engineer to trust the process next cycle).
+
+Do not:
+- Promise a different result next cycle without evidence that the gap will close
+- Attribute the outcome to external factors (the panel, the process) in a way that exonerates you from the conversation
+- Avoid the conversation and let the engineer find out from the announcement
+
+---
+
+## Part 3: Follow-Through
+
+### The Check-In Cadence
+
+A difficult conversation that is not followed up on is worse than no conversation. It signals that the named expectation was not real. The follow-up schedule:
+
+- **Underperformance:** at the specific timeframe named in the conversation (two weeks, one sprint, one month)
+- **Role mismatch:** at four weeks, to see how the engineer has processed the conversation and whether they have a path in mind
+- **Team conflict:** one week after the behavioral agreement, then monthly for a quarter
+- **Leveling disagreements:** at the next significant milestone (mid-cycle, pre-calibration)
+
+### Documentation Discipline
+
+Document the conversation in the 1:1 shared doc — not in exhaustive detail, but enough to create a record of what was said and what was agreed. For underperformance situations: record the specific behavioral expectation and the timeline. This documentation protects both parties: it gives the engineer a clear record of what was asked of them, and it gives the manager a record of the conversation if formal process becomes necessary later.
+
+Do not document in a way that feels punitive or that the engineer cannot see. If something goes in the 1:1 doc, assume the engineer will read it — because they should.
+
+### When to Escalate to HR
+
+Escalate to HR when:
+- A formal PIP or equivalent process is warranted (persistent underperformance that has not responded to coaching)
+- The conversation involves a complaint of discrimination, harassment, or hostile work environment
+- You have a conflict of interest in the situation (a relationship, a personal history, or a financial stake)
+- The outcome of the conversation may involve a role change, demotion, or separation
+
+HR escalation is not a failure — it is the right level of support for decisions with significant consequence. The mistake is escalating too late, after the situation has become a crisis, rather than involving HR early as a thought partner.
+
+---
+
+## Anti-Patterns
+
+**The Compliment Sandwich.** Positive feedback → difficult feedback → positive feedback. The difficult feedback gets lost. Name it directly: "I want to talk about something specific."
+
+**The Group Feedback.** Addressing individual behavior in a team setting to avoid a direct conversation. This is public humiliation with plausible deniability.
+
+**The Proxy Conversation.** Having the conversation through someone else — another manager, HR, a trusted colleague. The person who owns the relationship owns the conversation.
+
+**The One-And-Done.** Having the conversation once and considering the matter closed. Behavior change takes time and follow-through. A single conversation without follow-up produces at best a temporary adjustment and at worst the impression that you were not serious.
+
+**The Future-Tense Softening.** "You might want to think about..." or "it could be worth considering..." These phrasings are not feedback. They are suggestions the engineer can safely ignore, because they carry no observable expectation.

--- a/people/one-on-one-coaching-framework.md
+++ b/people/one-on-one-coaching-framework.md
@@ -4,7 +4,7 @@
 
 The 1:1 is the primary instrument of engineering management. Everything else — performance reviews, promotion calibration, team culture — is downstream of what happens in this meeting. A 1:1 that is used as a status update is an opportunity wasted. A 1:1 where the manager does most of the talking is not a 1:1 — it is a monologue. Done well, the weekly 1:1 is the mechanism through which you understand what is actually blocking an engineer, build the trust needed to give and receive difficult feedback, and create the growth conditions that lead to promotion, retention, and a team that can execute without you.
 
-This framework covers format, cadence, and the coaching arc across career stages. It is grounded in a practice of three promoted engineers over three years — two SE2→SSE2 double-jumps and one SSE→SSE2 — where the 1:1 was the primary vehicle for growth visibility, stretch assignment identification, and calibration preparation.
+This framework covers format, cadence, and the coaching arc across career stages. It is grounded in five promotions across three engineers over three years — two who advanced from SE2 to SSE2 through back-to-back promotions (SE2→SSE1→SSE2), and one from SSE1 to SSE2 — where the 1:1 was the primary vehicle for growth visibility, stretch assignment identification, and calibration preparation.
 
 ## Background and Motivation
 
@@ -85,7 +85,7 @@ If you have managers reporting to you, the 1:1 format shifts. Your job is no lon
 Focus areas:
 - **Their team's health, not just their team's output.** Is the on-call load distributed fairly? Are there performance situations being avoided? Is there a high performer at flight risk?
 - **Their growth as a manager.** Where is their practice strong? Where is it uneven? Give them the same behavior-specific feedback you give engineers, applied to management behaviors.
-- **Calibration support.** Before a calibration cycle, align with each manager on the evidence for their team members who are being discussed. Do not let calibration be the first time you understand their read on an engineer.
+- **Calibration support.** Before a calibration cycle, align with each manager on the evidence for their team members who are being discussed. Do not let calibration be the first time you understand their read on an engineer. For the full calibration session structure and level definition framework that backs these conversations, see [career-ladder-calibration.md](career-ladder-calibration.md).
 
 ---
 
@@ -134,6 +134,8 @@ Feedback without specificity is noise. The SBI framework makes feedback actionab
 Example: "In last week's sprint planning [situation], you pushed back on the scope reduction without offering an alternative [behavior]. It put [product manager] in the position of having to defend a decision with no room to negotiate, and she came to me to ask whether you were aligned with the roadmap [impact]. I want to talk about how we can give you more of a voice in planning in a way that doesn't put her on the defensive."
 
 This is different from: "You can come across as difficult in planning meetings." That observation is not actionable and invites defensiveness.
+
+SBI is also the structure for difficult conversations when the early-signal approach here is not resolving a situation — see the [Difficult Conversations Framework](difficult-conversations-framework.md) for underperformance, role mismatch, team conflict, and leveling disagreements.
 
 ### Feedback Cadence
 

--- a/people/one-on-one-coaching-framework.md
+++ b/people/one-on-one-coaching-framework.md
@@ -1,0 +1,172 @@
+# 1:1 Structure and Coaching Framework
+
+## Leadership Context
+
+The 1:1 is the primary instrument of engineering management. Everything else — performance reviews, promotion calibration, team culture — is downstream of what happens in this meeting. A 1:1 that is used as a status update is an opportunity wasted. A 1:1 where the manager does most of the talking is not a 1:1 — it is a monologue. Done well, the weekly 1:1 is the mechanism through which you understand what is actually blocking an engineer, build the trust needed to give and receive difficult feedback, and create the growth conditions that lead to promotion, retention, and a team that can execute without you.
+
+This framework covers format, cadence, and the coaching arc across career stages. It is grounded in a practice of three promoted engineers over three years — two SE2→SSE2 double-jumps and one SSE→SSE2 — where the 1:1 was the primary vehicle for growth visibility, stretch assignment identification, and calibration preparation.
+
+## Background and Motivation
+
+The promotion outcomes at ActBlue Technical Services (2022–2025) were not accidents. They were the product of consistent 1:1 practice: asking the same growth-oriented questions over multiple quarters until the answers changed, identifying the specific gap between a person's current scope and the next level's definition, and then engineering the project placements that would close those gaps. Calibration is retrospective — you can only promote someone for the work they have already done, which means the work has to exist first. The 1:1 is where you figure out what work needs to exist.
+
+---
+
+## Part 1: The 1:1 Format
+
+### Cadence
+
+Weekly for all direct reports. No exceptions for strong performers, senior ICs, or people who say they do not need it. The moment you make 1:1s optional is the moment they start getting canceled — and the people most likely to deprioritize them are the ones who most need the sustained attention.
+
+Thirty minutes per week is the floor. Fifty minutes is useful for engineers in growth conversations or performance situations. The meeting length is less important than the consistency.
+
+If your schedule genuinely cannot accommodate weekly 1:1s for every direct report, you have too many direct reports. The widely cited maximum for effective EM spans is six to eight; above eight, the 1:1 cadence is the first thing that degrades.
+
+### Agenda Structure
+
+The meeting belongs to them, not to you. The agenda is theirs to set. Your job is to hold the space, ask better questions, and bring observations from outside the room (calibration context, cross-team feedback, organizational signals they may not have access to).
+
+A reliable default structure for a 30-minute 1:1:
+
+- **Their agenda first (15 min).** What do they want to cover? This should be driven by a shared async doc where they can drop topics before the meeting. If they have nothing, that is a signal — not an excuse to skip the meeting.
+- **Your observations (10 min).** What have you seen that they should know? This is where feedback lives — not as a surprise performance review item, but as a regular practice of naming what you are noticing.
+- **Career context (5 min).** Not every week, but on some cadence: where are they going, what are they learning, what is blocking their growth?
+
+### Note-Taking Discipline
+
+Keep a shared document for each direct report. Both of you can add to it. The manager's entries should capture: decisions made, commitments recorded, feedback given, and questions to return to. The engineer's entries should capture: what they want help with, what is blocking them, what they are thinking about.
+
+The document has two functions: it prevents "we discussed this" from becoming a debate about memory, and it is the source material for performance reviews. If you cannot point to entries in the 1:1 doc, the review has no evidence base.
+
+---
+
+## Part 2: The Coaching Arc by Career Stage
+
+### New Hire (0–6 Months)
+
+The primary 1:1 function during onboarding is calibration and trust-building. A new engineer is simultaneously learning the codebase, the team's working norms, and what their manager is like. Your job is to make the last of these as clear as possible, as early as possible.
+
+Focus areas:
+
+- **Early wins and confidence.** The first few 1:1s should identify the places where the engineer can demonstrate their skills and get early, visible wins. Not softball — real work that matters. Stretch without overwhelm.
+- **Navigating the org.** New engineers often do not know who to talk to, what questions are safe to ask, or where the informal decision authority lives. The 1:1 is where you give them the map.
+- **Early performance feedback.** Do not wait for the 90-day review. Give specific, behavior-based feedback in the first month. "You did X in the code review this week; here's what that communicated to the team." This establishes feedback as a normal part of the relationship, not a warning signal.
+
+Common mistakes with new hires:
+- Assuming they are fine because they are not complaining
+- Overloading them with context in the 1:1 instead of letting them set the agenda
+- Skipping 1:1s because "they're still onboarding"
+
+### Growing IC (6 Months to Staff Trajectory)
+
+Once an engineer has their bearings, the 1:1 becomes the primary growth mechanism. The coach's job is to close the gap between where the engineer is now and where they need to be for the next level — and to do this through project placement and deliberate skill building, not just through encouragement.
+
+The growth conversation framework for this stage:
+
+1. **What is the next level asking for?** Be specific about the career ladder definition. If the ladder says "owns a project independently from scoping through delivery," what does that mean in your specific context? Name the work, not just the description.
+2. **Where are they now relative to that bar?** Calibrate against evidence, not impressions. "You consistently write clear proposals, but the last two projects needed more scope negotiation with product — that's the gap." Vague feedback ("you're close") is not useful.
+3. **What project or context would close the gap?** This is the key move. Do not tell an engineer to "get more cross-team experience" without engineering a specific opportunity for it. The 1:1 is where you connect the growth goal to the next sprint cycle or the next planning round.
+
+Repeat this framework every quarter, not just at performance review time. Growth conversations that happen only at review time are retrospective. Growth conversations that happen continuously are developmental.
+
+### Senior / Leveling Out
+
+Senior engineers who are not on a Staff trajectory are often under-managed because they "don't need it." What they actually need is different from what earlier-career engineers need: less tactical coaching, more strategic challenge.
+
+Focus areas for senior engineers:
+- **Technical direction input.** Include them in architectural conversations and decisions above their scope. Not as a courtesy — because their perspective should change the decision.
+- **Informal leadership development.** Give them opportunities to run design reviews, mentor more junior engineers, or own a cross-team initiative. This both develops them and multiplies your team's capacity.
+- **Honest career conversations.** If a senior engineer has leveled out at Senior — meaning the gap to Staff is real and not closing — be honest about it. A manager who strings an engineer along with vague promotion signals is doing damage that shows up as a regrettable attrition event 18 months later.
+
+### Manager Development
+
+If you have managers reporting to you, the 1:1 format shifts. Your job is no longer to coach individual IC performance — it is to develop your managers' ability to run their teams. The 1:1 becomes a coaching-of-coaching conversation.
+
+Focus areas:
+- **Their team's health, not just their team's output.** Is the on-call load distributed fairly? Are there performance situations being avoided? Is there a high performer at flight risk?
+- **Their growth as a manager.** Where is their practice strong? Where is it uneven? Give them the same behavior-specific feedback you give engineers, applied to management behaviors.
+- **Calibration support.** Before a calibration cycle, align with each manager on the evidence for their team members who are being discussed. Do not let calibration be the first time you understand their read on an engineer.
+
+---
+
+## Part 3: Career Development Conversations
+
+### The Growth Conversation Framework
+
+Run a dedicated career conversation once per quarter — not instead of the weekly 1:1, but as a distinct meeting or an extended check-in. The agenda:
+
+1. **Where do you want to be in two years?** If you have not asked this recently, the answer may have changed.
+2. **What is the work that will get you there?** Get specific about projects, not skills in the abstract.
+3. **What is blocking you from that work?** Often: time (they are too underwater in sprint work to take on stretch work), visibility (nobody outside the team knows they can do it), or confidence (they do not believe they are ready).
+4. **What can I do to help?** The answer here is your to-do list.
+
+### Promotion Readiness Conversations
+
+A promotion conversation should not be a surprise to either party. Run a "promotion readiness" check-in every half — or every quarter if the engineer is on a fast trajectory. The check-in covers:
+
+- Are you doing the work at the next level? (Evidence required — name the projects.)
+- Is that work visible to the right people? (Calibration requires others to confirm the level, not just you.)
+- What is the remaining gap, if any? (Be honest. If the gap is real, name it and plan around it.)
+
+When the answer to all three is yes, the conversation becomes: "I am going to advocate for your promotion in the next cycle. Here is how calibration works, here is who will be in the room, and here is what they will need to see."
+
+### Stretch Assignments
+
+A stretch assignment is work that is visibly above the engineer's current level, where success is plausible but not guaranteed. The "plausible but not guaranteed" part is important: too easy and it is not a stretch, too hard and it becomes a failure experience that sets back confidence.
+
+The manager's job in a stretch assignment:
+- **Scope it correctly.** Not the whole initiative — a specific, time-bounded piece with clear success criteria.
+- **Provide scaffolding without rescue.** Check in more frequently, offer to be a thought partner, review proposals before they go to the broader team. But let them drive.
+- **Name it explicitly.** "This is a stretch for you, and I am giving it to you because I think you can handle it. Let's talk about what success looks like." Engineers who know they are being stretched approach the work differently than engineers who think it is just a normal assignment.
+
+---
+
+## Part 4: Feedback That Lands
+
+### SBI: Situation, Behavior, Impact
+
+Feedback without specificity is noise. The SBI framework makes feedback actionable:
+
+- **Situation:** When and where did this happen? (Specific, not "you always...")
+- **Behavior:** What did you observe? (Observable behavior, not an inference about intent)
+- **Impact:** What was the effect on the team, the system, the relationship?
+
+Example: "In last week's sprint planning [situation], you pushed back on the scope reduction without offering an alternative [behavior]. It put [product manager] in the position of having to defend a decision with no room to negotiate, and she came to me to ask whether you were aligned with the roadmap [impact]. I want to talk about how we can give you more of a voice in planning in a way that doesn't put her on the defensive."
+
+This is different from: "You can come across as difficult in planning meetings." That observation is not actionable and invites defensiveness.
+
+### Feedback Cadence
+
+Feedback should be:
+- **Frequent.** Not monthly, and not only at performance review time. Weekly observations, weekly feedback. Small doses are easier to absorb and act on than an accumulated dump at review time.
+- **Close to the behavior.** Feedback about something that happened three weeks ago is harder to connect to the behavior and easier to argue with. Give it within a week of the observation.
+- **Two-directional.** Ask for feedback in your 1:1s. Not as a formality — as a genuine practice. "What is one thing I could do differently to be more useful to you this quarter?" If you never get critical feedback from your engineers, you are not safe to give it to.
+
+### The Feedback They Won't Give You
+
+Engineers often do not tell their managers when:
+- They are bored and close to disengaged
+- They are overwhelmed and close to burning out
+- They have a job offer and are evaluating whether to take it
+- They feel that a decision was wrong and they have stopped raising it because it was not listened to before
+
+You cannot wait for them to volunteer this. Ask directly:
+- "On a scale of one to ten, how energized are you by your current work? What would make it an eight?"
+- "What part of your job right now is the most draining?"
+- "Is there a decision I or the team made in the last quarter that you disagreed with but didn't push back on?"
+
+These questions will feel uncomfortable the first few times. Ask them anyway.
+
+---
+
+## Anti-Patterns
+
+**The Status Meeting.** The engineer walks through their sprint tickets for 25 minutes, the manager nods and makes notes. This is not a 1:1. This is a standup that was scheduled for the wrong calendar.
+
+**The Positive Feedback Spiral.** The manager only gives reinforcing feedback because difficult feedback feels risky. The engineer gets the impression they are doing great; the calibration cycle produces a different result; the trust built in twelve months of 1:1s is damaged in one conversation.
+
+**The One-Sided Career Plan.** The manager identifies what they think the engineer should work on and tells them. The engineer was thinking about a completely different direction and is now managing their manager's expectations rather than their own growth.
+
+**Frequency Collapse.** 1:1s go biweekly, then monthly, then "we should reschedule that." By the time the manager re-establishes the rhythm, the relationship context needed for a difficult feedback conversation or a growth conversation is gone.
+
+**The Rescue Reflex.** The engineer is struggling with a stretch assignment and the manager steps in and solves it. The stretch is no longer a stretch — it is now a demonstration that the engineer is not ready. Let them struggle longer than is comfortable. Offer scaffolding, not rescue.

--- a/strategy/technical-debt-prioritization.md
+++ b/strategy/technical-debt-prioritization.md
@@ -1,0 +1,158 @@
+# Technical Debt Prioritization Framework
+
+## Leadership Context
+
+Technical debt is not a moral failure — it is the accumulated cost of every speed trade-off ever made, including the ones that were correct at the time. The problem is not that it exists; it is that most engineering organizations have no systematic way to reason about which debt matters, in what order to address it, and how to argue for the time to do so in a roadmap context dominated by feature delivery.
+
+Leaders who treat debt as a single category make two predictable errors: they either argue for a dedicated cleanup quarter that never arrives, or they absorb it silently until it becomes a reliability crisis. Neither outcome is acceptable. This framework covers classification, visibility, and sequencing — the three things you need to talk about technical debt in a way that actually changes what gets prioritized.
+
+## Background and Motivation
+
+This framework was developed from two specific programs at ActBlue Technical Services (2022–2025). The first was a multi-year PCI environment deprecation initiative that reduced the active codebase by approximately 30% — 7,000+ lines of code eliminated and 2,600+ accounts migrated — while maintaining payment continuity on a system handling 1M+ transactions per day. The second was an infrastructure migration from Heroku to Kubernetes that reduced infrastructure costs by approximately $64,000 per year. Both programs required arguing for and winning dedicated engineering time against competing feature roadmap priorities, and both required translating technical risk into the language that finance, product, and legal leadership could evaluate.
+
+The core insight from both: debt that cannot be described in business terms will not be prioritized in business planning. The classification framework exists to make that translation possible.
+
+---
+
+## Part 1: Debt Classification
+
+Not all debt is equal. Treating it as a single category is the reason debt backlogs become infinite lists that nobody acts on. The four-class model forces a distinction between debt that will kill you, debt that is slowing you down, and debt that just makes engineers unhappy when they look at it.
+
+### Class 1: Load-Bearing Debt
+
+Debt that, if not addressed, will cause a system failure. The "if not addressed" is the critical qualifier — this is debt that is presently stable but is on a trajectory toward instability. Examples:
+
+- A database schema that cannot be migrated without downtime as data volume continues to grow at the current rate
+- A library with a security vulnerability where no upstream fix exists and the current version is approaching end-of-support
+- A monolith service boundary that cannot accommodate the load forecasted for the next 18 months without a structural change
+
+**How to identify it:** Load-bearing debt typically lives in the minds of your most senior engineers, in your incident post-mortems (as "contributing factors"), and in architecture diagrams that people annotate with "we don't talk about this." Surfacing it requires asking directly: "What are you most worried about in this system that you have never been given time to fix?"
+
+**How to argue for it:** Frame it as risk management. "If we do not address X by [timeline], we will lose the ability to [migrate / scale / patch] without a high-risk manual intervention. The cost of that intervention is [estimate]. The cost of addressing it now is [smaller estimate]." This is insurance language, not engineering language — and that is intentional.
+
+### Class 2: Risk Debt
+
+Debt that does not immediately threaten system stability but creates compliance, security, or operational exposure. The timeline pressure is external — a compliance audit, a regulatory deadline, a contractual SLA — rather than intrinsic to the system.
+
+Examples:
+- Dependencies not in scope of the current compliance boundary that extend the audit surface area
+- Authentication flows that predate the current security requirements and have not been reviewed against them
+- Logging gaps that make it impossible to reconstruct what happened in an incident with the specificity required by an SLA
+
+**How to identify it:** Risk debt lives in compliance checklists, security audits, and post-incident reviews. It also lives in conversations where an engineer says something like "technically we could do X, but if anyone looked at it closely..." That qualifier is the signal.
+
+**How to argue for it:** Frame it against the cost of the risk materializing. "This gap has a [probability] chance of surfacing in the next audit. If it does, the remediation will require [estimate] under time pressure, plus potential penalties. Addressing it now costs [estimate] with no time pressure." Organizations that have been through a compliance finding understand this framing immediately.
+
+### Class 3: Velocity Debt
+
+Debt that is not threatening stability or compliance but is slowing the team down every day. The compounding interest model applies here: the cost is not a single event but an ongoing tax on every sprint.
+
+Examples:
+- A test suite that takes 45 minutes to run, causing engineers to skip tests locally and only catch failures in CI
+- A deploy pipeline that requires manual steps, adding 20 minutes to every release
+- An internal API that is undocumented and whose behavior is discovered through trial and error, adding 2–3 days to onboarding for every engineer who touches it
+
+**How to identify it:** Ask your engineers how long common tasks actually take vs. how long they should take. The gap is velocity debt. Cycle time metrics and deployment frequency (from DORA) make this visible at the system level; sprint retrospectives surface it at the team level.
+
+**How to argue for it:** Quantify the tax. "The current test suite takes 45 minutes. Engineers run it [N] times per week across [M] engineers. At [loaded engineer cost], that is [dollar amount] per year in waiting time — and that does not include the cost of bugs that pass because people skip the suite locally." Product managers who think debt remediation is abstract often respond immediately to this kind of arithmetic.
+
+### Class 4: Cosmetic Debt
+
+Code that is ugly, inconsistent, or embarrassing — but does not threaten stability, compliance, or velocity. Naming conventions that were wrong in 2019. A component that nobody touches and that works fine. A function that is too long but has adequate test coverage and stable behavior.
+
+**How to treat it:** Do not prioritize cosmetic debt on its own. Address it opportunistically — when an engineer touches a file for another reason, they can clean it up. When a component needs to be understood for a new feature, it can be documented. But cosmetic debt does not go into the roadmap and does not get its own quarter.
+
+The cost of misclassifying cosmetic debt as velocity or risk debt is significant: it consumes the finite goodwill you have for debt work on items that do not change the trajectory.
+
+---
+
+## Part 2: Making Debt Visible
+
+### The Debt Inventory
+
+Start with a debt audit — a structured exercise where the team produces a list of debt items, classified using the framework above. The audit is not a planning exercise; it is a diagnosis exercise. The goal is to know what exists, not to commit to fixing it.
+
+Audit mechanics:
+- Run as a team workshop, not an async survey. Async produces a list; a workshop produces a shared understanding of which items are most consequential.
+- Give each item a class (1–4) and an estimated remediation cost (rough order of magnitude, not a sprint commitment).
+- Flag any items where there is disagreement about the class. Those disagreements are the most important conversations in the audit.
+
+Output: a debt register — a living document (not a ticket queue) that captures class, estimated cost, and the rationale for the classification. Review it quarterly. Items that are not in Class 1 or 2 do not get a place in roadmap conversations; they get addressed opportunistically.
+
+### Framing for Product and Finance Audiences
+
+The engineering debt conversation fails when it is presented in engineering terms to a non-engineering audience. The reframe:
+
+| Engineering language | Business language |
+|---|---|
+| We have a lot of technical debt | We are carrying [specific] risks that will cost us more to address later than now |
+| We need a refactoring sprint | We need to invest [X] to reduce delivery time by [Y%] starting in [quarter] |
+| Our test coverage is insufficient | Defect escape rate is [N%]; each escaped defect costs [average] to remediate in production |
+| We're running on a legacy framework | We are dependent on [library/platform] that reaches end-of-support in [date]; migration cost grows [rate] per quarter of delay |
+
+The business language version answers the question every non-technical leader is asking: "What happens if we don't?"
+
+### The Debt Roadmap Entry
+
+Class 1 and Class 2 debt should appear in the roadmap — not in a vague "tech debt" bucket, but as named initiatives with scopes, owners, and timelines. When debt items are anonymous, they compete with named features and lose. When they are named, they can be evaluated on the same terms.
+
+A roadmap entry for debt work should include:
+- **What it is:** a one-sentence description in non-technical language
+- **Why it matters now:** the risk or cost of delay
+- **What done looks like:** specific success criteria, not "we paid down debt"
+- **The resource ask:** team(s), timeframe, what will not be done in parallel
+
+---
+
+## Part 3: Sequencing Debt Paydown
+
+### Against Delivery Commitments
+
+The most common failure mode in debt remediation is treating it as a separate work stream from feature delivery. In practice, the teams doing the debt work are the same teams doing the feature work, and the sequencing has to account for both.
+
+A sustainable model: reserve 15–20% of sprint capacity for Class 1 and Class 2 debt work, every sprint. This is not a separate track — it is a capacity reservation. The specific items change quarter to quarter based on the debt register; the capacity reservation is constant. This approach produces steady debt reduction without requiring dedicated cleanup sprints, which are difficult to get and difficult to sustain.
+
+The capacity reservation has to be explicit and defended. "We have 20% reserved for debt" needs to be in the team's working agreements, communicated to product, and visible in sprint planning. If it is implicit, it will be the first thing compressed when delivery pressure increases.
+
+### The "Refactor Alongside Feature" Pattern
+
+When a feature touches a system that contains Class 3 (velocity) debt, include the remediation in the feature scope rather than treating it as separate work. "We will build the notification service, and in the same sprint we will migrate the adjacent logging code to the current standard." This is the opportunistic cleanup model applied at feature-planning time, not retrospectively.
+
+The discipline: scope the refactor before the sprint starts, not during it. Mid-sprint scope additions almost always compress the refactor when time gets tight.
+
+### Dedicated Cleanup Sprints
+
+Reserve for Class 1 debt only: items where the risk justifies taking engineering capacity fully offline from feature work. A dedicated cleanup sprint is a high-cost signal — it tells product and leadership that the debt is urgent enough to stop everything else. Using it for Class 3 or Class 4 debt destroys credibility for the times when the signal is genuinely warranted.
+
+Mechanics for running a dedicated sprint:
+- Frame it as a risk mitigation initiative, not a cleanup exercise
+- Define success criteria before the sprint starts (what state does the system need to be in when this is complete?)
+- Communicate the scope and justification to product and leadership before the sprint begins
+- Run a lightweight retrospective at the end: did we hit the success criteria, and what did we learn about the actual scope vs. the estimate?
+
+---
+
+## Part 4: Common Failure Modes
+
+### The Infinite Debt Backlog
+
+A debt backlog with 200 items is not a debt register — it is a guilt list. No one will work through 200 items; the list will be used as evidence that debt is unmanageable and therefore not worth trying to manage. Cut ruthlessly. If an item is not Class 1 or Class 2 and has been on the list for more than six months without a plan to address it, either schedule it or delete it.
+
+### "We'll Clean It Up Later"
+
+The phrase "we'll clean this up after the launch" is almost never true. Post-launch, the next feature is already in sprint planning, and the debt item has no advocate. Address debt at the time it is created or schedule a specific follow-up with an owner — not "the team" — assigned. A debt item without an owner is a debt item that will not be addressed.
+
+### The Big Bang Rewrite
+
+The proposal to rewrite a system from scratch rather than incrementally improving it. This is almost always the wrong answer. Big bang rewrites:
+- Take longer than estimated, because the original system's behavior is never fully understood until the rewrite reveals it
+- Risk migrating bugs from the old system to the new one (and introducing new ones)
+- Require maintaining two systems simultaneously during the transition period, doubling operational burden
+
+The alternative: the strangler fig pattern. Replace one piece of the system at a time, running the old and new code in parallel for each piece until the old piece is fully replaced. This is slower per piece and much faster overall, because each piece can be shipped and validated independently.
+
+Reserve full rewrites for systems where the existing architecture cannot accommodate the incremental change — not for systems that are merely unpleasant to work in.
+
+### Debt as Leverage
+
+Using debt as leverage in roadmap negotiations ("we can't add scope until we address the debt backlog") is tempting and almost always counterproductive. It frames engineering as the obstacle to delivery, damages the engineering/product partnership, and puts the engineering team in a defensive posture. The debt should be represented as a risk and a cost, not as a bargaining chip.

--- a/strategy/technical-debt-prioritization.md
+++ b/strategy/technical-debt-prioritization.md
@@ -8,7 +8,7 @@ Leaders who treat debt as a single category make two predictable errors: they ei
 
 ## Background and Motivation
 
-This framework was developed from two specific programs at ActBlue Technical Services (2022–2025). The first was a multi-year PCI environment deprecation initiative that reduced the active codebase by approximately 30% — 7,000+ lines of code eliminated and 2,600+ accounts migrated — while maintaining payment continuity on a system handling 1M+ transactions per day. The second was an infrastructure migration from Heroku to Kubernetes that reduced infrastructure costs by approximately $64,000 per year. Both programs required arguing for and winning dedicated engineering time against competing feature roadmap priorities, and both required translating technical risk into the language that finance, product, and legal leadership could evaluate.
+This framework was developed from two specific programs at ActBlue Technical Services (2022–2025). The first was a multi-year PCI environment deprecation initiative that reduced the PCI-scoped service codebase by approximately 30% — 7,000+ lines of code eliminated and 2,600+ accounts migrated — while maintaining payment continuity on a system handling 1M+ transactions per day. The second was an infrastructure migration from Heroku to Kubernetes that reduced infrastructure costs by approximately $64,000 per year. Both programs required arguing for and winning dedicated engineering time against competing feature roadmap priorities, and both required translating technical risk into the language that finance, product, and legal leadership could evaluate.
 
 The core insight from both: debt that cannot be described in business terms will not be prioritized in business planning. The classification framework exists to make that translation possible.
 
@@ -110,7 +110,7 @@ A roadmap entry for debt work should include:
 
 The most common failure mode in debt remediation is treating it as a separate work stream from feature delivery. In practice, the teams doing the debt work are the same teams doing the feature work, and the sequencing has to account for both.
 
-A sustainable model: reserve 15–20% of sprint capacity for Class 1 and Class 2 debt work, every sprint. This is not a separate track — it is a capacity reservation. The specific items change quarter to quarter based on the debt register; the capacity reservation is constant. This approach produces steady debt reduction without requiring dedicated cleanup sprints, which are difficult to get and difficult to sustain.
+A sustainable model: reserve 15–20% of sprint capacity for Class 1 and Class 2 debt work, every sprint. (This range is calibrated to mid-size product engineering teams; tune it against your team's actual risk register and delivery pressures — smaller teams often need proportionally more headroom, larger orgs with dedicated platform capacity may carry less.) This is not a separate track — it is a capacity reservation. The specific items change quarter to quarter based on the debt register; the capacity reservation is constant. This approach produces steady debt reduction without requiring dedicated cleanup sprints, which are difficult to get and difficult to sustain.
 
 The capacity reservation has to be explicit and defended. "We have 20% reserved for debt" needs to be in the team's working agreements, communicated to product, and visible in sprint planning. If it is implicit, it will be the first thing compressed when delivery pressure increases.
 

--- a/transitions/new-leader-30-60-90.md
+++ b/transitions/new-leader-30-60-90.md
@@ -1,0 +1,198 @@
+# New Engineering Leader 30-60-90 Day Plan
+
+## Leadership Context
+
+The single most costly mistake a new engineering leader makes is acting before listening. The org will read every early decision as a signal about who you are — what you value, what you will protect, and who is safe. Those signals, once sent, are difficult to walk back. The 30-60-90 framework is a forcing function against moving too fast. It structures the early months as a sequence of distinct modes: listening, diagnosing, and committing. Each mode has deliverables, and the deliverables exist to prevent the mode from becoming indefinite.
+
+The framework applies whether you are joining as an external hire or stepping into a director-level role from within. The timelines shift — internal transitions can compress phase 1 because relationship context already exists — but the phases do not collapse.
+
+A 90-180-360 extension applies for larger orgs (100+ engineers), M&A integrations, or situations where the prior leader left under difficult circumstances. In those cases the first 90 days is still listening and diagnosing, but the commitment and change horizons extend.
+
+## Background and Motivation
+
+This framework was developed from two distinct leadership transitions: stepping into the platform directorate at ActBlue Technical Services (2022), where I inherited six teams and approximately fifty engineers across payments, infrastructure, compliance, and developer experience, and a subsequent transition into a technical leadership role at Community Tech Alliance (2025), a smaller org with a narrower scope but different organizational maturity. The challenges are meaningfully different — inheriting an established org versus building in a greenfield context — but the listening-first discipline applies in both.
+
+## When to Use This
+
+**External hire as EM, Senior EM, Director, or VP.** You have no prior relationship capital with the team. Every early action is observed and interpreted.
+
+**Internal promotion into a larger scope.** You know the company but not all of the teams. Prior relationships create context but also expectations — some people will assume continuity, others will wait to see if you are actually different from your predecessor.
+
+**Stepping into a struggling org.** Pressure to act fast is highest in turnaround situations and precisely when premature action is most destructive. Diagnosis before prescription matters most here.
+
+---
+
+## Part 1: The Listening Tour (Days 1–30)
+
+### The Core Discipline
+
+Do not announce any changes during the first 30 days. Not in stand-ups, not in your first all-hands, not in a well-intentioned "here's my leadership philosophy" email. Changes announced before you have earned trust are not heard as good ideas — they are heard as a signal about whether you are safe to disagree with.
+
+The goal of month one is to leave every conversation having learned something and having made the person feel heard.
+
+### What to Listen For
+
+In 1:1s with every direct report and key stakeholder, ask the same five questions:
+
+1. **What is working well that you would protect at all costs?** This surfaces what the team is proud of and where your credibility is at risk if you accidentally break something.
+2. **What is the biggest problem that nobody is talking about loudly enough?** This surfaces the real signal, not the org chart version.
+3. **What has been tried that failed, and why?** This prevents you from re-proposing the idea that burned the team three years ago.
+4. **If you could change one thing about how this team operates, what would it be?** Different from the previous question — this is aspirational, not historical.
+5. **What do you wish the previous leadership had done differently?** Be careful with this one — not everyone will answer directly, but the indirect answers are often the most useful.
+
+Run these 1:1s for every direct report and every skip-level manager in your first two weeks. Then expand to key cross-functional partners (product, design, data, finance, legal) in weeks three and four.
+
+### Relationship Mapping
+
+Produce a written relationship map by the end of week two. Not for distribution — this is a working document for your own orientation. Capture:
+
+- **Key influencers** — the people whose opinions move others, regardless of title. Often a Staff Engineer or a senior IC who has been around long enough to remember everything.
+- **Coalition builders** — the people who know how to get things done informally. They often have titles that underrepresent their organizational reach.
+- **Skeptics** — the people who are waiting to see whether you are worth trusting. They are not enemies; they are reasonable people with evidence that change does not always go well.
+- **At-risk relationships** — people who were passed over for the role you now hold, or who had a difficult relationship with your predecessor.
+
+### What Not to Do in Month One
+
+- **Do not reorganize teams.** Even if the structure is obviously wrong. Wait until you understand why it is structured this way before changing it.
+- **Do not introduce new process.** Meeting changes, ticket workflow changes, documentation standards — all of this can wait.
+- **Do not signal favorites.** Spending visibly more time with certain engineers or managers signals a hierarchy of trust before you have earned the basis for one.
+- **Do not relitigate your predecessor's decisions publicly.** Even if those decisions were wrong. You can acknowledge that things are changing without framing the past as a failure.
+
+### Month One Deliverable: The Landscape Document
+
+A private written assessment (1–2 pages) covering:
+
+- The three strongest things you observed
+- The three biggest gaps or risks
+- The relationships you are most uncertain about
+- Open questions you cannot yet answer
+
+This document has two purposes: it forces you to synthesize what you heard rather than just collecting impressions, and it gives you a baseline to measure against in month six when your initial read looks different in hindsight.
+
+---
+
+## Part 2: Diagnosis and Early Action (Days 31–60)
+
+### The Shift from Listening to Structuring
+
+Month two is when you begin pattern-matching across what you heard and start to name things. You are not acting yet — you are triangulating. An observation you heard from three different people in three different contexts is a signal. An observation you heard from one passionate person is a data point.
+
+Use month two to:
+
+- **Validate your month one hypotheses.** Go back to three or four people from the listening tour and say: "Based on what I've been hearing, I'm starting to think [X]. Does that match your experience?" This builds trust and catches errors in your read before they harden.
+- **Identify the quick wins.** Every org has something that is broken, everybody knows it, and nobody has fixed it because nobody owns it. These are not the structural problems — they are the paper cuts. Fixing one or two of these signals competence and makes the team feel seen without requiring you to take a position on anything contentious.
+- **Map the technical landscape.** Where is the actual technical risk? What is held together with duct tape that everyone is afraid to touch? What is the state of incident response, on-call load, and deployment frequency? This is not an audit — it is orientation.
+
+### Building Trust With the Team
+
+Trust at the team level is built through consistency, not charisma. Specifically:
+
+- **Do what you said you would do.** If you told an engineer in your listening tour that you would follow up on something, follow up. The first time you do not, it will be noticed.
+- **Protect your team's capacity.** When cross-functional requests arrive that would derail sprint work without adequate prioritization, be the one who names the tradeoff and makes the org absorb it — not the team.
+- **Show your work.** When you make a decision that affects the team, explain the reasoning. You do not owe a justification for every decision, but you owe transparency about the trade-offs you weighed.
+
+### Month Two Deliverable: Written Assessment and North Star
+
+Share a written assessment with your manager and (in edited form) with your team. This is not a roadmap — it is a diagnosis. Cover:
+
+- What you observed about the team's strengths
+- What you believe the primary growth areas are (without attributing them to individuals)
+- Where you think the team should be heading and why
+- What you are not yet sure about
+
+The north star does not need to be fully formed. A clear direction with acknowledged uncertainty is more trustworthy than a polished vision that has no room for what you do not yet know.
+
+---
+
+## Part 3: Committing to a Direction (Days 61–90)
+
+### The Shift from Diagnosis to Action
+
+By day 60 you should have enough orientation to start acting. Not on everything — but on the things where waiting longer is itself a cost. The discipline in month three is distinguishing between:
+
+- **Decisions you can now make.** You have the information you need and delay is harmful.
+- **Decisions that need more time.** You have a hypothesis but not enough signal.
+- **Decisions that belong to someone else.** You have an opinion but it is not yours to make.
+
+Month three is also when the org's initial patience with a new leader begins to run out. A director who is still "getting oriented" at day 90 has not communicated enough about direction and will start losing credibility with high performers who are waiting to understand what they are working toward.
+
+### The First Changes
+
+Sequence changes in month three as follows:
+
+1. **Process changes first.** How meetings run, how decisions get made, how information flows. These are visible, low-risk, and signal that you are serious without touching people's projects or team structures.
+2. **Structural changes second.** If a team needs to be reorganized, or reporting lines need to shift, begin socializing and then execute. But do not execute a reorg before you have established trust with every manager affected.
+3. **People decisions last.** If a personnel issue exists that cannot wait — a performance problem, a role mismatch — begin addressing it through the appropriate channel. But do not make dramatic people decisions in month three unless inaction is creating real harm.
+
+### The 90-Day Retrospective
+
+At the end of the 90-day period, write a brief retrospective for yourself. Cover:
+
+- What your initial landscape document got right and what it missed
+- The decisions you made and how they are landing
+- What you would do differently if starting over
+- The 90-180 plan: the next three months now that you have your bearings
+
+This retrospective is for you, not your manager. Its value is forcing a confrontation with how your initial read diverged from reality.
+
+---
+
+## The 90-180-360 Extension
+
+For larger orgs, M&A integrations, or turnaround situations, extend the frame:
+
+| Horizon | Mode | Key Deliverable |
+|---|---|---|
+| 0–90 days | Listen and diagnose | Landscape doc, written assessment |
+| 90–180 days | Execute first changes | Team health baseline, roadmap Q1 |
+| 180–360 days | Structural and strategic moves | Org redesign if needed, multi-year strategy |
+
+The extension does not mean acting more slowly on urgent problems. It means distinguishing between urgency (this must happen now) and importance (this must happen, but the timing is mine to choose).
+
+---
+
+## Anti-Patterns
+
+**The Mandate Drop.** Announcing major changes in the first all-hands to signal decisiveness. The team hears: "I don't know us well enough to know if this is right, but I'm going to do it anyway."
+
+**The Consensus Trap.** Running the listening tour and then making every change by committee to avoid conflict. The team hears: "This person cannot make a decision." Listening does not require consensus-seeking on outputs.
+
+**The Transparency Overcorrection.** Sharing every half-formed thought in the spirit of openness. Uncertainty is fine; broadcasting uncertainty without framing creates anxiety. Be honest about what you do not know, but anchor it to what you are going to do about it.
+
+**The Prior Leader Shadow.** Every conversation beginning with implicit comparison to the person before you. Whether your predecessor was beloved or reviled, your job is to be you, not a corrective for them.
+
+**The Premature All-Hands.** Scheduling a team all-hands before you have had 1:1s with everyone you will be speaking about. You will say something wrong about someone's work or role that you would have known to avoid if you had met with them first.
+
+---
+
+## Templates
+
+### Listening Tour 1:1 Agenda (30 min)
+
+```
+1. Background and what brought you to this team (5 min)
+2. What's working well that you'd protect? (5 min)
+3. Biggest problem nobody talks about loudly enough? (5 min)
+4. What's been tried that failed? (5 min)
+5. One thing you'd change about how the team operates? (5 min)
+6. Anything else you want me to know? (5 min)
+```
+
+### 90-Day Assessment Outline (internal document)
+
+```
+## Strengths I Observed
+- [3–5 bullets, specific and evidenced]
+
+## Growth Areas
+- [3–5 bullets, framed as org challenges not individual failures]
+
+## Open Questions
+- [the things I still don't know]
+
+## Early Decisions I'm Considering
+- [with reasoning]
+
+## Relationships to Invest In
+- [names or roles, and why]
+```


### PR DESCRIPTION
## Summary

Five high-leverage leadership frameworks, all grounded in direct production experience, added to fill the gaps identified in the leadership artifact audit:

- **`transitions/new-leader-30-60-90.md`** — Phased listening/diagnosis/commitment framework for an engineering leader joining a new org. New `transitions/` directory, placed first in the README as the entry point for new leaders.
- **`operating-cadence/managing-up-across-playbook.md`** — Mechanics of exec relationships, skip-level dynamics, absorb vs. escalate decisions, and cross-functional partnership with product/legal/finance.
- **`people/one-on-one-coaching-framework.md`** — 1:1 as a coaching instrument. Coaching arc by career stage (new hire, growing IC, senior, manager). SBI feedback model. The questions engineers won't raise unless asked.
- **`strategy/technical-debt-prioritization.md`** — Four-class debt model (load-bearing/risk/velocity/cosmetic). Roadmap framing. 15–20% capacity reservation model. Strangler fig over big-bang rewrite.
- **`people/difficult-conversations-framework.md`** — Underperformance, role mismatch, team conflict, leveling disagreements. SBI structure. Follow-through cadence. When to escalate to HR.

README updated with new **Transitions & New Leader Toolkit** section and entries for all five new documents.

## Test plan

- [ ] All five new Markdown files render correctly (headers, links, code blocks)
- [ ] New `transitions/` directory and file are correctly linked from README
- [ ] All internal cross-references resolve (none in this PR — no new cross-references added)
- [ ] README section ordering and formatting is intact in preview

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)