### PR TITLE
fix: apply factual-accuracy rule to engineering-rhythm-of-business.md pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ How managers and Staff or Principal ICs divide technical authority and co-own te
 Frameworks for the Chief of Staff, Engineering function: how information flows, how decisions are made, how leadership time is spent, and how engineering communicates upward.
 
 **[operating-cadence/engineering-rhythm-of-business.md](operating-cadence/engineering-rhythm-of-business.md)**
-The weekly/monthly/quarterly/annual meeting cadence for a 50-engineer org. Covers agenda templates, decision authority (DACI), meeting health audit methodology, CoS responsibilities, and a sample weekly and monthly calendar.
+The weekly/monthly/quarterly/annual meeting cadence for a mid-size org (~30–60 engineers). Covers agenda templates, decision authority (DACI), meeting health audit methodology, CoS responsibilities, and a sample weekly and monthly calendar.
 
 **[operating-cadence/engineering-okr-framework.md](operating-cadence/engineering-okr-framework.md)**
 How to set, cascade, and report engineering OKRs without the common failure modes (activity OKRs, unmeasurable aspirations). Covers the org → team cascade, grading, quarterly review format, and anti-patterns.

--- a/operating-cadence/engineering-rhythm-of-business.md
+++ b/operating-cadence/engineering-rhythm-of-business.md
@@ -6,7 +6,7 @@ Without a defined operating cadence, decisions land at the wrong level or never 
 
 ## Background and Motivation
 
-This playbook synthesizes the operating cadence I participated in at ActBlue Technical Services (2024–2025), a platform directorate of approximately 50 engineers across 6 teams. The cadence captured here documents sustained delivery rhythm observed in practice at this scale; the playbook reflects an inside-the-room observer's synthesis of what I saw work, captured for re-use by others stepping into similar roles.
+This playbook synthesizes the operating cadence I participated in at ActBlue Technical Services (2024–2025), a platform directorate of approximately 20 IC engineers across 6 teams. The cadence captured here documents sustained delivery rhythm observed in practice at this scale; the playbook reflects an inside-the-room observer's synthesis of what I saw work, captured for re-use by others stepping into similar roles.
 
 ## When to Use This
 
@@ -385,7 +385,7 @@ A Chief of Staff or senior TPM owning the operating cadence carries more leverag
 
 ---
 
-## Sample Weekly Calendar: 50-Engineer Org
+## Sample Weekly Calendar: Mid-Size Org (~30–60 Engineers)
 
 ```
 Monday
@@ -405,7 +405,7 @@ Friday
             - One metric to watch
 ```
 
-## Sample Monthly Calendar: 50-Engineer Org
+## Sample Monthly Calendar: Mid-Size Org (~30–60 Engineers)
 
 ```
 Week 1


### PR DESCRIPTION
## Summary

Retroactive application of the new `Factual-accuracy verification` rule (career-playbook#255) to the merged pilot. Three changes, all in `operating-cadence/engineering-rhythm-of-business.md`:

- **Line 9** — "approximately 50 engineers" → "approximately 20 IC engineers". The "50" had no anchor in `accomplishments.md`, resume, LinkedIn, or any cover letter; Mike confirmed the directorate was 20 ICs across the six-team scope.
- **Lines 388 & 408** — sample-calendar headings rewritten from "50-Engineer Org" to "Mid-Size Org (~30–60 Engineers)". These are normative sizing labels, not biographical claims — neutral band keeps the templates useful without re-asserting the unverified figure.
- **Line 9 dates (2024–2025)** — no change, confirmed correct.

Closes #33.

## Test plan

Documentation-only change; per the repo's `## Testing` section, manual verification suffices.

- [x] File renders cleanly in markdown preview
- [x] No broken links introduced
- [x] First-person attribution still matches the rule's canonical form ("I participated in")
- [x] Section anchors for the two renamed H2s update consistently (no internal links pointed at the old `50-Engineer Org` slug)

## Follow-up (separate PR, career-playbook repo)

`career-playbook/context/playbook_writer_briefing.md` line 29 uses the unverified "~50" in an example sentence (*"At ActBlue (~50 engineers across 6 teams), I participated in..."*). It should be updated to "~20 IC engineers" and `accomplishments.md` should gain the headcount anchor. Not in scope for this PR — career-playbook worktree is read-only for this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
