### PR TITLE
Add wave-2 engineering leadership gap artifacts

### DIFF
--- a/ORIGINS.md
+++ b/ORIGINS.md
@@ -10,6 +10,16 @@ Every framework in this repo was developed from real work, not synthesized from 
 
 ---
 
+## Transitions & New Leader Toolkit
+
+| Framework | Engagement | Origin | Outcome | In my own words |
+|---|---|---|---|---|
+| [New Engineering Leader 30-60-90 Day Plan](transitions/new-leader-30-60-90.md) | ActBlue Technical Services (2022) → Community Tech Alliance (2025) | Platform directorate onboarding (6 teams, ~50 engineers); CTA technical leadership ramp | Listening tour and landscape doc completed in both contexts; early structural changes sequenced correctly | "I developed this framework from two meaningfully different leadership transitions — inheriting an established directorate at ActBlue and onboarding into a greenfield context at CTA." |
+| [Inheriting a Team You Didn't Hire](transitions/inheriting-a-team.md) | ActBlue Technical Services (2022) | Platform directorate formation — inheriting teams from prior reporting structure with different norms, informal authority, and unresolved personnel situations | Loyalty traps identified and navigated; informal authority figures engaged productively; early personnel concerns addressed with appropriate timeline | "I stepped into a directorate with existing team culture, informal leaders, and open personnel questions. The framework reflects what I learned about reading those dynamics before acting on them." |
+| [New Hire Onboarding Framework](transitions/new-hire-onboarding-framework.md) | ActBlue Technical Services (2022–2025) → Community Tech Alliance (2025–2026) | Onboarding multiple ICs across six platform teams at ActBlue; establishing onboarding structure from scratch at CTA | Reduced time-to-first-contribution variance across platform teams; created structured ramp where none existed at CTA | "I designed and ran onboarding across six platform teams and observed the failure modes that emerge when it is not structured. The CTA context required building the process with almost no existing scaffolding." |
+
+---
+
 ## Org Design & Strategy
 
 | Framework | Engagement | Origin | Outcome | In my own words |
@@ -19,6 +29,7 @@ Every framework in this repo was developed from real work, not synthesized from 
 | [Technical Strategy Template](strategy/technical-strategy-template.md) | ActBlue Technical Services (2024–2025) → Community Tech Alliance (2025–2026) | Multi-year platform directorate technical vision (ActBlue); 12-month technical investment roadmap (CTA) | Set direction for 6-team directorate; at CTA, prioritized DR posture and dependency management | "I developed the vision and presented roadmaps to the VP of Engineering and Head of Product. At CTA I designed and wrote the roadmap entirely." |
 | [Build vs. Buy Framework](strategy/build-vs-buy-framework.md) | ActBlue Technical Services (2022–2025) | Heroku→Kubernetes on AWS migration decision; payment processor migration to Stripe | $64K/year infrastructure savings (K8s); 2,600+ accounts migrated; 7,000+ lines of code removed (Stripe) | "I identified the priority, built the business case, and cleared the organizational path for both programs." |
 | [M&A Technical Due Diligence Framework](strategy/ma-technical-due-diligence.md) | ActBlue Technical Services (2022–2025) | Synthesized from PCI environment deprecation, multi-regional infrastructure, monolith decomposition, and DR validation | N/A — framework synthesized from cross-domain platform and compliance experience | "This framework synthesizes the diligence posture developed across multi-year platform, compliance, and DR programs in regulated environments." |
+| [Reorg Execution Guide](org-design/reorg-execution-guide.md) | ActBlue Technical Services (2022) | Platform directorate formation — chartering new teams, realigning reporting structures, and managing the human dynamics of structural change across ~50 engineers | New team charters established; reporting lines transitioned; team norms re-established in reconfigured structures | "I executed the platform directorate formation — the pre-announcement sequencing, the manager briefings, and the post-announcement norm re-establishment across six teams." |
 
 ---
 
@@ -28,6 +39,8 @@ Every framework in this repo was developed from real work, not synthesized from 
 |---|---|---|---|---|
 | [Career Ladder and Calibration Playbook](people/career-ladder-calibration.md) | ActBlue Technical Services (2022–2025) | Three IC promotions in three years; Engineering Management Community of Practice | Two SE2→SSE2 double promotions; one SSE→SSE2 promotion; CoP systematized talent development | "I drove three promotions within three years through deliberate project placement, calibration preparation, and sustained advocacy. Two were double promotions from SE2 to SSE2." |
 | [Headcount and Capacity Planning Playbook](people/headcount-capacity-planning.md) | ActBlue Technical Services (2024–2025) | HC modeling for a multi-year 6-team platform directorate | HC sequenced against roadmap; finance alignment achieved across two planning cycles | "I developed the platform directorate technical vision and translated it into headcount requirements across 6 teams, presenting to the VP of Engineering and Head of Product." |
+| [Hiring and Technical Interview Design](people/hiring-and-interview-design.md) | ActBlue Technical Services (2022–2025) | Interview loop design and calibration across platform engineering, payments, and EM roles; Engineering Management Community of Practice interview calibration sessions | Structured loops for three distinct hiring domains; interviewer calibration sessions systematized within the EM CoP | "I designed and calibrated interview loops for three distinct hiring domains and ran calibration sessions as part of the Engineering Management Community of Practice." |
+| [Staff and Principal Engineer Partnership](people/staff-engineer-partnership.md) | ActBlue Technical Services (2022–2025) | Staff IC partnerships in database engineering, DevEx, and payments architecture — each with different authority scope, roadmap co-ownership needs, and career stage | Effective technical roadmap co-ownership across three Staff-level partnerships; authority split explicit in each domain | "I managed Staff and Principal ICs across three distinct domains. The authority split, roadmap co-ownership model, and sponsor/coach/peer modes in this framework come from those partnerships." |
 
 ---
 
@@ -63,6 +76,7 @@ Every framework in this repo was developed from real work, not synthesized from 
 | [DR Fire Drill Template](disaster-recovery/fire-drill-template.md) | ActBlue Technical Services (2022–2024) | Disaster recovery fire drills introduced to validate payment continuity under failure scenarios | Improved incident preparedness; DR posture validated before a real event | "I designed the fire drill structure and ran the drills." |
 | [CI/CD Pipeline Governance Guide](ci-cd/pipeline-governance-guide.md) | Capital One (2019–2022) → ActBlue Technical Services (2022–2024) | CI/CD pipeline standardization across multiple engineering departments (Capital One); DevEx team ownership of application-level delivery tooling (ActBlue) | Saved 300 engineering hours per team (Capital One); application-level delivery tooling owned and governed (ActBlue) | "I led the migration planning at Capital One. At ActBlue, I chartered the DevEx team that owned application-level CI/CD." |
 | [LaunchDarkly Rollout Governance](experimentation/launchdarkly-rollout-governance.md) | ActBlue Technical Services (2022–2024) | End-to-end LaunchDarkly rollout: vendor relationship, proof-of-concept, cross-team adoption | First customer-facing flag in production within 4 months; several teams adopted | "I managed the vendor relationship, designed the proof-of-concept, and drove cross-team adoption." |
+| [Blameless Post-Mortem Framework](incident-management/blameless-postmortem-framework.md) | ActBlue Technical Services (2022–2025) | Post-mortem culture for high-availability payments infrastructure under PCI-DSS; SRE restructuring included post-mortem process redesign | Blameless analysis culture established; action item follow-through improved via ticket integration | "I was responsible for post-mortem culture across the platform directorate. The facilitation techniques and action item tracking approach here are what made the difference between post-mortems that changed things and those that didn't." |
 
 ---
 
@@ -88,6 +102,7 @@ Every framework in this repo was developed from real work, not synthesized from 
 |---|---|---|---|---|
 | [AI-Assisted Documentation Standards](leadership/ai-documentation-standards.md) | Community Tech Alliance (2025–2026) | Claude Code + Claude integration initiative — auditability standards for AI-generated documentation | Framework designed; did not advance to implementation before departure | "I designed the initiative and the sequencing, including separate use cases for engineers and managers and a structured evaluation rubric." |
 | [PRD Lifecycle Management](leadership/prd-lifecycle.md) | Community Tech Alliance (2025–2026) | Feature lifecycle and roadmapping process revision | Reduced planning debt; improved IC alignment; shifted emphasis to outcomes | "I designed and drove the process changes. The team adopted them." |
+| [RFC and Design Doc Process](leadership/rfc-design-doc-process.md) | ActBlue Technical Services (2022–2025) → Community Tech Alliance (2025–2026) | Architectural decision-making structure for Stripe migration, K8s migration, and PCI deprecation (ActBlue); lightweight RFC process establishment in a team with no prior structured decision process (CTA) | Cross-team alignment on major architectural decisions maintained across multi-year programs; RFC process adopted at CTA | "I used structured proposal and review processes for major architectural decisions at ActBlue. At CTA, I established the process from scratch in a team that had been deciding in Slack." |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,16 @@ Operational and leadership frameworks from production engineering work across pa
 
 ## Transitions & New Leader Toolkit
 
-Frameworks for the first 90–360 days in a new engineering leadership role. Start here. (Additional docs — inheriting a team, reorg execution — are forthcoming in wave 2.)
+Frameworks for the first 90–360 days in a new engineering leadership role, and the full engineer lifecycle from first day to fully ramped.
 
 **[transitions/new-leader-30-60-90.md](transitions/new-leader-30-60-90.md)**
 Phased framework for an engineering leader joining a new org. Covers the listening tour (days 1–30), diagnosis and early action (days 31–60), and committing to a direction (days 61–90). Includes a 90-180-360 extension for larger orgs or turnaround situations, anti-patterns, and reusable templates for the listening tour 1:1 and the 90-day written assessment. Grounded in the ActBlue platform directorate ramp and the CTA technical leadership onboarding.
+
+**[transitions/inheriting-a-team.md](transitions/inheriting-a-team.md)**
+Companion to the 30-60-90 for the specific dynamics of stepping into an existing team you did not hire. Covers the three predecessor archetypes (beloved, embattled, absent), loyalty traps (passed-over team members, informal authority figures), the trust signals the team is watching for in weeks 1–4, and early personnel decisions. Includes modified listening tour questions and a personnel decision decision tree.
+
+**[transitions/new-hire-onboarding-framework.md](transitions/new-hire-onboarding-framework.md)**
+The 30-day plan handed to an incoming engineer — the complement to the new-leader 30-60-90. Covers the three-phase ramp (orientation, first contribution, independent delivery), the three roles (manager, buddy, new hire), ramp metrics, and the most common onboarding failure modes. Includes a 30-day checklist, manager kick-off agenda, buddy guide, and 30-day retrospective format. Grounded in onboarding across six platform teams at ActBlue and the CTA engineering team.
 
 ---
 
@@ -37,6 +43,9 @@ Engineering assessment framework for acquisitions. Covers 8 domains (architectur
 **[strategy/technical-debt-prioritization.md](strategy/technical-debt-prioritization.md)**
 Framework for classifying, communicating, and sequencing technical debt work. Introduces a four-class model (load-bearing, risk, velocity, cosmetic) with guidance on translating each class into business language for roadmap conversations. Covers the debt inventory process, a 15–20% capacity reservation model, the refactor-alongside-feature pattern, and common failure modes including the infinite backlog and the big bang rewrite. Grounded in the PCI environment deprecation (30% codebase reduction, 7,000+ lines eliminated) and Heroku→Kubernetes migration at ActBlue.
 
+**[org-design/reorg-execution-guide.md](org-design/reorg-execution-guide.md)**
+Companion to the team topology framework: the *how* of reorgs rather than the *why*. Covers the pre-announcement checklist (HR alignment, manager briefing sequence), the announcement structure (what to say, what not to say, the five questions to answer), the 72-hour period after announcement, and re-establishing team norms in the new structure. Includes announcement templates, manager briefing agenda, team charter kickoff, and re-norming retro format. Grounded in the platform directorate formation at ActBlue (2022).
+
 ---
 
 ## People Systems
@@ -54,6 +63,12 @@ How to run 1:1s as a coaching instrument, not a status meeting. Covers agenda st
 
 **[people/difficult-conversations-framework.md](people/difficult-conversations-framework.md)**
 How to prepare for and deliver the four most common difficult conversations in engineering management: underperformance (early-signal and pre-formal), role mismatch, team conflict, and leveling disagreements. Covers SBI structure, pre-conversation preparation, follow-through cadence, documentation discipline, and when to escalate to HR. Grounded in calibration advocacy and leveling dispute conversations at ActBlue.
+
+**[people/hiring-and-interview-design.md](people/hiring-and-interview-design.md)**
+End-to-end structured hiring process from job spec design through debrief. Covers panel composition principles, a four-axis competency rubric (technical depth, collaboration, communication, growth), rubric calibration sessions, bias mitigation mechanisms (standardized questions, written notes before discussion, score submission before debrief), and debrief facilitation for signal-based rather than gut-based consensus. Includes job spec template, scorecard, debrief agenda, and offer-stage checklist. Grounded in hiring across platform, payments, and engineering management roles at ActBlue.
+
+**[people/staff-engineer-partnership.md](people/staff-engineer-partnership.md)**
+How managers and Staff or Principal ICs divide technical authority and co-own technical direction. Covers the authority split (what belongs to the manager, what belongs to the IC, the shared overlap zone), the sponsor/coach/peer distinction at different career stages, co-owning the technical roadmap, career pathing for the Staff track (team vs. org vs. company scope), and the failure modes when the partnership breaks. Includes a Staff partnership charter and a career conversation guide for the Staff track.
 
 ---
 
@@ -109,6 +124,9 @@ Frameworks for running reliable engineering operations: on-call structure, incid
 **[incident-management/on-call-restructuring-framework.md](incident-management/on-call-restructuring-framework.md)**
 Framework for restructuring an on-call program that has outgrown its original design. Covers the IC/responder split, rotation structure, Wed-Wed cadence, metrics instrumentation via Jeli and Jira, and the rollout approach. Based on a restructuring that expanded the on-call program from a 5-person SRE team absorbing everything to per-team responder rotations backed by a 12-person incident commander rotation.
 
+**[incident-management/blameless-postmortem-framework.md](incident-management/blameless-postmortem-framework.md)**
+The artifact produced after a real incident — distinct from the DR fire drill template. Covers the five-part post-mortem document (incident summary, impact assessment, incident timeline, root cause analysis using 5-why and contributing factors, action items), blameless facilitation techniques, and the action item tracking problem. Includes a post-mortem document skeleton, facilitator opening statement, AI tracking table format, and a post-mortem-lite variant for near-misses. Grounded in incident response operations for high-availability payments infrastructure at ActBlue.
+
 **[disaster-recovery/fire-drill-template.md](disaster-recovery/fire-drill-template.md)**
 Tabletop exercise format for stress-testing DR posture and incident management protocols. Covers scenario sequencing (catastrophic failure first), participant structure, pre/post checklists, and what to watch for. Built from exercises run at ActBlue to validate payment continuity under failure scenarios.
 
@@ -143,6 +161,9 @@ Auditability and verifiability standards for AI-generated architectural document
 
 **[leadership/prd-lifecycle.md](leadership/prd-lifecycle.md)**
 One living PRD per product. Covers PRD structure (job-outcome table, personas, hypothesis and bets, append-only changelog), two-tier update process (minor vs. major changes), lifecycle stages with gates (Discovery → Alignment → Delivery → Shipped), ownership model, and common failure modes including the frozen PRD, PRD-as-contract, and solution PRD anti-patterns.
+
+**[leadership/rfc-design-doc-process.md](leadership/rfc-design-doc-process.md)**
+How technical decisions get proposed, reviewed, and recorded at the team or org level. Covers when an RFC is warranted (scope, reversibility, blast radius thresholds), the full RFC lifecycle (draft → open for comment → decision → ADR), review mechanics (blocking authority vs. advisory voice, async vs. sync review), and the RFC-to-ADR relationship. Includes RFC document skeleton, reviewer guidance card, and decision-record footer block. Complements the ADR convention established in dev-env.
 
 ---
 

--- a/incident-management/blameless-postmortem-framework.md
+++ b/incident-management/blameless-postmortem-framework.md
@@ -1,0 +1,311 @@
+# Blameless Post-Mortem Framework
+
+## Leadership Context
+
+The post-mortem is the most widely misused artifact in engineering operations. In principle, it is a structured process for learning from an incident in a way that makes the next incident less likely. In practice, it is often used as a documentation checkbox — something that gets written after a significant outage and filed in a wiki where nobody reads it, or as a mechanism for assigning responsibility in a way that is politically palatable but organizationally counterproductive.
+
+This document is distinct from the [Disaster Recovery Fire Drill Template](../disaster-recovery/fire-drill-template.md), which covers proactive resilience testing. The post-mortem is a reactive artifact — it is written after a real incident has occurred. The fire drill produces evidence that systems work as designed. The post-mortem produces learning when they did not.
+
+The "blameless" framing requires more precision than it usually receives. Blameless does not mean consequence-free. It means the analysis is directed at systems, processes, and conditions rather than at individuals. An engineer who made an error that contributed to an incident did so within a system that allowed that error to happen. The post-mortem's job is to understand the system, not to identify the human as the root cause. If the human is the cause, the system created the conditions in which the human cause was possible — and that system is what the post-mortem should analyze.
+
+## Background and Motivation
+
+This framework is grounded in incident response operations at ActBlue Technical Services (2022–2025), where I was responsible for post-mortem culture across a platform directorate handling high-availability payments infrastructure. The payments context — PCI compliance, SLA obligations, and voter data sensitivity — created genuine organizational consequences for how incidents were analyzed and documented. The blameless framing was not aspirational in that context; it was operationally necessary. Attribution-focused post-mortems in a regulated environment produce two outcomes: engineers who are afraid to make changes, and documentation that obscures more than it reveals.
+
+The five-part structure in this framework is an adaptation of the Google SRE post-mortem format[^1], modified for team-level use in contexts without a dedicated SRE function.
+
+## When to Use This
+
+| Trigger | What This Framework Provides |
+|---|---|
+| Any incident that crossed the severity threshold for a post-mortem (typically: customer impact > N minutes, SLO breach, data loss, or security event) | A structured document and facilitation process |
+| Recurring incidents of the same type | A root cause framework for identifying systemic causes rather than treating recurrences as isolated events |
+| Near-misses where no impact occurred but failure was likely | An abbreviated post-mortem process (the "postmortem-lite" variant) |
+| Establishing a post-mortem culture in a team that doesn't have one | A starting protocol and facilitation guide |
+
+---
+
+## Part 1: The Five-Part Post-Mortem Document
+
+The post-mortem document is written before the post-mortem meeting, not during it. The on-call owner (or whoever has the best incident context) drafts the document as a starting point. The meeting is for review, correction, and collaborative root cause analysis — not for first-draft synthesis.
+
+### 1. Incident Summary
+
+A three-sentence summary that answers: what happened, when it happened, and who was affected. This section is read by people who were not involved in the incident. It should be intelligible to a non-technical stakeholder.
+
+```
+On [date], [system or service] experienced [impact description] from [start time] to [end time].
+Approximately [N users / $X revenue / N% of requests] were affected.
+The incident was resolved when [brief resolution description].
+```
+
+### 2. Impact Assessment
+
+The specific, quantified impact. This is not the place for hedging language ("the impact was potentially significant"). If the impact is unknown, say so and why.
+
+| Dimension | Impact |
+|---|---|
+| Duration | [Start time to end time, total minutes] |
+| User impact | [Number of affected users, or % of traffic] |
+| Revenue impact | [$X if calculable, or "not calculable" with reason] |
+| SLO impact | [Which SLO was breached, by how much] |
+| Data impact | [Any data loss, corruption, or privacy implications] |
+| Secondary systems | [Other systems affected by the incident or its remediation] |
+
+### 3. Incident Timeline
+
+A timestamped log of what happened, in chronological order. The timeline is not a narrative — it is a factual record. Each entry should have a timestamp, an actor (person or system), and an action or observation.
+
+Format:
+```
+HH:MM  [Actor]   [Action or observation]
+14:32  Alerting  PagerDuty alert: payment service error rate > 5% (threshold: 1%)
+14:34  @alice    Acknowledged alert, began investigation
+14:41  @alice    Identified elevated error rate correlating with recent deploy
+14:43  @bob      Initiated rollback of deployment abc123
+14:51  @bob      Rollback complete; error rate returning to baseline
+15:04  Alerting  Alert resolved; error rate < 0.5%
+```
+
+The timeline should be assembled from alert logs, Slack history, runbook entries, and on-call notes — not from memory after the fact. Encourage on-call engineers to maintain a running timeline during the incident.
+
+### 4. Root Cause Analysis
+
+This is the core analytical work of the post-mortem. Two methodologies apply here; use one or both depending on the complexity of the incident.
+
+**The 5 Whys.** Iterative questioning that traces a symptom to its systemic root.
+
+Example:
+```
+Why did the payment service return errors?
+  → The database connection pool was exhausted.
+Why was the connection pool exhausted?
+  → A recent deploy changed the query pattern in a way that held connections longer.
+Why did the query pattern change reach production?
+  → The change was tested on a small dataset that didn't reproduce the connection pressure.
+Why was the test dataset small?
+  → We don't have a process for synthetic load testing before payment service deploys.
+Why don't we have that process?
+  → It was flagged as a gap eighteen months ago and never prioritized.
+Root cause: Absence of load testing protocol for payment service deploys.
+```
+
+**Contributing Factors.** A list of conditions that allowed the incident to occur or made it worse — distinct from the root cause, which is the primary cause.
+
+```
+Contributing factors:
+- Deploy was on Friday afternoon, reducing availability of experienced on-call responders
+- Monitoring alert threshold was set to 5% error rate; earlier detection at 1% might have
+  shortened the impact window
+- Runbook for this service had not been updated in six months and did not reflect the
+  current rollback procedure
+```
+
+### 5. Action Items
+
+The action items are the primary output of the post-mortem. A post-mortem without action items is a documentation exercise. A post-mortem with action items that are never completed is worse — it produces a false sense of closure.
+
+Each action item must have:
+- A specific, testable description of what will change
+- An owner (a single person, not a team)
+- A due date
+- A severity (P1: address before next deploy; P2: address within 30 days; P3: backlog)
+
+| Action Item | Owner | Due | Priority |
+|---|---|---|---|
+| Add load test to payment service deploy pipeline | @alice | [date] | P1 |
+| Update on-call runbook with current rollback procedure | @bob | [date] | P2 |
+| Review and lower alert thresholds for payment error rate | @carol | [date] | P2 |
+| Conduct post-mortem retro on Friday deploy policy | @manager | [date] | P3 |
+
+---
+
+## Part 2: Blameless Facilitation
+
+The post-mortem meeting is where the blameless framing is most at risk. Even in organizations with explicit blameless policies, the group dynamics of a post-mortem meeting can produce attribution — an engineer who is embarrassed by their role in an incident may volunteer blame preemptively, and other participants may accept it because it provides a clean narrative.
+
+The facilitator's job is to keep the analysis directed at systems rather than people.
+
+### Facilitation Principles
+
+**Separate the person from the action.** When an engineer says "I made a mistake," redirect: "What in the system made that action possible? What would have had to be true for a different engineer to avoid the same outcome?"
+
+**Name contributing factors, not culpable individuals.** When the timeline shows that an individual made a decision that contributed to the incident, the post-mortem records the decision and the context — not the individual's name as the cause. "A deploy was initiated without load testing" is a system observation. "Alice initiated the deploy without load testing" is an attribution.
+
+**Ask what would have to change, not what should have been done differently.** "What would have to be true for this incident to not have happened?" produces system changes. "What should [person] have done differently?" produces individual accountability without systemic learning.
+
+**Read the contributing factors list aloud and ask: did we miss any?** This prevents the post-mortem from closing around a single root cause when the reality is multi-causal. Complex systems fail through the combination of small gaps, not a single catastrophic error.
+
+### The Facilitator Role
+
+The facilitator should not be the on-call owner from the incident. The on-call owner is a primary contributor to the timeline and root cause analysis; they should not also be managing the meeting dynamics. Assign facilitation to a manager, a senior IC from an adjacent team, or a designated post-mortem facilitator if your team has one.
+
+**Facilitator responsibilities:**
+- Open the meeting by reading the blameless principle aloud (see template)
+- Drive through each section of the post-mortem document for review and correction
+- Redirect attribution language toward system analysis
+- Ensure every action item has an owner and a date before the meeting ends
+- Close the meeting with explicit acknowledgment of the work the on-call team did
+
+---
+
+## Part 3: The Action Item Tracking Problem
+
+Post-mortem action items are the highest-mortality artifact in engineering operations. They are created with good intentions, assigned to owners, and then deprioritized in the next sprint, the one after that, and the one after that. Months later, the same incident type recurs and the post-mortem produces the same action items.
+
+### Why Action Items Die
+
+- They are in a wiki, not a ticket system. Engineers do not live in wikis.
+- They are assigned to individuals who do not have the authority to prioritize them.
+- They require cross-team coordination that nobody owns.
+- The sprint is full and the post-mortem AIs have no deadline enforcement.
+
+### What Actually Works
+
+**Create tickets immediately.** At the end of the post-mortem meeting, post-mortem action items become tickets in whatever system the team uses for sprint work. Not wiki tasks, not a checkbox in the post-mortem doc — actual backlog items.
+
+**P1 items block the next deploy.** If an action item is classified P1, it should block the next production deploy for the service that had the incident. This is a strong policy that will generate pushback. It is also the only mechanism that reliably ensures critical post-mortem AIs get completed.
+
+**Manager reviews open post-mortem AIs monthly.** The manager — not the on-call owner — owns the review of outstanding post-mortem action items. This removes the conflict of interest (the on-call owner may be reluctant to surface that their AIs are not complete) and signals organizational commitment to the follow-through.
+
+**The aging post-mortem is a signal.** If a post-mortem has open P2 action items more than sixty days past their due date, something is wrong with the prioritization process, the ownership assignment, or the clarity of what "done" means. Treat aged AIs as a process problem, not an individual accountability problem.
+
+---
+
+## Part 4: The Post-Mortem-Lite for Near-Misses
+
+Not every incident that warrants learning warrants the full five-part process. Near-misses — situations where no customer impact occurred but failure was close — produce valuable learning at lower cost than a full post-mortem.
+
+The post-mortem-lite covers three questions:
+
+1. **What almost happened?** (Brief incident summary — one to two sentences)
+2. **Why didn't it happen?** (What prevented the customer impact — the catch or the luck)
+3. **What one thing would make this more robust?** (Single action item with owner and date)
+
+Run the post-mortem-lite as a short Slack thread or a fifteen-minute sync, not a formal meeting. The value is capturing the near-miss signal while it is fresh — not producing a comprehensive analysis.
+
+---
+
+## Templates
+
+### Post-Mortem Document Skeleton
+
+```markdown
+# Post-Mortem: [Incident Name or ID]
+
+**Date:** [Date of incident]
+**Severity:** [P0 / P1 / P2]
+**Status:** [Draft / In Review / Complete]
+**Document owner:** [Name of primary author]
+**Review date:** [Date of post-mortem meeting]
+
+---
+
+## Incident Summary
+
+[3 sentences: what happened, when, who was affected]
+
+---
+
+## Impact Assessment
+
+| Dimension | Impact |
+|---|---|
+| Duration | |
+| User impact | |
+| Revenue impact | |
+| SLO impact | |
+| Data impact | |
+| Secondary systems | |
+
+---
+
+## Incident Timeline
+
+| Time | Actor | Action / Observation |
+|---|---|---|
+| | | |
+
+---
+
+## Root Cause Analysis
+
+### Primary Root Cause
+[One sentence: the systemic condition that enabled this incident]
+
+### 5 Whys
+Why [symptom]?
+  →
+Why [answer]?
+  →
+Why [answer]?
+  →
+[Continue until you reach a systemic cause]
+Root cause: [statement]
+
+### Contributing Factors
+- [Condition that allowed the incident to occur or worsen]
+- [Condition]
+- [Condition]
+
+---
+
+## Action Items
+
+| Action Item | Owner | Due Date | Priority |
+|---|---|---|---|
+| | | | |
+
+---
+
+## Lessons Learned
+
+[Optional: 1–3 generalizable observations from this incident — something
+other teams or future post-mortems should know]
+```
+
+### Facilitator Opening Statement
+
+```
+Before we start, I want to name the purpose of this meeting. We're here to
+understand what happened in a way that makes the next incident less likely.
+We're analyzing systems, not people. If you made a decision that contributed
+to this incident, we want to understand what the system made possible —
+not assign responsibility for the outcome.
+
+We will leave this meeting with: a shared understanding of the timeline,
+an agreed root cause, and action items with owners and dates.
+
+Let's start with the timeline.
+```
+
+### AI Tracking Table (for sprint system integration)
+
+```
+Post-mortem AI tracking table — created [date], incident [ID]
+
+| Ticket | Action Item | Owner | Due | Priority | Status |
+|---|---|---|---|---|---|
+| [JIRA-XXX] | [Description] | [Name] | [Date] | P1/P2/P3 | Open |
+```
+
+---
+
+## Anti-Patterns
+
+**The Shame Spiral.**
+A post-mortem meeting where the on-call owner spends the first ten minutes apologizing and the rest of the meeting defending their decisions. The facilitator's job is to interrupt this pattern before it begins. An opening statement that names the blameless frame explicitly reduces the probability of the shame spiral.
+
+**The Single Point of Failure Attribution.**
+A post-mortem that concludes "the engineer should have tested this before deploying" and stops there. This is almost never the root cause — it is the proximate cause. The root cause is whatever in the system made inadequate testing possible: no automated test gate, insufficient review coverage, no deploy checklist, inadequate staging environment fidelity. Stop at the person only when you cannot find the system.
+
+**The Orphaned Action Item.**
+A post-mortem action item without a single named owner. Teams, committees, and "we" do not own action items. If the action requires coordination across multiple owners, one of them is the lead and the others are contributors.
+
+**The Filed and Forgotten.**
+A post-mortem document written, reviewed, and posted to a wiki — with no mechanism for ensuring the action items are ever completed. The post-mortem is only as valuable as the systemic changes it produces.
+
+**The Retrospective Creep.**
+A post-mortem meeting that evolves into a general retrospective on engineering practices, team dynamics, or historical grievances. Keep the post-mortem scoped to the specific incident. A good post-mortem surfaces opportunities for improvement that belong in the team's regular retro process — it does not try to run that retro in the same session.
+
+[^1]: Beyer, B., Jones, C., Petoff, J., & Murphy, N. R. (2016). *Site Reliability Engineering: How Google Runs Production Systems*. O'Reilly Media. Chapter 15 covers the post-mortem culture and format that this framework adapts.

--- a/leadership/rfc-design-doc-process.md
+++ b/leadership/rfc-design-doc-process.md
@@ -1,0 +1,321 @@
+# RFC and Design Doc Process
+
+## Leadership Context
+
+Every technical team makes architectural decisions — about service boundaries, data models, infrastructure choices, integration patterns, and operational practices. In small teams, these decisions happen in conversation and are documented after the fact, if at all. In larger teams or across teams, undocumented decisions are a recurring source of friction: engineers make incompatible assumptions, the person who made the original decision leaves, or a new engineer re-investigates and re-proposes a decision that was already made and for good reason.
+
+The RFC (Request for Comments) process is the primary mechanism for making significant technical decisions in a structured, reviewable, and documented way. It is not a bureaucratic checkpoint — it is a forcing function for articulating a decision's rationale in writing before implementing it, making the decision visible to the people it will affect, and creating a searchable record that future engineers can find when they encounter the same question.
+
+The relationship between an RFC and an Architectural Decision Record (ADR) is frequently confused. An RFC is a proposal: it describes a decision that has not yet been made, invites feedback, and documents the options considered. An ADR is a record: it captures a decision that has already been made, along with the context, rationale, and consequences. Not every RFC produces an ADR — some RFCs conclude with no change to the existing approach. Every significant ADR should be preceded by an RFC-equivalent process, though the process may be lighter for smaller decisions.
+
+## Background and Motivation
+
+This framework is grounded in technical decision-making across multiple contexts at ActBlue Technical Services (2022–2025) and Community Tech Alliance (2025–2026). At ActBlue, the scale of the platform directorate — six teams, significant cross-system dependencies, regulated infrastructure — required structured decision-making for architectural changes. The payment processor migration (Stripe), Heroku-to-Kubernetes migration, and PCI environment deprecation all involved decisions where the RFC process provided structure and created organizational alignment that ad-hoc decision-making would not have produced.
+
+At CTA, the challenge was different: establishing a lightweight RFC process in a smaller team where the instinct was to decide in Slack and move on. The friction the RFC process resolves is not primarily size-related — it is documentation and asynchronous review discipline, which matters even in a team of five.
+
+The RFC format in this document is adapted from the Rust RFC process and from the patterns described by Will Larson in his writing on engineering decision-making.[^1][^2]
+
+## When to Use This
+
+| Trigger | RFC Required? | Format |
+|---|---|---|
+| Choosing a new external service or infrastructure component | Yes | Full RFC |
+| Changing a service's API contract in a backward-incompatible way | Yes | Full RFC |
+| Introducing a new architectural pattern across multiple services | Yes | Full RFC |
+| Changing an existing pattern within a single service | Maybe | Abbreviated RFC or ADR-only |
+| Choosing between two implementation approaches within a ticket | No | PR description is sufficient |
+| Documenting a decision already made without significant options analysis | No | ADR directly |
+
+The key threshold question: **would a reasonable engineer on an adjacent team want to know about this decision before it is implemented?** If yes, an RFC is warranted. If the decision affects only the team making it and has limited surface area for future engineers, document the decision as an ADR without a full RFC process.
+
+---
+
+## Part 1: When an RFC Is Warranted
+
+Beyond the table above, three factors push a decision toward the full RFC process:
+
+**Irreversibility.** Decisions that are hard to undo — schema changes, external API contract commitments, infrastructure migrations — warrant more upfront review than easily-reversible decisions. The asymmetry in the cost of getting these decisions wrong justifies the asymmetry in the process.
+
+**Blast radius.** Decisions that affect multiple teams, multiple services, or customer-facing behavior warrant broader review than decisions contained within a single team's scope. The RFC process creates a forcing function for identifying all the stakeholders who should have input before the decision is made.
+
+**Novelty.** Decisions that establish a new pattern — the first time the team uses a particular data consistency strategy, the first time a new infrastructure component is introduced — warrant documentation of the options considered and the rationale for the choice. Future engineers encountering the same question should be able to find the prior analysis.
+
+---
+
+## Part 2: RFC Lifecycle
+
+### Stage 1: Draft
+
+The author produces a draft RFC using the document skeleton provided below. The draft should be complete enough for substantive review — not a rough sketch, but not a polished document that presents a single option without acknowledging trade-offs.
+
+**Draft criteria:**
+- Problem statement is specific and bounded (not "we should improve our database strategy")
+- At least two options are presented and evaluated (including "do nothing")
+- Author's recommendation is stated with reasoning
+- Known risks and open questions are named
+
+The draft is shared with a limited initial audience: the author's manager, the Staff IC if one exists, and one to two engineers from adjacent teams who will be affected. This pre-review surfaces obvious gaps before the RFC is opened to broader comment.
+
+### Stage 2: Open for Comment
+
+The RFC is published to the team or org's designated RFC channel or repository. The review window should be explicit and long enough for async review: a minimum of five business days for team-scoped decisions, ten business days for org-scoped decisions.
+
+**Opening announcement format:**
+```
+RFC-[number]: [title]
+Author: [name]
+Review deadline: [date]
+Scope: [team / multiple teams / org-wide]
+Summary: [one sentence]
+Link: [link to document]
+
+I'm looking for feedback specifically on:
+- [Question 1]
+- [Question 2]
+```
+
+During the review window, the author should actively engage with comments — not to defend the proposal, but to clarify ambiguities, acknowledge concerns, and update the document when feedback surfaces gaps.
+
+### Stage 3: Decision
+
+At the end of the review window, the designated decision-maker (typically the author's manager for team-scoped decisions, a Director or VP for org-scoped decisions) makes a decision. The three outcomes:
+
+- **Approve:** The RFC is accepted. Implementation may begin. The decision is recorded as an ADR.
+- **Revise:** The RFC requires significant changes before a decision can be made. The author revises and the review window reopens.
+- **Decline:** The RFC is not accepted. The "do nothing" option is chosen, or a different option from the RFC is selected. The decision is still recorded as an ADR — why not to change something is as valuable as why to change it.
+
+The decision should be communicated in the same channel where the RFC was published, with a brief rationale. Engineers who commented on an RFC and received no decision communication are likely to comment on future RFCs with lower engagement.
+
+### Stage 4: Decision Record
+
+The RFC's decision is converted to an ADR (Architectural Decision Record). The ADR captures the final decision and its rationale; the RFC document is preserved as the record of the review process and the options considered.
+
+**Relationship between RFC and ADR:**
+- The RFC lives in the RFC archive (a directory or wiki section designated for in-progress and completed RFCs)
+- The ADR lives in the codebase or repository it applies to (typically `/docs/adr/` or equivalent)
+- The ADR should link back to the RFC for the full context; the RFC should link forward to the ADR for the final decision
+
+---
+
+## Part 3: Review Mechanics
+
+### Who Has Blocking Authority vs. Advisory Voice
+
+Not every comment on an RFC has the same weight. Making this explicit prevents the RFC process from becoming a consensus-seeking exercise that stalls on every objection.
+
+**Blocking authority:** The decision-maker (manager or designated approver) has the only true blocking authority. An RFC cannot be blocked by a commenter who raises concerns — it can be blocked by the decision-maker who agrees those concerns are unresolved.
+
+**Technical blocking signals:** A Staff or Principal IC who identifies a technical flaw in the proposed approach has a strong signal. Their concern should be addressed or explicitly acknowledged in the decision rationale. Ignoring a Staff IC's technical objection and approving the RFC anyway without explanation damages the RFC process's credibility.
+
+**Advisory voice:** Everyone else. Advisory comments are valuable input to the decision — they are not veto power. The author and decision-maker should engage with advisory comments seriously, but "I disagree with this approach" from an advisory commenter does not block the decision.
+
+### Async vs. Sync Review
+
+Most RFC review should happen asynchronously. The review window exists to allow people to read, think, and respond on their own schedule — not to create a meeting. Reserve synchronous discussion for:
+
+- RFCs where the problem space is genuinely complex and a conversation would produce better signal than written comments
+- RFCs where the comment thread has reached an impasse that a structured conversation could resolve
+- RFCs with significant cross-team implications where a joint session prevents misunderstanding
+
+If a synchronous session is held, document the key points of the conversation and add them to the RFC before the review window closes. Engineers who could not attend should be able to read the RFC and understand the full context of the decision.
+
+### The Decision-Maker's Responsibility
+
+The decision-maker's job is not to find consensus. Consensus is valuable when it is natural; forced consensus — where the decision-maker delays the decision until objections go away — produces slow organizations and rewards the most persistent objectors. The decision-maker's job is to:
+
+1. Confirm that the review window was sufficient
+2. Confirm that significant objections were addressed or acknowledged
+3. Make the decision with the available information
+4. Communicate the decision and its rationale
+
+Disagreement after the decision is made is a normal outcome. Engineers who disagree should be able to express that in the ADR's "dissenting views" section, which exists precisely to avoid the false consensus of a document that pretends the decision was unanimous.
+
+---
+
+## Part 4: The RFC-to-ADR Relationship
+
+### What Goes in the RFC vs. the ADR
+
+| Content | RFC | ADR |
+|---|---|---|
+| Problem statement | Full description | Brief reference |
+| Options considered | Full analysis of all options | Summary of options, detail on chosen option |
+| Review comments | Yes | No (archived in RFC) |
+| Author's recommendation | Yes | N/A |
+| Final decision | Decision recorded at end | Primary content |
+| Consequences | Options for each alternative | Consequences of the decision as made |
+| Dissenting views | Comments section | Explicit "dissenting views" section |
+| Link to counterpart | Link to ADR (added after decision) | Link to RFC |
+
+### ADR Decision-Record Footer Block
+
+Add this block to the RFC document after the decision is made:
+
+```markdown
+---
+
+## Decision Record
+
+**Decision:** [Approve / Decline / Revise]
+**Decision-maker:** [Name and title]
+**Date:** [Date of decision]
+**ADR:** [Link to the ADR document]
+
+**Rationale:** [2–3 sentences summarizing why this decision was made]
+
+**Significant objections considered:**
+- [Objection]: [How it was addressed or why it was acknowledged but not determinative]
+```
+
+---
+
+## Templates
+
+### RFC Document Skeleton
+
+```markdown
+# RFC-[number]: [Title]
+
+**Author:** [Name]
+**Created:** [Date]
+**Status:** Draft | In Review | Decided | Superseded
+**Review deadline:** [Date]
+**Decision-maker:** [Name or role]
+**ADR:** [Link — added after decision]
+
+---
+
+## Summary
+
+[One paragraph: the problem, the proposed solution, and why it matters.
+Write this last — it should summarize the document, not introduce it.]
+
+---
+
+## Problem Statement
+
+[What problem are we solving? Be specific. Describe the current state and
+why it is insufficient. Include evidence where possible: error rates,
+performance data, developer time estimates, incident patterns.]
+
+---
+
+## Goals
+
+- [Specific, testable outcome 1]
+- [Specific, testable outcome 2]
+
+## Non-Goals
+
+- [What this RFC is explicitly not trying to solve]
+- [Scope boundary]
+
+---
+
+## Options Considered
+
+### Option 1: [Name] (Recommended)
+
+[Description of the option]
+
+**Pros:**
+- [Pro]
+- [Pro]
+
+**Cons:**
+- [Con]
+- [Con]
+
+**Risk:** [Primary risk of this option]
+
+### Option 2: [Name]
+
+[Description]
+
+**Pros / Cons / Risk** [same format]
+
+### Option 3: Do Nothing
+
+[What happens if we don't act. This option should always be included.
+If "do nothing" is clearly worse than every proposed option, say why.]
+
+---
+
+## Recommendation
+
+[Author's recommended option and 2–3 sentence rationale. Be direct.
+"I recommend Option 1 because..." not "Option 1 may be worth considering."]
+
+---
+
+## Open Questions
+
+- [Question that reviewers should specifically address]
+- [Dependency or assumption that needs validation]
+
+---
+
+## Consequences
+
+If the recommended option is adopted:
+- [What changes]
+- [What ongoing cost is introduced]
+- [What future flexibility is constrained]
+
+---
+
+## References
+
+- [Link to relevant prior RFC or ADR]
+- [Link to external documentation]
+```
+
+### Reviewer Guidance Card
+
+```
+When reviewing an RFC:
+
+1. Focus on the problem statement first. Is this the right problem to solve?
+   Is it bounded enough to be actionable?
+
+2. Evaluate the options analysis. Are the options genuinely distinct? Are the
+   trade-offs accurately represented? Is there an important option that's missing?
+
+3. Check the recommendation. Does the rationale follow from the analysis?
+   Is the author's preference legible, or does the recommendation appear
+   disconnected from the options as written?
+
+4. Name your role in the comment. "I think this is wrong" is less useful than
+   "As the team that owns the downstream service, we will need to [change X]
+   if this RFC is adopted — is that accounted for in the cost estimate?"
+
+5. If you have a blocking concern, say so explicitly. "This RFC should not
+   proceed without resolving [X]." Don't bury a blocking concern in a list
+   of advisory suggestions.
+
+6. If you don't have a blocking concern but have a preference, say that too.
+   "I'd prefer Option 2, but I can live with Option 1 if [condition]."
+```
+
+---
+
+## Anti-Patterns
+
+**The RFC as a Rubber Stamp.**
+A process where RFCs are written after the decision has already been made and implemented, used only to create documentation. The RFC loses its value as a review mechanism. Engineers learn that commenting on RFCs has no effect and stop engaging.
+
+**The Consensus Trap.**
+Delaying decision-making until every objection is resolved. In a technically opinionated team, some objections will never be fully resolved — the decision-maker's job is to acknowledge them and decide anyway. A process that requires consensus to move forward produces paralysis on contested decisions.
+
+**The Scope Creep RFC.**
+An RFC that starts with a specific technical question and expands to include organizational philosophy, process reform, or questions that belong in a different forum. Scope-creep RFCs become long, unfocused, and hard to decide on. Keep the problem statement bounded.
+
+**The Missing "Do Nothing" Option.**
+An RFC that presents two implementation approaches without considering whether the change is necessary at all. "Do nothing" is always an option and should always be analyzed. An RFC that cannot make the case against "do nothing" may not have a sufficiently compelling problem statement.
+
+**The Undocumented Decision.**
+An RFC that concludes with a decision communicated verbally or in a Slack thread, without an ADR. The RFC process's value is captured in the ADR — a decision that exists only in memory or a Slack archive is effectively undocumented, regardless of how thorough the RFC was.
+
+[^1]: The Rust RFC Process. https://github.com/rust-lang/rfcs — the canonical open-source RFC process from which many engineering RFC conventions derive.
+[^2]: Larson, W. (2019). *An Elegant Puzzle: Systems of Engineering Management*. Stripe Press. Chapter 4 discusses architectural decision-making and documentation at the org level.

--- a/leadership/rfc-design-doc-process.md
+++ b/leadership/rfc-design-doc-process.md
@@ -174,6 +174,8 @@ Add this block to the RFC document after the decision is made:
 
 ### RFC Document Skeleton
 
+Write the Summary section last — it should compress the completed document, not introduce it.
+
 ```markdown
 # RFC-[number]: [Title]
 
@@ -188,8 +190,7 @@ Add this block to the RFC document after the decision is made:
 
 ## Summary
 
-[One paragraph: the problem, the proposed solution, and why it matters.
-Write this last — it should summarize the document, not introduce it.]
+[One paragraph: the problem, the proposed solution, and why it matters.]
 
 ---
 

--- a/org-design/reorg-execution-guide.md
+++ b/org-design/reorg-execution-guide.md
@@ -1,0 +1,262 @@
+# Reorg Execution Guide
+
+## Leadership Context
+
+The [Team Topology Framework](team-topology-framework.md) describes the principles for designing a well-structured engineering organization: stream-aligned teams, platform teams, enabling teams, and the cognitive load thresholds that tell you when a team topology has run past its usefulness. That framework addresses the question of *what* to change and *why*. This guide addresses what happens after that question is answered — the execution of the reorganization itself.
+
+The execution is where most reorgs fail to achieve their intended effect. The structural change is made correctly: reporting lines are updated, charters are redrawn, headcount is reallocated. But the human elements — the communication sequencing, the handling of the announcement, the re-establishment of norms in reconfigured teams — are underestimated or deferred. Engineers who experience a reorg as a thing that happened to them rather than a decision they can understand are less likely to perform well in the new structure, regardless of whether the structure is correct.
+
+This guide is not about whether to reorg. That decision belongs in the topology framework. This guide is about how to execute a reorg in a way that preserves trust, minimizes the performance dip that every reorg produces, and re-establishes effective team norms as quickly as possible.
+
+## Background and Motivation
+
+This framework is grounded in the platform directorate formation at ActBlue Technical Services (2022), which involved significant structural change: chartering new teams (DevEx, Payments Architecture, Database Platform), realigning existing team scope, and shifting reporting structures across approximately fifty engineers. The framework also reflects observation of subsequent reorgs at ActBlue where I was an organizational stakeholder rather than the primary executor — which provided a contrasting view of what the process looks like from the receiving end.
+
+For engineers stepping into the role of a newly reorganized team, the [Inheriting a Team You Didn't Hire](../transitions/inheriting-a-team.md) framework provides the complementary playbook.
+
+## When to Use This
+
+| Trigger | What This Framework Provides |
+|---|---|
+| Chartering a new team from scratch | Pre-announcement checklist, communication sequencing |
+| Merging two teams into one | Announcement guidance, re-norming process for the combined team |
+| Splitting a team into two | Structural preparation, manager briefing sequence |
+| Realigning reporting lines without changing team charters | Simplified communication sequence (skip team charter work) |
+| Post-acquisition integration of an engineering team | Extended version of the full execution sequence with HR and legal coordination |
+
+---
+
+## Part 1: Pre-Announcement Checklist
+
+Nothing should be communicated to the broader team before every item on this list is complete. The sequencing matters: the people most affected should know before the people least affected. Reverting this order — announcing broadly before affected managers are prepared — is the single most common execution failure in reorgs.
+
+### Structural Decisions (complete before any communication)
+
+- [ ] Reporting lines are finalized and approved by the appropriate level of leadership
+- [ ] New team charters are drafted (scope, ownership boundaries, team name if changing)
+- [ ] Headcount assignments are confirmed — every engineer has a clear landing in the new structure
+- [ ] Any role changes (level adjustments, new manager assignments) are confirmed with HR
+- [ ] Compensation adjustments if applicable are confirmed and ready to communicate
+
+### HR and Legal Alignment
+
+- [ ] HR has reviewed the plan for any performance-related personnel decisions made in connection with the reorg
+- [ ] If any roles are being eliminated: HR, legal, and the manager of record are aligned on timing and communication
+- [ ] If any roles are being created: job specs and level definitions are drafted and approved
+
+### Manager Briefing Sequence
+
+Before any broader communication:
+
+1. **Brief the manager's manager first** — they need to be able to answer questions without appearing surprised
+2. **Brief each affected manager in 1:1 conversations** — do not deliver reorg news to managers in a group setting
+3. **Allow 24 hours for managers to process** before expecting them to deliver the news to their teams
+4. **Confirm manager messaging** — give each manager the core points they need to communicate and the questions they should be prepared to answer
+
+The gap between the manager briefings and the team announcement should be as short as possible (24–72 hours). Reorg plans that are widely known at the manager layer but not communicated to ICs produce anxiety from information asymmetry.
+
+---
+
+## Part 2: The Announcement
+
+### What to Say
+
+The announcement should answer five questions in the following order. If the announcement does not answer one of these questions, the team will spend the post-announcement period generating their own answers, and the generated answers will be worse than anything you would have said.
+
+1. **What is changing?** The specific structural change: who is moving where, what teams are changing, what the new structure looks like. Specific, not vague. "The platform and infrastructure teams are merging" is better than "we are optimizing our org structure for scale."
+
+2. **Why is this happening now?** The business or technical rationale. Not a comprehensive history — one to two sentences that give engineers a real reason, not a platitude. "Our current team boundaries have created a dependency bottleneck that is slowing every team's delivery" is a real reason. "To position the org for future growth" is not.
+
+3. **What does this mean for you specifically?** The team members want to know: does my job change? does my manager change? does my project change? Generic announcements that do not answer the individual question produce individual anxiety that spreads into collective distraction.
+
+4. **What is not changing?** Naming what stays the same is as important as naming what changes. Engineers will assume that everything is uncertain until you tell them otherwise. If the tech stack, the current project commitments, and the on-call rotation are not changing, say so explicitly.
+
+5. **What happens next, and by when?** A concrete timeline for the transition. "Team charters will be finalized by [date]. New sprint planning begins on [date]. Individual 1:1s with your new manager will be scheduled by [date]." Uncertainty about next steps produces more anxiety than the reorg itself.
+
+### Announcement Formats
+
+**All-hands (synchronous, preferred):** Allows questions to be answered in real time. Schedule no more than 24 hours after manager briefings. Prepare for questions in three categories: logistics (what exactly is changing and when), motivation (why this decision was made), and personal impact (what does this mean for me). Answers should be prepared for each category.
+
+**Written announcement (async, as supplement):** Always follow a verbal announcement with a written summary that engineers can reference later. The written version should contain the same five-question structure as the verbal announcement. Do not send the written announcement before the verbal — questions arrive without any opportunity for clarification.
+
+**Do not announce via org chart change.** Org charts updated in systems before the announcement has been made allow engineers to discover the change without context. Check whether your HR system's org chart is visible to employees before the announcement and, if it is, delay the system update until after.
+
+---
+
+## Part 3: The 72 Hours After Announcement
+
+The 72 hours following a reorg announcement are the highest-risk period for the changes the reorg intended to produce. Engineers are processing, and what they are looking for from leadership is not more information — it is consistency between what was said in the announcement and what is happening in the building.
+
+### What to Watch For
+
+**The Informal Information Network.** Engineers talk to each other, and the informal information that circulates after an announcement is often more influential than the official communication. Watch for the signal that is moving through the team's informal channels: what questions are being asked in Slack, what uncertainty is being expressed in retros, what the first-line managers are hearing in 1:1s. The gap between what was communicated and what is circulating informally is where the announcement failed.
+
+**The High Performer Who Goes Quiet.** After a reorg, strong performers who are uncertain about the new structure may go quiet — not as an act of disengagement, but as a processing strategy. A high performer who is visibly less engaged in the week after an announcement should have a direct check-in conversation: "How are you experiencing the change? Is there anything I can answer or clarify?" This should not wait for the next scheduled 1:1.
+
+**The Manager Who Is Not Ready.** Some managers will have absorbed the reorg news intellectually but will not be emotionally ready to deliver it clearly to their teams. If you observe a manager who is communicating uncertainty, frustration, or ambivalence to their direct reports, address it in a 1:1 with the manager — not in the all-hands.
+
+### One-on-One Cadence
+
+In the week following the announcement, every manager should have a 1:1 with every direct report. These should not be status meetings — they should be check-in conversations:
+
+- How are you doing with the change?
+- What is the most uncertain thing for you right now?
+- Is there anything about your role or project that you need clarity on?
+- What can I do to make this transition easier?
+
+Do not skip these conversations because the team "seemed fine" in the all-hands. The all-hands creates a social context in which expressing concern is uncomfortable. The 1:1 is where the real concerns surface.
+
+---
+
+## Part 4: Re-Establishing Norms
+
+The most underestimated phase of a reorg is the re-establishment of team norms. Even when the individual engineers are the same and the work is the same, a change in team membership or structure disrupts the implicit agreements that govern how work gets done.
+
+### What Norms Need Re-Establishing
+
+**Decision-making authority.** In a newly formed team, nobody is yet certain whose job it is to make which decisions. Explicitly re-run the decision authority conversation early: who has authority in which domains, how disagreements get resolved, what gets escalated.
+
+**Communication cadence.** How the team communicates across sync (standups, planning, retro) and async (Slack, docs, code review) channels should be explicitly agreed, not assumed to transfer from the prior structure. Different teams have different norms, and a merged team will bring multiple prior norms into contact.
+
+**Quality standards.** Code review standards, test coverage expectations, and deployment conventions should be explicitly re-agreed when a team's membership changes. "We've always done it this way" is no longer a complete statement when half the team is new to this team's "always."
+
+### The Re-Norming Retro
+
+Within the first two sprints of the new team structure, run a structured retro focused specifically on norms — not on sprint output. Format:
+
+```
+1. What do we want to keep from how each of our prior teams operated? (10 min)
+2. What do we want to leave behind? (10 min)
+3. What do we need to create that neither team had? (10 min)
+4. What is the one thing we should decide today to make the next sprint go better? (10 min)
+```
+
+The output of this retro is a brief working agreement — not a comprehensive policy document, but a short list of explicit agreements that the team can hold each other accountable to.
+
+### The New Team Charter
+
+For teams that are newly formed or significantly restructured, a written team charter reduces the period of norm uncertainty. The charter should cover:
+
+- Team mission and primary ownership domain
+- Team name (if new)
+- Scope: what the team is responsible for, and what is explicitly out of scope
+- Dependencies: which other teams this team depends on, and which teams depend on this team
+- Decision authority: how the team makes decisions within its scope
+- Operating cadence: recurring ceremonies and their purpose
+
+The team charter is not a bureaucratic document — it is a working tool. It should be short enough to be consulted in practice (one page is ideal) and should be revisited at the six-month mark or after any significant scope change.
+
+---
+
+## Templates
+
+### Announcement Email / Slack Message
+
+```
+Subject: [Team name] — organizational change
+
+I want to share a change we're making to our team structure, effective [date].
+
+**What's changing:**
+[Specific structural change: who moves where, what team names change, what scope changes]
+
+**Why:**
+[1–2 sentences of real rationale — a specific problem this change addresses]
+
+**What this means for you:**
+[The individual impact — role changes if any, manager changes if any, project continuity]
+
+**What's not changing:**
+[Explicit list of things that stay the same]
+
+**What happens next:**
+- [Date]: [Specific next step — new manager 1:1s, charter finalization, etc.]
+- [Date]: [Specific next step]
+- [Date]: [Specific next step]
+
+I'll be holding time in [all-hands / office hours / channel] on [date] for questions.
+
+[Signature]
+```
+
+### Manager Briefing Agenda (pre-announcement)
+
+```
+1. What is changing (5 min)
+   - Walk through the specific structural change
+   - Show the before and after reporting structure
+
+2. Why it's happening (5 min)
+   - The rationale, at the level of detail you are authorized to share
+   - What problems this is intended to solve
+
+3. What each manager needs to communicate to their team (10 min)
+   - The core message: what, why, personal impact, what's not changing, next steps
+   - What questions to expect and how to answer them
+   - What to say when you don't know the answer ("I'll find out and get back to you by [date]")
+
+4. Manager questions (10 min)
+   - Take questions. Document anything you cannot answer in the room.
+   - Follow up on undisclosed items before the announcement.
+```
+
+### Team Charter Kickoff Agenda
+
+```
+45-minute working session, first week of new team structure
+
+1. Mission statement draft (15 min)
+   - Why does this team exist? What would be missing if it didn't?
+   - What is the team responsible for? What is explicitly out of scope?
+
+2. Dependencies and interfaces (10 min)
+   - Which teams do we depend on?
+   - Which teams depend on us?
+   - Where are the potential conflict points?
+
+3. Decision authority (10 min)
+   - What decisions does the team make independently?
+   - What requires escalation?
+   - How do we handle disagreements within the team?
+
+4. Operating cadence (10 min)
+   - What recurring ceremonies do we want? At what frequency?
+   - How do we communicate across sync/async?
+   - Who owns the team calendar / documentation home?
+```
+
+### Re-Norming Retro Format
+
+```
+Pre-work: every team member writes 2–3 sticky notes per prompt before the session
+
+Prompt 1: What do we want to KEEP from how our prior teams operated?
+Prompt 2: What do we want to LEAVE BEHIND?
+Prompt 3: What do we need to CREATE that neither team had?
+
+Session structure:
+- Share and cluster stickies (15 min)
+- Dot vote on most important items in each category (5 min)
+- Discuss top 3 per category (20 min)
+- Agree on one working agreement to start with (10 min)
+- Schedule follow-up retro in 2 sprints (5 min)
+```
+
+---
+
+## Anti-Patterns
+
+**The Surprise Announcement.**
+An all-hands where the engineering team first learns about a reorg. This is almost always avoidable — the leak risk of manager-first briefings is lower than the trust damage of a surprise announcement. Engineers who learn about a reorg from a system update or a hallway conversation before the formal announcement feel managed rather than respected.
+
+**The Org Chart Without Context.**
+A reorg communicated only as a reporting-line change, without explanation of the rationale or the intended outcome. Engineers experiencing this will supply their own rationale, and the supplied rationale will frequently be worse than the actual one ("they must be preparing to reduce headcount," "they must have lost confidence in [manager]").
+
+**The False Certainty.**
+An announcement that presents the new structure as definitely correct and final. Engineers know that org structures change. Presenting a reorg as permanent — "this is the right structure for where we're going" — and then revising it six months later produces more trust damage than an announcement that acknowledges the structure is the best current answer to the current problem.
+
+**The Skipped Re-Norming.**
+Assuming that because the work is the same and some of the people are the same, the team norms transfer automatically. They do not. Every team membership change resets some portion of the implicit operating agreement, and the reset period is longer when it is unaddressed.
+
+**The Delayed Charter.**
+Running a newly structured team without a written charter for the first quarter because "we'll figure it out as we go." The figuring-out period produces real costs: scope disputes with adjacent teams, decision-making ambiguity, and onboarding friction for any new engineer who joins before the charter exists.

--- a/people/hiring-and-interview-design.md
+++ b/people/hiring-and-interview-design.md
@@ -4,7 +4,7 @@
 
 Hiring is the highest-leverage people decision an engineering leader makes. A promotion affects one career. A hire affects the team's culture, capability, and capacity for the next two to four years — longer if the hire becomes a senior IC or manager. Yet most engineering interview processes are designed by accident: a standard take-home problem inherited from a prior loop, a panel assembled by availability, and a debrief that surfaces the hiring manager's gut feelings dressed in technical language.
 
-The structural failure of accidental interview processes is that they optimize for pattern-matching against the interviewers rather than against the role. A panel of engineers who all came from similar backgrounds, companies, or problem domains will consistently prefer candidates who look like them — not because they are biased in the colloquial sense, but because their calibration anchors are skewed. Structured hiring design is not primarily about fairness, though fairness is a real benefit. It is about signal quality. A structured process produces more accurate predictions of job performance than an unstructured one, because it forces the signal to be role-relevant rather than interviewer-convenient.
+The structural failure of accidental interview processes is that they optimize for pattern-matching against the interviewers rather than against the role. A panel of engineers who all came from similar backgrounds, companies, or problem domains will consistently prefer candidates who look like them — not because they are biased in the colloquial sense, but because their calibration anchors are skewed. Structured hiring design is not primarily about fairness, though fairness is a real benefit. It is about signal quality. A structured process produces more accurate predictions of job performance than an unstructured one, because it forces the signal to be role-relevant rather than interviewer-convenient.[^1]
 
 This framework covers the full hiring loop from job spec to offer, with emphasis on panel design, rubric calibration, and the debrief — the three moments where structured design produces the most measurable improvement.
 
@@ -141,7 +141,7 @@ Structured process is the primary bias mitigation mechanism — not training, no
 
 **Standardized questions.** Every candidate is asked the same core questions in the same order by each interviewer. Variation from the standard question set should be noted in the debrief.
 
-**Written notes before discussion.** Every interviewer records their scores and evidence in writing before the debrief begins. Research consistently shows that oral-first debriefs produce anchoring effects — the first opinion expressed shapes subsequent evaluations, regardless of evidence quality. Written notes before discussion prevent this.
+**Written notes before discussion.** Every interviewer records their scores and evidence in writing before the debrief begins. Research consistently shows that oral-first debriefs produce anchoring effects — the first opinion expressed shapes subsequent evaluations, regardless of evidence quality.[^2] Written notes before discussion prevent this.
 
 **Score submission before debrief.** Scores are submitted (to the recruiter or an ATS system) before the debrief. This creates an auditable record and prevents retroactive score adjustment to align with consensus.
 
@@ -256,3 +256,6 @@ Adding interview stages past the point of new signal because the panel is not co
 
 **The Comfort Hire.**
 Hiring the candidate the panel is most comfortable with rather than the most capable. Comfort correlates with similarity. The candidate who challenges the panel's assumptions, asks hard clarifying questions, and pushes back on an underspecified prompt is demonstrating exactly the behavior a strong engineer should demonstrate in production — but they are often experienced as difficult in an interview context.
+
+[^1]: Schmidt, F. L., & Hunter, J. E. (1998). The validity and utility of selection methods in personnel psychology: Practical and theoretical implications of 85 years of research findings. *Psychological Bulletin*, 124(2), 262–274. The canonical meta-analysis on interview validity; structured interviews consistently outpredict unstructured ones across job types and levels.
+[^2]: Tversky, A., & Kahneman, D. (1974). Judgment under uncertainty: Heuristics and biases. *Science*, 185(4157), 1124–1131. The foundational anchoring-effect research; the application to group debriefs (where the first speaker's framing shapes subsequent evaluations) is its direct downstream use.

--- a/people/hiring-and-interview-design.md
+++ b/people/hiring-and-interview-design.md
@@ -1,0 +1,258 @@
+# Hiring and Technical Interview Design
+
+## Leadership Context
+
+Hiring is the highest-leverage people decision an engineering leader makes. A promotion affects one career. A hire affects the team's culture, capability, and capacity for the next two to four years — longer if the hire becomes a senior IC or manager. Yet most engineering interview processes are designed by accident: a standard take-home problem inherited from a prior loop, a panel assembled by availability, and a debrief that surfaces the hiring manager's gut feelings dressed in technical language.
+
+The structural failure of accidental interview processes is that they optimize for pattern-matching against the interviewers rather than against the role. A panel of engineers who all came from similar backgrounds, companies, or problem domains will consistently prefer candidates who look like them — not because they are biased in the colloquial sense, but because their calibration anchors are skewed. Structured hiring design is not primarily about fairness, though fairness is a real benefit. It is about signal quality. A structured process produces more accurate predictions of job performance than an unstructured one, because it forces the signal to be role-relevant rather than interviewer-convenient.
+
+This framework covers the full hiring loop from job spec to offer, with emphasis on panel design, rubric calibration, and the debrief — the three moments where structured design produces the most measurable improvement.
+
+## Background and Motivation
+
+This framework is grounded in hiring across three domains at ActBlue Technical Services (2022–2025): platform engineering (backend systems, infrastructure, database engineering), payments and integrations (high-reliability, regulatory-adjacent), and engineering management (technical EMs for platform teams). Across those domains I designed and calibrated interview loops, trained interviewers, ran debriefs, and made or contributed to hiring decisions at the SE2 through Staff level. The calibration experience is further grounded in the Engineering Management Community of Practice at ActBlue, where interview calibration was a recurring agenda item.
+
+The hard-won lesson from that work: the debrief is where most structured processes fall apart. Rubrics that are carefully designed in the abstract are ignored in practice once a senior person in the room signals a strong opinion. The debrief facilitation guidance in this framework is specifically designed to address that failure mode.
+
+## When to Use This
+
+| Trigger | What This Framework Provides |
+|---|---|
+| Opening a new IC or EM role | End-to-end loop design: job spec, panel composition, rubric, debrief |
+| Inheriting a broken or inconsistent interview process | A structured replacement with role-relevant calibration |
+| Calibrating a panel of interviewers for a specific level | A rubric format and anchor examples for each competency |
+| Running a debrief where consensus is elusive | A facilitation protocol for signal-based decision-making |
+| Post-hire retrospective on a failed hire | A diagnostic for which stage of the loop produced false signal |
+
+---
+
+## Part 1: Job Spec Design
+
+The job spec is not a recruiting document. It is a forcing function for the hiring team to agree on what they actually need before interviewing anyone.
+
+### The Two Failure Modes of Job Specs
+
+**The Kitchen Sink:** Every desirable attribute is listed as a requirement. The spec describes a unicorn, the recruiting team presents unicorn candidates, and the panel debates whether each one is unicorn enough. The interview loop becomes a search for disqualifying evidence rather than a calibration of signal against role requirements.
+
+**The Copy-Paste:** The spec is copied from a prior role or a job board template and minimally modified. The panel interviews against a spec that does not reflect the actual role, produces signal that does not answer the right questions, and debrief discussions get muddled because different interviewers were evaluating for different things.
+
+### Job Spec Structure
+
+A useful job spec for calibration purposes has four sections:
+
+```
+## What This Role Does
+[2–3 sentences: the primary responsibility, the team context, and what
+"done well" looks like in the first year. Not a list of tasks — a description
+of impact.]
+
+## Must Have
+[3–5 specific, testable requirements. These are used to screen candidates in
+or out at the resume and phone screen stage. If every candidate passes must-have,
+the criteria are not discriminating enough.]
+
+## Strong Signal
+[3–5 attributes that distinguish a strong hire from a passing hire.
+These are the rubric axes the panel is evaluating.]
+
+## Not Required
+[1–3 things that look relevant but are not actually needed for success.
+This section exists to prevent false negatives: candidates rejected for
+lacking something the role does not require.]
+```
+
+---
+
+## Part 2: Panel Design
+
+### Principles
+
+**Each interviewer covers one competency, not all competencies.** A panel where every interviewer asks "tell me about a time you disagreed with a stakeholder" produces redundant signal and leaves gaps. Assign coverage explicitly.
+
+**Panel composition should not mirror the team's current composition.** If the entire team is backend engineers from similar backgrounds, a panel that is entirely backend engineers from similar backgrounds will consistently prefer candidates who match that profile. Intentionally include at least one panel member from an adjacent function (product, platform, data) for roles that require cross-functional collaboration.
+
+**The hiring manager is not the best rubric judge.** Hiring managers are the worst people to evaluate whether the process is working — they want to hire the person they are excited about, which creates motivated reasoning when evaluating how well the rubric was applied. Assign a process owner (often a senior IC or an EM from another team) whose job is to ensure the rubric was applied, not to make the hiring decision.
+
+### Standard Loop Structure
+
+| Stage | Owner | Purpose | Signal Captured |
+|---|---|---|---|
+| Resume screen | Recruiter + hiring manager | Must-have filter | Technical background, role relevance |
+| Recruiter screen (30 min) | Recruiter | Logistics and communication baseline | Availability, level-setting, communication clarity |
+| Technical phone screen (45 min) | Senior IC | Technical depth baseline | Domain knowledge, problem-solving process |
+| Take-home or async exercise (≤2 hrs) | N/A | Applied problem-solving | Approach, quality, trade-off articulation |
+| Loop day | Panel (3–4 interviewers) | Multi-axis evaluation | See rubric below |
+| Debrief | Hiring manager + panel | Decision | Rubric-based consensus |
+
+**On take-home exercises:** time-bounded exercises (2 hours maximum) with explicit instructions that completion is not expected reduce both candidate burden and signal noise. A candidate who makes reasonable progress and articulates trade-offs clearly has demonstrated more relevant signal than one who completes a polished submission after six hours.
+
+### Panel Role Assignments (IC Loop)
+
+| Interviewer | Competency | Format |
+|---|---|---|
+| Senior IC (same domain) | Technical depth | Paired problem-solving or code review |
+| EM or senior IC (adjacent domain) | System design | Architecture discussion |
+| IC (any level) | Collaboration and communication | Behavioral: cross-functional scenarios |
+| Hiring manager | Role fit and growth | Behavioral: career trajectory, motivation |
+
+---
+
+## Part 3: Rubric Design
+
+### Four-Axis Format
+
+Every rubric should evaluate the same four axes, with the relative weight adjusted per role:
+
+| Axis | Definition | Example Evidence |
+|---|---|---|
+| **Technical Depth** | Domain-specific knowledge and problem-solving capability | Correct reasoning under ambiguity; identifies trade-offs rather than reciting patterns |
+| **Collaboration** | How the candidate operates in multi-person contexts | Listens before proposing; builds on interviewer input; disagrees constructively |
+| **Communication** | Clarity and efficiency of explanation | Can explain a complex system to a non-expert; asks clarifying questions before answering |
+| **Growth** | Trajectory and capacity to develop | Names what they do not know; describes how they address gaps; adapts when given new information |
+
+### Scoring Scale
+
+Use a four-point scale — do not use a five-point scale with a nominal midpoint, because midpoint scores produce no signal.
+
+| Score | Label | Meaning |
+|---|---|---|
+| 4 | Strong Yes | Clear evidence; would be an asset at this level |
+| 3 | Yes | Adequate evidence; meets bar for this level |
+| 2 | No | Insufficient evidence; does not meet bar |
+| 1 | Strong No | Clear evidence of disqualifying gap |
+
+**Write anchor examples for each score on each axis before the loop begins.** Without anchors, interviewers apply their own personal calibration to the scale, which produces the comparison problem the rubric is designed to prevent.
+
+### Rubric Calibration Session
+
+Before the first candidate in a loop, the panel meets for 30 minutes to align on:
+
+1. What does a "3 on Technical Depth" look like for this specific role and level?
+2. What specific question will each interviewer use to evaluate their assigned axis?
+3. Are there any known biases in our panel composition that we should name explicitly?
+
+The calibration session does not need to be a major production. Thirty minutes of alignment before the first interview is worth more than an hour of debrief cleanup after the fifth.
+
+---
+
+## Part 4: Bias Mitigation
+
+Structured process is the primary bias mitigation mechanism — not training, not checklist, not single-point awareness interventions. The following structural choices reduce bias by design:
+
+**Standardized questions.** Every candidate is asked the same core questions in the same order by each interviewer. Variation from the standard question set should be noted in the debrief.
+
+**Written notes before discussion.** Every interviewer records their scores and evidence in writing before the debrief begins. Research consistently shows that oral-first debriefs produce anchoring effects — the first opinion expressed shapes subsequent evaluations, regardless of evidence quality. Written notes before discussion prevent this.
+
+**Score submission before debrief.** Scores are submitted (to the recruiter or an ATS system) before the debrief. This creates an auditable record and prevents retroactive score adjustment to align with consensus.
+
+**Named calibration anchors.** "I felt like they were confident" is not evidence. "They correctly identified the consistency trade-off in the distributed caching scenario without prompting" is evidence. The calibration session's anchor examples enforce evidence-based language in the debrief.
+
+---
+
+## Part 5: The Debrief
+
+The debrief is where structured processes most commonly fail. A well-designed rubric applied inconsistently in the debrief produces worse outcomes than an imperfect rubric applied consistently, because it creates false precision.
+
+### Debrief Protocol
+
+**Step 1 — Scores surface first (5 min).** The recruiter or process owner reads each interviewer's scores aloud before discussion begins. No commentary, no justification — just the numbers. This creates a visible distribution. Outliers (one "4" and three "2"s) surface immediately and direct the debrief toward the most uncertain signal.
+
+**Step 2 — Evidence round (15 min).** Each interviewer summarizes their evidence in 2–3 sentences. The format is: "I scored [axis] a [score] because [specific observation]." The hiring manager does not offer their view during the evidence round — they facilitate it.
+
+**Step 3 — Disagreement resolution (10 min).** Where scores diverge by more than one point on the same axis, the interviewers present their evidence and the panel tries to reconcile the divergence with additional context. If the divergence cannot be resolved with available evidence, that axis is marked "insufficient signal" — not averaged.
+
+**Step 4 — Hiring manager decision (5 min).** After evidence is on the table, the hiring manager makes a recommendation: hire, no-hire, or additional interview (used sparingly — second loops should be reserved for genuine insufficient signal, not ambivalence). The decision is theirs to make, but it should be grounded in the rubric evidence, and the hiring manager should be able to articulate which axis drove the decision.
+
+### Breaking the Halo Effect
+
+The halo effect — where a strong impression on one axis inflates scores on all others — is the most common rubric failure mode. Watch for:
+
+- An interviewer who scored every axis identically
+- A score pattern that does not match the qualitative evidence offered
+- Language like "just a really strong engineer" without axis-specific grounding
+
+When you see this pattern, ask: "Which axis produced that impression, specifically?" This forces the interviewer to locate their evaluation in evidence rather than gestalt.
+
+---
+
+## Templates
+
+### Job Spec Template
+
+```
+## What This Role Does
+[2–3 sentences. Primary responsibility, team context, first-year definition of done.]
+
+## Must Have
+- [Specific, testable requirement 1]
+- [Specific, testable requirement 2]
+- [Specific, testable requirement 3]
+
+## Strong Signal
+- [Differentiating attribute 1]
+- [Differentiating attribute 2]
+- [Differentiating attribute 3]
+
+## Not Required
+- [Thing that looks relevant but isn't]
+- [Thing that looks relevant but isn't]
+```
+
+### Rubric Scorecard
+
+```
+Candidate: _______________    Interviewer: _______________    Date: ___________
+Role: _______________         Level: _______________
+
+Axis                | Score (1–4) | Evidence (2–3 sentences)
+--------------------|-------------|---------------------------
+Technical Depth     |             |
+Collaboration       |             |
+Communication       |             |
+Growth              |             |
+
+Overall: [ ] Strong Yes  [ ] Yes  [ ] No  [ ] Strong No
+
+Additional context for debrief:
+```
+
+### Debrief Agenda
+
+```
+1. Score read-out — recruiter/process owner reads all scores aloud (5 min)
+2. Evidence round — each interviewer: "I scored [axis] a [N] because..." (15 min)
+3. Disagreement resolution — outliers only (10 min)
+4. Hiring manager recommendation (5 min)
+5. Next steps and offer discussion if hire (5 min)
+```
+
+### Offer-Stage Checklist
+
+```
+[ ] Rubric scores documented in ATS
+[ ] Debrief summary written and attached to candidate record
+[ ] Offer parameters confirmed with recruiter (level, band, start date)
+[ ] Hiring manager makes verbal offer call (do not email an offer before verbal)
+[ ] Written offer sent within 24 hours of verbal acceptance
+[ ] Background check initiated (where applicable)
+[ ] Start date and onboarding plan confirmed before offer letter closes
+```
+
+---
+
+## Anti-Patterns
+
+**The Vibe Check.**
+A debrief where the primary question is "did you like them?" A candidate can be likable and wrong for the role. A candidate can be awkward and exactly what the team needs. Likability is not a rubric axis unless the role is externally-facing in a way that makes communication style a performance requirement — in which case it should appear as a named axis with evidence anchors.
+
+**The Bar Raiser Bottleneck.**
+A process where a single designated "bar raiser" has veto authority without needing to articulate rubric-based evidence. The bar raiser role (adapted from Amazon's loop design) works well when the bar raiser is required to justify their decision in evidence-based terms. It fails when the role becomes a license for undisclosed personal standards.
+
+**The Recency Trap.**
+A debrief where the final interviewer's impression dominates because it is freshest in the room. This is why scores are submitted in writing before the debrief — so the last impression is on record before discussion, not recorded after it.
+
+**The Loop Inflation.**
+Adding interview stages past the point of new signal because the panel is not confident. A sixth interview does not produce confidence that four interviews did not provide — it produces fatigue on the candidate's side and ambivalence on the panel's. If the panel cannot make a hire/no-hire decision after four to five structured interviews, the problem is rubric calibration or signal quality, not quantity.
+
+**The Comfort Hire.**
+Hiring the candidate the panel is most comfortable with rather than the most capable. Comfort correlates with similarity. The candidate who challenges the panel's assumptions, asks hard clarifying questions, and pushes back on an underspecified prompt is demonstrating exactly the behavior a strong engineer should demonstrate in production — but they are often experienced as difficult in an interview context.

--- a/people/staff-engineer-partnership.md
+++ b/people/staff-engineer-partnership.md
@@ -1,0 +1,240 @@
+# Staff and Principal Engineer Partnership
+
+## Leadership Context
+
+The manager-IC relationship at the senior level is one of the most underspecified partnerships in engineering organizations. At the Staff level — Staff Engineer, Principal Engineer, and their manager-track equivalents — the relationship changes character in ways that most engineering management frameworks do not describe adequately. The Staff IC is not a very good senior engineer who needs more coaching. They are a peer operating in a different functional dimension: where the manager owns the org, the Staff IC owns the technical direction, and both need the other to do their job well.
+
+The failure mode is predictable: either the manager over-controls the technical domain (producing an IC who stops taking technical initiative) or the IC operates with full independence in a way that disconnects from organizational priorities (producing technical work that nobody asked for). The partnership model described here is a forcing function against both failure modes. It requires both parties to make the implicit explicit: who owns what, how decisions get made when they conflict, and what each party needs from the other to operate at full effectiveness.
+
+This framework is distinct from the [Career Ladder and Calibration Playbook](career-ladder-calibration.md), which describes what Staff-level performance looks like. This framework describes how to operate the relationship once someone is at the Staff level — or aspiring toward it.
+
+## Background and Motivation
+
+The framework draws on the Staff and Principal IC partnerships built during the platform directorate at ActBlue Technical Services (2022–2025). Across six platform teams, the directorate included Staff-level ICs in database engineering, DevEx, and payments architecture. The partnerships were meaningfully different in each domain: the database Staff IC operated with near-total technical autonomy in a domain with limited cross-team overlap; the DevEx Staff IC co-owned a roadmap that touched every team; the payments architecture IC operated in a regulatory context where technical decisions required legal and compliance sign-off. The framework abstracts from those three cases the elements that generalized across domain contexts.
+
+The "sponsor/coach/peer" distinction is grounded in the work of Lara Hogan and the sponsor concept developed in equity and career development research, applied here to the specific context of the Staff IC career track.[^1]
+
+## When to Use This
+
+| Trigger | What This Framework Provides |
+|---|---|
+| First time managing a Staff or Principal IC | A structured approach to the authority split and shared roadmap |
+| Staff IC and manager in misalignment about scope or priorities | A shared vocabulary and process for surfacing and resolving the conflict |
+| IC approaching Staff readiness | A map of what changes about the relationship at the Staff level |
+| Post-reorg where a Staff IC changes reporting lines | A re-norming process for a partnership that is starting over with prior context |
+| Org adding its first Staff IC | A charter for establishing the role before misaligned expectations calcify |
+
+---
+
+## Part 1: The Authority Split
+
+The most important thing to make explicit in a Staff partnership is who has authority over what. Ambiguity here is the root cause of most partnership failures — not personality conflict, not misaligned goals, but unstated assumptions about who gets to make which decisions.
+
+### What Belongs to the Manager
+
+- Team structure, reporting lines, and team charters
+- Headcount decisions: when to hire, who to hire for, at what level
+- Performance evaluation and calibration (the Staff IC's input is highly weighted but the decision is the manager's)
+- Roadmap prioritization where multiple teams or business priorities are in conflict — the manager breaks ties when technical preference does not provide a resolution
+- Organizational communication: what goes to senior leadership, what gets escalated, what is decided within the team
+
+### What Belongs to the Staff IC
+
+- Technical approach decisions within the team's scope — what architecture to adopt, what tools to standardize on, what patterns to avoid
+- Technical standards: what constitutes a "good" implementation, what goes in a code review, what the team's quality bar is
+- Technical mentorship of ICs at the senior and below levels — the Staff IC's perspective on a senior IC's work carries more weight than the manager's in technical calibration
+- Identifying technical risks that are not visible to the manager — this is one of the primary reasons the role exists
+- Cross-team technical coordination where the domain overlaps with adjacent teams' systems
+
+### The Overlap Zone
+
+There is a category of decisions where the authority is genuinely shared and needs to be explicitly negotiated:
+
+- **Technical roadmap sequence.** What gets built and in what order involves both technical judgment (which dependency needs to come first) and organizational judgment (which initiative aligns with the next planning cycle). Neither party owns this unilaterally.
+- **Technical hiring decisions.** The manager owns the hire; the Staff IC's technical bar-setting defines what a passing candidate looks like. Disagreements here require resolution before the loop begins, not during the debrief.
+- **"Make vs. adopt" decisions** (build something internally vs. integrate a vendor or open-source tool). These carry both technical and business implications — see [Build vs. Buy Framework](../strategy/build-vs-buy-framework.md).
+
+The charter template at the end of this document is a mechanism for making these three overlap-zone categories explicit at the start of the partnership, rather than discovering the ambiguity in the middle of a conflict.
+
+---
+
+## Part 2: The Sponsor/Coach/Peer Distinction
+
+The manager's role relative to a Staff IC is not static — it shifts depending on the IC's career stage and what they need. Three distinct modes apply:
+
+### Sponsor Mode
+
+A sponsor actively uses their organizational position to create visibility and opportunity for the IC. This is the mode most appropriate for an IC who is approaching Staff readiness or who has recently been promoted and needs to establish their scope in the eyes of the broader organization.
+
+In practice, sponsorship looks like:
+- Naming the IC's work and decisions in senior leadership conversations
+- Creating opportunities for the IC to present technical strategy to stakeholders who would not otherwise interact with them
+- Advocating for the IC's perspective in roadmap discussions before the IC is in the room
+- Connecting the IC to cross-functional relationships that extend their influence beyond the team
+
+Sponsorship is not advocacy for its own sake — it is creating the organizational conditions in which the IC's technical work can have the impact that justifies the Staff level. A Staff IC who is technically excellent but organizationally invisible is not operating at Staff scope regardless of their output.
+
+### Coach Mode
+
+A coach helps the IC identify and work through professional development edges that are not self-evident. This is the mode most appropriate for a technically strong IC who is not yet operating with consistent organizational influence.
+
+The coaching relationship at the Staff level is qualitatively different from coaching at the senior level. A senior IC typically needs coaching on deepening technical judgment and extending impact beyond their immediate projects. A Staff IC who needs coaching is usually working on something more subtle: how to make their technical positions land in cross-functional conversations, how to navigate organizational resistance to technical direction, or how to build influence with stakeholders who do not share their technical vocabulary.
+
+The [One-on-One Coaching Framework](one-on-one-coaching-framework.md) covers the Staff-level coaching arc in detail.
+
+### Peer Mode
+
+A peer relationship is appropriate when the Staff IC is operating at full scope and the manager's primary function is coordination and organizational support rather than direction. This is the mode that most managers are least practiced in: stepping back from the guidance posture and operating as a peer who has a different functional view.
+
+In peer mode, the manager's 1:1 with the Staff IC looks less like a coaching conversation and more like a partner sync: what are you working on that I should know about, what organizational friction are you experiencing that I can clear, what decisions are coming that require our shared input.
+
+The appropriate mode shifts over time and in response to context. A Staff IC who has been operating in peer mode may need coach mode when they are moving into a new technical domain. A sponsor engagement is appropriate at specific career inflection points, not as a permanent posture.
+
+---
+
+## Part 3: Co-Owning the Technical Roadmap
+
+A technical roadmap co-owned by a manager and a Staff IC needs a decision process that both parties agree on before the roadmap is built. Without that agreement, every roadmap conversation is implicitly a negotiation about who has authority, which makes the roadmap process slow and the outputs less trustworthy.
+
+### The Shared Roadmap Process
+
+**Input phase:** The Staff IC identifies technical priorities based on technical risk, dependency sequencing, and team capability gaps. The manager maps organizational priorities from the planning cycle, stakeholder commitments, and headcount constraints. Both inputs enter the roadmap process simultaneously — neither is a filter on the other.
+
+**Synthesis phase:** The two inputs are combined into a single view. Where they align, the synthesis is straightforward. Where they conflict — an organizational priority that creates technical debt, or a technical priority that does not map to any current business objective — the conflict is named explicitly rather than resolved through implicit deference.
+
+**Conflict resolution:** When technical priority and organizational priority are in genuine tension, the resolution mechanism should be agreed upon in advance. A common pattern: the Staff IC has decision authority on anything within the team's technical scope with no cross-team dependencies; the manager has decision authority on anything with significant cross-team or stakeholder implications; genuinely contested cases escalate to a short joint session with the manager's manager and the Staff IC together.
+
+**Communication:** The roadmap is communicated to the team with both the technical rationale (owned by the Staff IC) and the organizational context (owned by the manager). A roadmap that arrives from the manager without technical rationale signals that the Staff IC is not a real partner in setting direction. A roadmap that arrives from the Staff IC without organizational context signals that the manager is not engaged in the work.
+
+---
+
+## Part 4: Career Pathing for the Staff Track
+
+### What "Staff-Level Impact" Means
+
+The defining characteristic of Staff-level impact is scope. A senior engineer's impact is primarily within the team. A Staff engineer's impact extends beyond the team — to adjacent systems, to other teams' technical decisions, to org-wide standards, or to the industry's understanding of a problem domain (through writing, open source, or conference work).
+
+The scope expansion is not automatic at promotion. Many engineers are promoted to Staff based on their demonstrated technical excellence and then continue operating at a senior scope. The partnership's role is to actively create the conditions for Staff-level scope, not to wait for the IC to discover it.
+
+| Scope Level | Impact Radius | Example |
+|---|---|---|
+| Team | Decisions affect one team's systems | Architecting a service migration within the team's domain |
+| Org | Decisions affect multiple teams or the organization's technical direction | Establishing a logging standard adopted across four teams |
+| Company | Decisions affect how the company's technology is positioned externally | An open-source contribution that attracts candidates; a technical post that shapes industry practice |
+
+### The Leveling Conversation
+
+The annual calibration for a Staff IC should include an explicit conversation about which scope level they are operating at and what would constitute a move to the next level. This conversation belongs in the 1:1, not the calibration session. By the time calibration arrives, both parties should already know where the IC stands.
+
+The [Career Ladder and Calibration Playbook](career-ladder-calibration.md) provides the four-axis framework for this evaluation. The axis most relevant to Staff-level calibration is impact scope — not the most technically impressive work, but the work with the largest organizational reach.
+
+---
+
+## Part 5: When the Partnership Breaks
+
+Not every manager-Staff IC partnership works. The failure modes are worth naming so they can be identified before they require a structural resolution.
+
+### Misalignment on Priorities
+
+The most common failure: the Staff IC believes the most important technical work is X, the manager's organizational priorities require Y, and neither party has surfaced the tension explicitly. The IC works on X, the manager repeatedly redirects toward Y, and both parties become frustrated without understanding why.
+
+Fix: establish the shared roadmap process described above before priorities are in conflict. If the conflict has already arrived, surface it explicitly in a 1:1 before it calcifies into a trust problem.
+
+### The IC Who Has Gone Independent
+
+A Staff IC who has stopped consulting the manager on technical decisions — not because the manager has interfered inappropriately, but because the IC has concluded that the manager is not a useful input — has effectively broken the partnership. The IC may still be producing excellent technical work. But the organizational implications of their decisions are no longer being examined by anyone with organizational visibility.
+
+Fix: name what has happened. "I've noticed that we're not talking about technical decisions the way we used to. I want to understand what's changed." If the underlying cause is that the IC does not trust the manager's technical judgment, address that directly — the manager does not need to be technically superior to the Staff IC to be a useful partner, but they need to be trusted to bring organizational context the IC does not have.
+
+### The Manager Who Micro-Manages Technical Decisions
+
+A manager who requires sign-off on technical decisions within the Staff IC's authority scope is effectively preventing the IC from operating at Staff level. The IC either complies (and operates like a senior engineer with a fancy title) or routes around the manager (and the partnership breaks in the other direction).
+
+Fix: revisit the authority split. If the manager's instinct to control technical decisions comes from uncertainty about technical risk, address the risk communication — the Staff IC should be briefing the manager on significant technical decisions before they are made, not for approval, but for organizational situational awareness. If the control comes from a general management style, it is a harder conversation about how the partnership is supposed to work.
+
+---
+
+## Templates
+
+### Staff Partnership Charter
+
+A one-pager completed by the manager and Staff IC together at the start of the partnership or after a significant change (reorg, new team, new scope).
+
+```
+## Role: [Staff IC name and title]
+
+## Manager: [Manager name]
+
+## Technical Authority (IC owns these decisions without escalation)
+-
+-
+-
+
+## Organizational Authority (Manager owns these decisions)
+-
+-
+-
+
+## Shared Decisions (require joint input before decision)
+-
+-
+-
+
+## Escalation Process
+When we disagree on a decision in the shared zone:
+[describe the agreed process — e.g., "bring in [manager's manager] if we cannot resolve in one session"]
+
+## Current Mode
+[ ] Sponsor  [ ] Coach  [ ] Peer
+[Note: this changes over time; revisit quarterly]
+
+## Current Focus Area for Career Development
+[One sentence on what the IC is working on toward the next scope level]
+
+## Review Cadence
+[How often we will revisit this charter — suggest quarterly]
+```
+
+### Career Conversation Guide for the Staff Track
+
+```
+## Questions for a Staff-Level Career Conversation
+
+1. At what scope level do you believe you're currently operating?
+   (Team / Org / Company)
+
+2. What is the most organizationally significant technical decision you've
+   made or influenced in the last quarter?
+
+3. Who outside the immediate team is aware of your technical contributions
+   and how they are impacted by them?
+
+4. What is the biggest technical risk in the org that you are not yet
+   positioned to address? What would change that?
+
+5. Where do you want to be in scope and impact in 12 months, and what
+   is the first step toward that?
+
+6. What do you need from me (manager) that you're not currently getting?
+```
+
+---
+
+## Anti-Patterns
+
+**The Ceremonial Staff.**
+A Staff IC whose title reflects prior contributions but whose current scope is senior-level. The promotion solved a retention problem but did not expand the role. The partnership has not been designed to create Staff-level scope, so the IC operates below it. Both parties eventually become dissatisfied without being able to name why.
+
+**The Technical Fiefdom.**
+A Staff IC who treats technical authority as absolute and the manager as an organizational inconvenience. Technical decisions made without organizational context accumulate debt: systems that are technically correct but organizationally unmaintainable, standards that are right but unadoptable, roadmaps that are impressive but unfunded.
+
+**The Manager as Technical IC.**
+A manager who uses the 1:1 with a Staff IC to participate in technical decision-making — not as a sounding board, but as a design partner. The problem is not the engagement; it is the accountability gap. The manager is making decisions they will not be held responsible for while the IC carries accountability for outcomes they did not fully control.
+
+**The Undefined Overlap.**
+A partnership where the three overlap-zone categories (roadmap sequencing, technical hiring bar, build/buy decisions) have never been explicitly discussed. Every conflict in these zones becomes a negotiation about authority rather than a conversation about the decision, because the authority has not been established.
+
+**The One-Mode Manager.**
+A manager who operates exclusively in one mode — always coaching, always sponsoring, always treating the IC as a peer — regardless of what the IC actually needs. A Staff IC in a new technical domain needs coaching, not peer-mode. A Staff IC whose work is invisible to senior leadership needs sponsorship, not coaching. The mode should adapt to what the IC needs at this moment, not to the manager's default style.
+
+[^1]: Hogan, L. (2019). *Resilient Management*. A Book Apart. The sponsor/coach distinction is developed in Chapter 3 and applied specifically to senior IC career development.

--- a/transitions/inheriting-a-team.md
+++ b/transitions/inheriting-a-team.md
@@ -1,0 +1,205 @@
+# Inheriting a Team You Didn't Hire
+
+## Leadership Context
+
+The 30-60-90 framework is built for a relatively clean scenario: you are new, the team knows it, and the relationship starts from zero. Inheriting an existing team adds a layer of complexity that the standard ramp framework does not fully address. The team has a history — a culture, a set of norms, and a prior relationship with someone who is not you. Every action you take in the first weeks is filtered through that history whether you know it or not.
+
+The specific risks are distinct from the new-leader general case. Trust is not absent — it is present and allocated to a predecessor. Loyalty to the prior leader or to informal power structures within the team may express itself in ways that look like support but are actually tests. Personnel problems the prior leader left unresolved do not disappear at the transition; they surface faster under a new leader because the team is watching to see whether you will handle what was not handled before.
+
+The framework here is a companion to the [New Engineering Leader 30-60-90 Day Plan](new-leader-30-60-90.md). Use that framework as the operating structure; use this one as a lens for interpreting what you observe and for navigating the specific dynamics that inheritance introduces.
+
+## Background and Motivation
+
+This framework draws primarily on the ActBlue platform directorate transition (2022), where I inherited six teams and approximately fifty engineers from a prior organizational structure that had different reporting lines, team scope, and leadership philosophy. Many of the challenges described here — the informal authority figures, the personnel problems that surfaced early, the loyalty signals that were actually ambivalence tests — were encountered directly in that context. The CTA transition (2025) provided a contrasting case: inheriting a smaller team with a longer prior-leader tenure and more explicit institutional memory of how things had been done.
+
+## When to Use This
+
+| Trigger | What This Framework Provides |
+|---|---|
+| Stepping into a director or senior EM role covering teams you did not build | A structured reading of early team dynamics and how to respond |
+| Inheriting after a beloved predecessor | How to avoid the comparison trap and build credibility on your own terms |
+| Inheriting after a struggling or departed predecessor | How to avoid inheriting the prior leader's relationship damage alongside their reports |
+| Stepping in when there was no prior leader (absent predecessor) | How to fill a leadership vacuum without overwhelming the team's existing self-governance |
+| Early personnel concerns that predate your arrival | A framework for distinguishing inherited problems from self-created ones |
+
+---
+
+## Part 1: Reading the Room — The Three Predecessor Archetypes
+
+Before adapting your approach, diagnose which predecessor archetype you are following. Each creates a distinct set of expectations and loyalty dynamics.
+
+### The Beloved Predecessor
+
+This is the hardest scenario. The team has a reference point that you will be compared against, and the comparison is often flattering to the predecessor because memory softens criticism. You cannot win a comparison contest — you can only opt out of it.
+
+Signs you are in this scenario:
+- Early 1:1s include unprompted stories about how the prior leader handled things
+- Your first process or structural changes are met with "we used to do it differently"
+- A subset of the team seems to be waiting to see if you will revert a change the prior leader made
+
+What to do: Name the history explicitly and early. In your first all-hands, acknowledge that you know the team has an established culture and that your job is to understand it before changing anything. Do not position yourself as a departure from the predecessor. Position yourself as the next chapter — which requires you to read the prior chapters first.
+
+### The Embattled or Departed Predecessor
+
+In this scenario, the team may have legitimate grievances with prior leadership: unfulfilled commitments, unresolved conflicts, or a culture that did not serve them well. There is a temptation to absorb the team's frustration and signal that you are different by criticizing the prior approach. Resist this.
+
+Signs you are in this scenario:
+- Early 1:1s surface complaints about prior leadership structure, process, or decisions unprompted
+- The team seems relieved rather than uncertain — which is a warning sign, not a green light
+- There is a specific grievance that the team clearly wants you to address immediately
+
+What to do: Listen fully to what is named. Acknowledge what you hear. Do not validate complaints about the prior leader directly — say instead that you want to understand the team's experience and what would help going forward. Act on what is actionable. But distinguish between systemic problems (which deserve structural response) and interpersonal grievances (which deserve empathy, not confirmation).
+
+### The Absent Predecessor
+
+A vacant role often means the team has been running itself for weeks or months. Informal leaders have stepped into the gap. Norms have calcified around whoever was most willing to make decisions. Introducing formal leadership into a self-governing system is a disruption, and the team may not experience it as relief.
+
+Signs you are in this scenario:
+- Early 1:1s suggest that the team has been making decisions autonomously and is uncertain about what the new hierarchy means for them
+- One or two people have clearly been covering leadership functions informally
+- There is no clear operating cadence — everything has been ad hoc
+
+What to do: Identify the informal leaders early and make your respect for their role explicit in private before public. Introduce structure gradually — pick one cadence to establish first (usually the weekly 1:1) and build from there. Avoid announcing a comprehensive new operating model in week one; the team will read it as erasure of what they built in the absence.
+
+---
+
+## Part 2: Loyalty Traps
+
+Loyalty in an inherited team is not the same as trust. It is the residue of prior relationships, and it expresses itself in ways that can mislead a new leader into misreading who is aligned and who is waiting.
+
+### The Passed-Over Team Member
+
+If someone on the team was a candidate for the role you now hold and did not get it, they represent a complex relationship. They may be entirely professional and supportive. Or they may be performing support while withholding real engagement. The performance is the problem — not the ambivalence itself, which is understandable.
+
+How to handle it: Have a direct conversation early. Acknowledge the situation plainly — you know this is a complex dynamic, you value their experience, and you want to understand what they need from the relationship going forward. Most people respond well to being seen rather than managed around.
+
+### The Veteran Who Owns the Informal Authority
+
+Every established team has one: the person who has been there the longest, who everyone goes to when they need to know how things really work, who carries institutional memory that is not written down anywhere. This person is an asset and a potential source of friction, depending on whether they feel the new leader respects what they know.
+
+How to handle it: Go to them early and explicitly. Ask them to help you understand the team's history. Listen more than you talk. When they share perspective, validate that you heard it — not that you agree with it, but that it is informing how you think. Do not make changes that affect their domain without checking in first.
+
+### The One Who Asks "What Are You Going to Change?"
+
+This question is almost never a sincere request for a change agenda. It is a loyalty test. The asker wants to know whether you are going to disrupt something they value, and they are hoping your answer reassures them.
+
+The wrong answer: "I have some ideas, but I want to listen first." This sounds diplomatic and lands as evasive.
+
+The right answer: "I don't have a change agenda yet. I have questions. The only thing I know for certain is that I won't change anything I don't understand." This is specific, honest, and removes the uncertainty that produced the question.
+
+---
+
+## Part 3: Trust Signals — What the Team Is Actually Watching
+
+In weeks one through four, the team is calibrating you on signals that have nothing to do with your technical or strategic capability. They are watching for evidence about whether you are safe.
+
+### Signals you can control:
+
+**Consistency between private and public.** If you tell someone in a 1:1 that their work on a project was excellent, and then you say nothing about it in the next team meeting, the discrepancy is noticed. The team learns that private conversations with you do not translate to public credit.
+
+**What you do when a decision goes wrong.** Early in the tenure there will be something — a production issue, a missed commitment, a miscommunication. The team is watching whether you attribute it accurately, protect the team from disproportionate blame, and move constructively toward resolution.
+
+**Whether your first month is more questions than answers.** Teams that have been through multiple leadership transitions have a pattern-detector for new leaders who arrive with all the answers. If your 1:1s are primarily you talking, the team will conclude that the listening tour was performance.
+
+**Whether you follow through on small commitments.** In the listening tour, you will make implicit or explicit promises: "I'll look into that," "I'll come back to you on that by end of week." These are tracked. Following through on small commitments creates more trust than any single large gesture.
+
+### Signals you cannot control:
+
+**Whether the team liked your predecessor more.** This is irrelevant to your work and cannot be changed by your behavior. It only matters if you let it shape how you lead.
+
+**Whether the org's decision to restructure or hire externally was the right call.** If the team believes the restructuring that put you in this role was a mistake, they may extend that skepticism to you. You cannot argue them out of this. You can only demonstrate over time that you are worth the transition cost.
+
+---
+
+## Part 4: Early Personnel Decisions
+
+Inherited personnel situations are the most consequential early-tenure decisions you will make, and the ones where new leaders most often err in either direction.
+
+### The Timeline Problem
+
+Every leader brings a different threshold for acting on performance concerns. But when you inherit a team, your threshold is not the only variable. The prior leader may have set expectations — formal or informal — that affect how the team member understands their standing. Acting on a performance concern in week three without understanding the prior context is likely to feel arbitrary or retaliatory to the team, even if the concern is legitimate.
+
+The general rule: you need at least one full performance cycle with your own observations before you can act on a performance concern with confidence that it is based on your evidence, not your inheritance. The exception is conduct: if you inherit a conduct problem that requires immediate action, the threshold for acting quickly is justified regardless of how early you are in tenure.
+
+### Distinguishing Inherited from Self-Created Problems
+
+The question to ask before acting on a performance concern: "Would I have seen this problem if I had hired this person fresh?"
+
+If yes — the concern is about the person's actual performance, and it is yours to address.
+
+If no — the concern may be about fit to a prior structure, a prior manager's style, or a set of expectations that were created before you arrived. Address the fit problem before concluding there is a performance problem.
+
+### The Loyalty Signal That Looks Like a Performance Problem
+
+Sometimes a team member who was aligned with the prior leader will appear to disengage in the early weeks of a new leader's tenure. The disengagement can look like performance: slower work, less initiative, fewer contributions in meetings. It is usually temporary and resolves as the new relationship builds. Do not address it as a performance problem in week four; address it as a relationship concern in week two with a direct conversation about how the transition is going for them.
+
+---
+
+## Templates
+
+### Inherited Team Listening Tour: Modified 1:1 Agenda (30 min)
+
+The standard 30-60-90 listening tour agenda works for most contexts. Add these questions when inheriting an existing team:
+
+```
+1. How long have you been on this team, and what brought you here? (5 min)
+2. What was working well under the prior structure that you'd want to make sure survives? (5 min)
+3. What do you think the team needs from a leader right now that it hasn't had? (5 min)
+4. Is there anything you started working on that you're worried might get lost in the transition? (5 min)
+5. What would make this transition successful from your perspective? (5 min)
+6. Anything else you want me to know? (5 min)
+```
+
+### Personnel Decision Decision Tree
+
+```
+Is this a conduct concern?
+├── Yes → Act immediately through appropriate HR channel.
+│          Document before acting.
+└── No → Is this a performance concern?
+         ├── Yes → Have I completed at least one full observation cycle
+         │         (sprint, quarter, or equivalent)?
+         │         ├── No  → Do not act. Address as fit conversation.
+         │         │          Set explicit expectations. Document.
+         │         └── Yes → Was this problem visible to the prior leader?
+         │                    ├── Yes → Escalate through appropriate process.
+         │                    │          Document what the prior leader observed.
+         │                    └── No  → Re-examine: is this a performance
+         │                              problem or a fit/transition problem?
+         └── No → Is this a fit concern (role mismatch, team structure change)?
+                  └── Yes → Separate conversation from performance process.
+                             Address through role clarity, not performance plans.
+```
+
+### First All-Hands Opening (suggested language)
+
+```
+I want to use the first few minutes to be direct about how I'm approaching
+this transition. I know this team has a history — work you're proud of,
+norms you've built, and a relationship with [prior leader] that I'm not
+trying to replace. My job in the next thirty days is to understand what
+you've built before I change anything. I'll be meeting with each of you
+individually to listen first. I'll tell you more about how I plan to lead
+once I know what this team actually needs. What I can tell you now is what
+I won't do: I won't make changes I don't understand, and I won't make
+commitments I can't keep.
+```
+
+---
+
+## Anti-Patterns
+
+**The Clean Slate.**
+Announcing that you are starting fresh, resetting everything, and building a new culture. The team hears: "Everything you built doesn't count." New leaders who lead with this framing lose trust with experienced team members before the second week.
+
+**The Predecessor Critique.**
+Positioning yourself by contrasting with the prior leader's failures. Even when the prior leadership was genuinely poor, validating team complaints about the predecessor signals that you are willing to build your credibility on someone else's failure rather than your own performance. This invites the team to play the same game with you later.
+
+**The Premature All-Clear.**
+Deciding that because the team seems welcoming, you can move faster than the 30-60-90 framework suggests. Warmth in week one is not trust. It is hospitality. The full listening tour is still warranted.
+
+**The Undifferentiated 1:1 Schedule.**
+Running the same listening tour with everyone in the same order, without adapting to the specific dynamics of inherited teams. The passed-over team member, the informal authority figure, and the disengaged team member all need 1:1s that are shaped by the specific dynamic, not a generic template.
+
+**The Ownership Assumption.**
+Treating the team's prior commitments as yours without reviewing them. Projects, promises, and roadmap items made by the prior leader may or may not be the right direction for the team under your leadership. Before inheriting someone else's commitments publicly, understand them privately.

--- a/transitions/new-hire-onboarding-framework.md
+++ b/transitions/new-hire-onboarding-framework.md
@@ -1,0 +1,250 @@
+# New Hire Onboarding and Ramp-Up Framework
+
+## Leadership Context
+
+The 30-60-90 framework for a new engineering leader is written from the leader's perspective: how to listen, diagnose, and commit. The new hire onboarding framework is written from the other direction — the document handed to an incoming engineer that tells them what the first thirty days will look like, what success means, and who is responsible for what. These are complementary, not overlapping.
+
+The structural problem with most engineering onboarding is that it is designed for the organization's convenience, not the engineer's ramp. A list of systems to read, a Slack workspace to join, a calendar of recurring meetings to attend — these are information delivery mechanisms, not onboarding frameworks. A new hire who has read all the wikis and joined all the channels but has not shipped anything and has not built a working relationship with their team has not onboarded. They have accumulated content.
+
+The thirty-day ramp that matters is defined by three observable outcomes: understanding the system well enough to contribute to it, shipping something small enough to be low-risk but real enough to be valuable, and establishing a working relationship with at least one teammate beyond the buddy assignment. If an engineer reaches day thirty without all three of these, the onboarding has failed regardless of how many Confluence pages they have read.
+
+## Background and Motivation
+
+This framework was developed from onboarding multiple engineers into platform and payments teams at ActBlue Technical Services (2022–2025) and refined through the Community Tech Alliance context (2025–2026), where onboarding happened into a smaller team with less standardized infrastructure. At ActBlue, the challenge was scaling onboarding across six platform teams without sacrificing the 1:1 calibration that makes the first weeks effective. At CTA, the challenge was creating structure where very little existed without overengineering a process the team would not sustain.
+
+The framework reflects a recurring observation: the engineers who struggled in their first quarter almost always had onboarding that was heavy on orientation (reading, attending, watching) and light on contribution (shipping, deciding, asking questions that changed the plan).
+
+## When to Use This
+
+| Trigger | What This Framework Provides |
+|---|---|
+| New IC joining the team at any level | A structured 30-day ramp with clear ownership and observable milestones |
+| Returning engineer after extended leave | A compressed version for re-establishing context without re-doing the full ramp |
+| Bootcamp or internship conversion hire | A bridge from educational context to production ownership |
+| Post-reorg team integration (engineer joins an existing team as part of a structural change) | A ramp that accounts for existing team context the engineer does not yet share |
+
+---
+
+## The Three Roles
+
+Onboarding requires three distinct roles. Conflating them — or leaving any of them unfilled — produces the common failure modes.
+
+**The Manager** is responsible for the success of the onboarding. This means setting the ramp plan, checking in weekly on milestones, clearing blockers that the engineer and buddy cannot resolve, and conducting the 30-day retrospective. The manager owns the outcome, not the execution.
+
+**The Buddy** is responsible for daily context and access. This is a peer engineer, not a senior leader. The buddy is the first call when something is confusing, when tooling is broken, or when the engineer does not know which channel to ask in. The buddy should be someone who joined in the last eighteen months and still remembers what it felt like to not know things. Do not assign the team's most senior IC as the onboarding buddy — they have a different relationship to not-knowing and are rarely the right first stop for operational friction.
+
+**The New Hire** is responsible for communicating blockers, asking questions, and not waiting until a 1:1 to surface that something is wrong. Learned helplessness — waiting for explicit permission to do the next thing — is the most common new hire anti-pattern. The manager and buddy need to create an environment where asking questions is treated as signal of engagement, not evidence of gap.
+
+---
+
+## The 30-Day Ramp
+
+### Phase 1: Orientation (Days 1–7)
+
+The goal of phase one is access and context — getting the engineer to the point where they can read the codebase and understand what the team is working on. This is not the time to ship. Shipping before understanding produces the wrong kind of confidence.
+
+**Days 1–3: Infrastructure access and environment setup.**
+Every new engineer should have a working local development environment and repository access by end of day 3. If this is not achievable, it is a tooling problem — note it and fix it. Do not let environment setup drift into week two.
+
+**Days 4–5: Architecture orientation.**
+The buddy walks the engineer through the primary systems: service boundaries, data flows, deployment pipeline, on-call structure, and monitoring stack. Not a comprehensive wiki review — a live conversation with a working local environment open. The goal is a mental model, not a fact list.
+
+**Days 6–7: Team context and cadence.**
+The engineer attends the team's primary recurring meetings (sprint planning, standup, retrospective if scheduled). The manager conducts the first 1:1, using it to confirm the environment is set up, answer open questions, and identify the first task.
+
+**Milestone at end of week 1:** The engineer can run the application locally, has read the architecture overview, and has identified their first task.
+
+### Phase 2: First Contribution (Days 8–21)
+
+The goal of phase two is a real, merged contribution. The specific scope of "first task" matters more than most managers realize.
+
+**Criteria for the first task:**
+- Small enough to merge in under a week with review cycles included
+- Real enough that it will matter to someone — not a documentation task invented to give the engineer something to do
+- Low enough blast radius that a mistake does not require an all-hands incident response
+- In a part of the codebase the engineer will work in regularly — not a one-off corner that provides no transferable context
+
+Good first tasks: fixing a known bug in a non-critical path, adding a metric or log line to an existing flow, implementing a small feature with clear acceptance criteria, improving test coverage in an area with known gaps.
+
+Poor first tasks: refactoring a large module, implementing a new external integration, anything that requires coordinating with another team, anything the engineer will never touch again.
+
+**Days 8–14: First task in progress.**
+The buddy does at least one pair programming session during this week — not to write the code for the engineer, but to walk through how to navigate the codebase and tooling in practice. Code review on the first PR should be thorough and instructional, not just approval. Explain why, not just what.
+
+**Days 15–21: Second task and independent navigation.**
+By day 15 the engineer should be able to identify their next task from the backlog without the manager assigning it. If they cannot, they have not yet built the context to be independent — surface this in the week 2 1:1 and address it explicitly.
+
+**Milestone at end of week 3:** At least one PR merged. Engineer can identify their own next task. Engineer has participated in at least one code review as reviewer (reviewing someone else's work is one of the fastest ways to build codebase context).
+
+### Phase 3: Independent Delivery (Days 22–30)
+
+The goal of phase three is sprint participation at a level where the engineer is no longer on a separate ramp track but is contributing to the team's shared commitments.
+
+**Days 22–28: Sprint integration.**
+The engineer should be carrying story-level work in the sprint, not just tasks assigned as "onboarding" items. They should be in the sprint ceremonies as a participant, not an observer — that means commenting in retrospectives, asking questions in planning, and flagging scope risks when they see them.
+
+**Days 29–30: 30-day retrospective.**
+The manager and engineer conduct a structured retrospective (see template below). The output is: what worked in the ramp, what should be changed for future hires, and an explicit agreement on what the engineer's first 60-day goals look like.
+
+**Milestone at end of day 30:** Engineer is carrying sprint commitments at partial velocity. Manager has completed 30-day retrospective. Engineer has named at least one thing they want to learn in the next thirty days.
+
+---
+
+## Ramp Metrics
+
+These are for the manager to track, not to share with the engineer as a performance rubric.
+
+| Metric | Target | Warning Signal |
+|---|---|---|
+| Time to first merged PR | ≤ 14 days | > 21 days without a blocker explanation |
+| Time to first solo incident participation | ≤ 45 days | Not on-call rotation by day 60 |
+| Time to sprint participation | ≤ 30 days | Still on separate ramp track at day 30 |
+| 30-day retrospective held | Day 28–32 | Not scheduled or skipped |
+| Manager 1:1 frequency in month 1 | Weekly | Biweekly or skipped |
+
+---
+
+## Onboarding Failure Modes
+
+**Too much reading, not enough doing.** A two-week "reading sprint" before the engineer touches code is almost always a mistake. The reading does not stick without context, and the context comes from doing. Send the engineer to the codebase on day four, not day fourteen.
+
+**No defined success criteria.** "Get comfortable with the codebase" is not a milestone. Engineers who do not know what success looks like in week one will not know whether they are on track in week three. The manager's job is to make success concrete and observable.
+
+**Buddy assignment without buddy preparation.** Assigning a buddy without telling the buddy what their responsibilities are is a guarantee of inconsistency. The buddy needs to know: what they own, what the manager owns, how to escalate a blocker, and when the buddy relationship formally ends (typically 30 days, with optional continuation).
+
+**The firehose first week.** Cramming every system introduction, every team overview, and every stakeholder meeting into the first five days produces an engineer who has heard everything and retained little. Sequence context so each layer builds on the last. The payment system architecture overview belongs in week two, not day two.
+
+**The invisible first month.** An engineer who gets through thirty days without being visible in any team communication — no questions in Slack, no comments in code reviews, no contributions to a planning meeting — has been allowed to hide. Hiding in the first month is not humility; it is a failure of the environment to create safety for participation.
+
+---
+
+## Templates
+
+### 30-Day Onboarding Checklist (for the engineer)
+
+```
+## Week 1: Access and Orientation
+[ ] Development environment running locally
+[ ] Repository and CI/CD access confirmed
+[ ] Primary communication channels joined (Slack workspaces, incident tooling)
+[ ] Architecture walkthrough with buddy completed
+[ ] First 1:1 with manager completed
+[ ] First task identified
+
+## Week 2: First Contribution
+[ ] First task in progress
+[ ] One pair programming session with buddy
+[ ] PR opened
+[ ] At least one code review completed as reviewer
+
+## Week 3: Independent Navigation
+[ ] First PR merged
+[ ] Second task self-identified from backlog
+[ ] Attended sprint ceremonies as participant (not observer)
+
+## Week 4: Sprint Integration
+[ ] Carrying sprint story points or tasks in shared sprint
+[ ] On-call shadowing scheduled (if applicable)
+[ ] 30-day retrospective scheduled with manager
+
+## Day 30
+[ ] 30-day retrospective held
+[ ] 60-day goals agreed with manager
+[ ] Buddy relationship formally acknowledged and transitioned to peer
+```
+
+### Manager Onboarding Kick-Off Agenda (first 1:1, day 1–3)
+
+```
+1. Context and team overview (10 min)
+   - What the team owns, what we are working on, where we are in the sprint
+   - How to find information (who to ask, where to look)
+
+2. Ramp plan walkthrough (10 min)
+   - The three phases and what success looks like in each
+   - The buddy role and how to use it
+   - When to escalate vs. when to figure it out
+
+3. First task (5 min)
+   - Walk through the task together
+   - Confirm the engineer understands scope and acceptance criteria
+   - Identify the first person to talk to if they get stuck
+
+4. Open questions (5 min)
+   - What is the engineer most uncertain about right now?
+   - Is there anything about the environment or team that is not clear?
+
+5. Weekly 1:1 cadence confirmed (1 min)
+   - Day and time, format, agenda ownership
+```
+
+### Buddy Guide
+
+```
+## Your Role
+You are the first stop for operational friction — environment problems, tooling
+confusion, "which channel do I ask this in?" questions. You are not responsible
+for teaching the engineer their job. You are responsible for making sure the
+environment does not get in the way of them doing it.
+
+## What You Own
+- One architecture walkthrough in days 4–5
+- One pair programming session in week 2
+- Availability for ad-hoc questions (same-day response; no need to be instant)
+- Weekly check-in (informal, 15 min or less) for the first four weeks
+
+## What the Manager Owns
+- Assigning and scoping the first task
+- Weekly 1:1 with the engineer
+- Clearing blockers that are outside the team (access, process, tooling)
+- The 30-day retrospective
+
+## Escalation
+If the engineer is blocked on something you cannot resolve in 30 minutes, flag it
+to the manager the same day. Don't spend a day debugging an environment issue
+that a manager could clear in ten minutes with one Slack message to IT.
+
+## When It Ends
+The buddy relationship is formal for the first 30 days. After that, you transition
+to peer. There is no ceremony required — just acknowledge it in the week 4 check-in:
+"The formal buddy period is ending; I'm here as a peer going forward."
+```
+
+### 30-Day Retrospective Agenda
+
+```
+1. What worked in the ramp? (10 min)
+   - What was most useful in the first week?
+   - What made the first contribution go smoothly?
+
+2. What should be changed? (10 min)
+   - What took longer than expected?
+   - What was missing from the onboarding that would have helped?
+
+3. Process feedback (5 min)
+   - What should we change for the next hire?
+   - Is there documentation that should exist but doesn't?
+
+4. Looking ahead (5 min)
+   - What does the engineer want to learn in the next 30 days?
+   - What are the 60-day goals we are agreeing on now?
+```
+
+---
+
+## Anti-Patterns
+
+**The Information Dump.**
+Scheduling twelve system overview meetings in the first week because "there's a lot to learn." The engineer absorbs about 20% of it, and the 80% they missed produces a false sense of completion. Prioritize the systems they will work in first; sequence everything else.
+
+**The Invisible Buddy.**
+Assigning a buddy who is too senior, too busy, or too unfamiliar with day-to-day operational friction to be useful. The best buddy is one to two years into their tenure — experienced enough to know the system, recent enough to remember not knowing it.
+
+**The Test-Free First PR.**
+Allowing the first merged contribution to skip tests "just to get something in." This teaches the engineer that the team's test standards are negotiable from day one. Hold the bar.
+
+**The Delayed Retrospective.**
+Skipping or rescheduling the 30-day retrospective because the manager is busy. The retrospective is the primary mechanism for improving onboarding for the next hire. It also signals to the engineer that their experience was worth examining.
+
+**The Sink-or-Swim Frame.**
+Framing onboarding as a proving ground rather than a ramp. Engineers who feel they are being tested from day one rather than supported are less likely to ask questions and more likely to hide when they are stuck. The first thirty days should feel like a structured ramp, not a trial.

--- a/transitions/new-hire-onboarding-framework.md
+++ b/transitions/new-hire-onboarding-framework.md
@@ -92,7 +92,7 @@ The manager and engineer conduct a structured retrospective (see template below)
 
 ## Ramp Metrics
 
-These are for the manager to track, not to share with the engineer as a performance rubric.
+These are for the manager to track, not to share with the engineer as a performance rubric. The underlying milestones match the engineer-facing checklist — the difference is that the warning signals and framing here are calibrated for manager monitoring, not engineer self-assessment.
 
 | Metric | Target | Warning Signal |
 |---|---|---|


### PR DESCRIPTION
## Summary

- Adds 7 new leadership artifact files covering the full engineering leadership lifecycle as specified in issue #29
- Updates `README.md` with entries for all 7 new artifacts; removes stale "forthcoming in wave 2" note
- Updates `ORIGINS.md` with engagement, origin, outcome, and first-person framing for each new artifact; adds a new Transitions section

## Artifacts added

| File | Topic |
|---|---|
| `transitions/inheriting-a-team.md` | Trust dynamics, loyalty traps, and early personnel decisions when stepping into an existing team |
| `transitions/new-hire-onboarding-framework.md` | 30-day ramp-up plan for incoming engineers; complement to the new-leader 30-60-90 |
| `people/hiring-and-interview-design.md` | Structured interview loop design, rubric calibration, and debrief facilitation |
| `people/staff-engineer-partnership.md` | Authority split, sponsor/coach/peer modes, and co-owned technical roadmap for Staff ICs |
| `org-design/reorg-execution-guide.md` | Pre-announcement checklist, announcement structure, 72-hour period, and team norm re-establishment |
| `incident-management/blameless-postmortem-framework.md` | Five-part post-mortem document, blameless facilitation, and action item tracking |
| `leadership/rfc-design-doc-process.md` | RFC lifecycle, review mechanics, blocking vs. advisory authority, RFC-to-ADR relationship |

## Test plan

- [ ] All 7 new Markdown files render correctly in VS Code preview
- [ ] Internal cross-links resolve (`../org-design/team-topology-framework.md`, `../transitions/new-leader-30-60-90.md`, etc.)
- [ ] README section entries match actual file paths
- [ ] No "wave 2" forward-reference remaining in README (`grep "wave 2" README.md` returns empty)
- [ ] ORIGINS.md Transitions section is new (did not exist before this PR)
- [ ] Footnote markers in `staff-engineer-partnership.md`, `blameless-postmortem-framework.md`, and `rfc-design-doc-process.md` have matching definitions

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)