### PR TITLE
Voice + FA sweep: ai-adoption/ (folder 1 of 14)

### DIFF
--- a/ORIGINS.md
+++ b/ORIGINS.md
@@ -92,7 +92,7 @@ Every framework in this repo was developed from real work, not synthesized from 
 
 | Framework | Engagement | Origin | Outcome | In my own words |
 |---|---|---|---|---|
-| [AI Adoption Readiness Framework](ai-adoption/ai-adoption-readiness-framework.md) | ActBlue Technical Services (2024–2025) → Community Tech Alliance (2025–2026) | GitHub Copilot + Claude pilot (ActBlue); Claude Code integration initiative with phased rollout, IC/manager use cases, and evaluation rubric (CTA) | Observability built into rollout at ActBlue; structured framework with separate use cases and rubric developed at CTA | "I designed the ActBlue pilot and built observability into it. The structured framework — separate use cases, evaluation rubric, and phased rollout — came together at CTA." |
+| [AI Adoption Readiness Framework](ai-adoption/ai-adoption-readiness-framework.md) | ActBlue Technical Services (2024–2025) → Community Tech Alliance (2025–2026) | GitHub Copilot + Claude pilot (ActBlue); Claude Code and Claude integration initiative for engineering and non-engineering workflows respectively, staggered to limit organizational risk (CTA) | Observability built into rollout at ActBlue; structured framework with separate use cases and rubric developed at CTA | "I designed the ActBlue pilot and built observability into it. The structured framework — separate use cases, evaluation rubric, and phased rollout — came together at CTA." |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Engineering-focused checklist for a PCI-DSS v4.0 gap analysis. Organized by all 
 ## Technology Adoption
 
 **[ai-adoption/ai-adoption-readiness-framework.md](ai-adoption/ai-adoption-readiness-framework.md)**
-Framework for rolling out AI-assisted development tools (GitHub Copilot, Claude, Claude Code, Cursor) across engineering organizations. Covers a four-stage IC fluency rubric, role-differentiated use cases (IC vs. manager), task classification by risk level, a three-tier observability model, and a phased gate model that sequences access to higher-risk workflows on demonstrated readiness. Developed across two production rollouts (ActBlue 2024–2025, CTA 2025–2026). Includes a worked example and rollback triggers.
+Framework for rolling out AI-assisted development tools (GitHub Copilot, Claude, Claude Code, Cursor) across engineering organizations. Presents a four-stage IC fluency rubric, role-differentiated use cases for ICs and managers, task classification by risk level, a three-tier observability model, and a phased gate model sequencing access to higher-risk workflows on demonstrated readiness. Grounded in two production rollouts: GitHub Copilot and Claude piloted at ActBlue (2024–2025) with observability instrumented from day one; Claude Code and Claude integration initiative designed at CTA (2025–2026) for engineering and non-engineering workflows respectively, staggered to limit organizational risk. Includes a worked example and rollback triggers.
 
 ---
 

--- a/ai-adoption/ai-adoption-readiness-framework.md
+++ b/ai-adoption/ai-adoption-readiness-framework.md
@@ -2,9 +2,9 @@
 
 ## Leadership Context
 
-AI tooling adoption is a capability investment with a measurable ROI — and a risk surface if left ungoverned. The engineering leader's job is not to decide whether to adopt AI tools (that decision is effectively made), but to structure the rollout so that productivity gains are captured, quality does not regress, and the org does not develop a dependency on a tool no one fully understands. This framework treats adoption as a phased program with gates, not a one-time rollout.
+AI tooling adoption carries measurable ROI and a risk surface if left ungoverned. At ActBlue and CTA, the question was not whether to adopt AI tools — the decision had been made — but how to structure the rollout to capture productivity gains, prevent quality regression, and keep the org from depending on tools no one fully understands. This framework treats adoption as a phased program with gates.
 
-> A practitioner's guide to rolling out AI-assisted development tools in engineering organizations — designed to accelerate leverage while preventing engineers from outsourcing judgment to the tool.
+> Practitioner's guide to rolling out AI-assisted development tools in engineering organizations: accelerate leverage, prevent engineers from outsourcing judgment to the tool.
 
 **Author:** Mike Brown  
 **Version:** 1.0  
@@ -15,33 +15,33 @@ AI tooling adoption is a capability investment with a measurable ROI — and a r
 
 ## Background and Motivation
 
-This framework emerged from two successive AI rollouts:
+The framework emerged from two successive AI rollouts:
 
-1. **ActBlue Technical Services (2024–2025):** Piloted GitHub Copilot and Claude across ICs and engineering managers. Observability was instrumented into the rollout from day one to track adoption patterns, friction points, and quality signals.
+1. **ActBlue Technical Services (2024–2025):** Piloted GitHub Copilot and Claude across ICs and engineering managers. Observability was instrumented into the rollout from day one to track adoption patterns.
 
-2. **Community Tech Alliance (2025–2026):** Developed a more structured successor framework — separating use cases by role (IC vs. manager), introducing a formal fluency rubric, and sequencing Claude Code integration in phases gated on demonstrated organizational readiness.
+2. **Community Tech Alliance (2025–2026):** Designed the Claude Code and Claude integration initiative — Claude Code for engineering workflows, Claude for non-engineering workflows, sequenced in stages to limit organizational risk.
 
-The failure mode both rollouts were designed to guard against: **engineers using AI as a substitute for judgment rather than an accelerant of it.** This framework makes that distinction explicit and gives managers a shared vocabulary for coaching toward it.
+The failure mode both rollouts were designed to guard against: engineers outsourcing judgment to AI. The framework gives managers a shared vocabulary for coaching against it.
 
 ---
 
 ## Design Principles
 
-Three tensions this framework is built to hold in balance:
+Three tensions hold the framework together:
 
 | Tension | Resolution |
 |---|---|
-| **Leverage vs. dependency** | AI should surface options and reduce toil — engineers remain accountable for every line they ship. |
-| **Speed vs. risk** | The same capability that accelerates a junior engineer can introduce subtle errors in high-stakes contexts. Task classification, not blanket policy, resolves this. |
-| **Individual fluency vs. org consistency** | Adoption spreads unevenly. The rubric creates a shared coaching vocabulary across that variance, rather than pretending it doesn't exist. |
+| **Leverage vs. dependency** | AI surfaces options and reduces toil; engineers remain accountable for every line they ship. |
+| **Speed vs. risk** | The same capability accelerating a junior engineer can introduce subtle errors in high-stakes contexts. Task classification resolves the conflict; blanket policy does not. |
+| **Individual fluency vs. org consistency** | Adoption spreads unevenly. The rubric creates a shared coaching vocabulary across the variance, instead of pretending uniformity. |
 
 ---
 
 ## Part 1: Task Classification
 
-Before deploying AI tooling, publish a shared taxonomy of where AI creates leverage and where it introduces unacceptable risk. This becomes the policy reference for ICs and reviewers.
+Before deploying AI tooling, publish a shared taxonomy of where AI creates leverage and where it introduces unacceptable risk. The taxonomy becomes the policy reference for ICs and reviewers.
 
-> **Design pattern:** This follows the principle of *policy-as-code* — making implicit norms explicit and version-controlled. See: [NIST AI RMF 1.0, Govern function](https://airc.nist.gov/Home) for the governance framing; [OWASP LLM Top 10](https://owasp.org/www-project-top-10-for-large-language-model-applications/) for risk classification in AI-assisted software development.
+> **Design pattern:** Policy-as-code makes implicit norms explicit and version-controlled. See: [NIST AI RMF 1.0, Govern function](https://airc.nist.gov/Home) for the governance framing; [OWASP LLM Top 10](https://owasp.org/www-project-top-10-for-large-language-model-applications/) for risk classification in AI-assisted software development.
 
 | Task Type | AI Leverage | Risk Level | Policy |
 |---|---|---|---|
@@ -49,33 +49,31 @@ Before deploying AI tooling, publish a shared taxonomy of where AI creates lever
 | Test generation | High | Low–Med | Encourage; IC reviews all generated assertions |
 | Code review assistance | Medium | Medium | Treat as one input; human renders verdict |
 | PR summaries / documentation | High | Low | Encourage |
-| Debugging production issues | Medium | High | Human-led; AI as collaborator, not lead |
+| Debugging production issues | Medium | High | Human-led; AI in a supporting role |
 | Compliance-adjacent logic (PCI-DSS, FEC, HIPAA) | Low | Very High | Require senior review of all AI-assisted output |
 | Architectural decisions | Low | High | AI generates options; human decides and documents rationale |
 | Performance reviews / people decisions | None | Extreme | **Prohibited** |
 
-> **Note on compliance-adjacent tasks:** In regulated environments, AI-generated logic that touches payment flows, authentication, data residency, or audit trails requires explicit sign-off. The risk is not that AI is wrong — it's that the error surface is subtle and the blast radius is high. This mirrors the defense-in-depth principle from PCI-DSS v4.0 requirement 12.3 (targeted risk analysis).
+> **Note on compliance-adjacent tasks:** In regulated environments, AI-generated logic touching payment flows, authentication, data residency, or audit trails requires explicit sign-off. The risk: subtle error surface, high blast radius. Mirrors the defense-in-depth principle from PCI-DSS v4.0 requirement 12.3 (targeted risk analysis).
 
 ---
 
 ## Part 2: Fluency Rubric
 
-Four stages of AI fluency. ICs self-assess; managers calibrate in 1:1s.
-
-**The goal is not to sort people — it's to open a coaching conversation.** The rubric gives both parties a shared frame for discussing where an engineer is and what growth looks like.
+Four stages of AI fluency. ICs self-assess; managers calibrate in 1:1s. The rubric opens a coaching conversation and gives both parties a shared frame for discussing where an engineer sits and what growth looks like.
 
 ---
 
 ### Stage 1 — Naive User
 
-**Behavior:** Uses AI to generate output and accepts it without critical evaluation. Commits AI-written code without reading it closely. Treats AI output as authoritative.
+**Behavior:** Generates output and accepts it without critical evaluation, commits AI-written code without close reading, and treats AI output as authoritative.
 
 **Observable signals:**
 - Difficulty explaining AI-generated changes when questioned in code review
 - Frequent silent failures (tests pass, behavior is wrong)
 - Copy-paste patterns from AI output without adaptation to the codebase
 
-**Coaching target:** Establish the habit of reading and understanding every line before shipping. The prompt is a starting point for thinking, not a final answer.
+**Coaching target:** Establish the habit of reading and understanding every line before shipping. Use the prompt to start thinking; finish it yourself.
 
 **Coaching question for 1:1s:**
 > "Walk me through the last thing you used AI to help with. What did you change before committing it?"
@@ -84,7 +82,7 @@ Four stages of AI fluency. ICs self-assess; managers calibrate in 1:1s.
 
 ### Stage 2 — Skeptical Integrator
 
-**Behavior:** Treats AI output as a draft requiring validation. Can identify when the model is wrong. Begins refining prompts based on output quality.
+**Behavior:** Treats AI output as a draft requiring validation. Identifies model errors. Refines prompts based on output quality.
 
 **Observable signals:**
 - Catches hallucinated API signatures or incorrect library usage before they reach review
@@ -100,14 +98,14 @@ Four stages of AI fluency. ICs self-assess; managers calibrate in 1:1s.
 
 ### Stage 3 — Deliberate Practitioner
 
-**Behavior:** Actively designs prompts for specific outcomes. Has internalized which task types benefit from AI and which don't. Uses AI earlier in the task lifecycle (design and planning, not just implementation).
+**Behavior:** Designs prompts for specific outcomes. Has internalized which task types benefit from AI and which do not. Uses AI earlier in the task lifecycle: design and planning, then implementation.
 
 **Observable signals:**
 - Fewer revision cycles; output closer to intent on first pass
-- Rejects AI output in appropriate high-risk contexts without needing to be coached
-- Uses AI for clarifying requirements and surfacing edge cases, not just writing code
+- Rejects AI output in appropriate high-risk contexts without needing coaching
+- Uses AI to clarify requirements and surface edge cases, then to write code
 
-**Coaching target:** Begin teaching others. Document effective patterns. Identify edge cases where AI is unreliable in your specific domain.
+**Coaching target:** Begin teaching others. Document effective patterns. Identify edge cases where AI proves unreliable in your specific domain.
 
 **Coaching question for 1:1s:**
 > "Have you run into a situation where AI misled you? What did you catch it on, and how?"
@@ -116,25 +114,25 @@ Four stages of AI fluency. ICs self-assess; managers calibrate in 1:1s.
 
 ### Stage 4 — Workflow Architect
 
-**Behavior:** Has internalized AI as a design variable in how they structure work. Contributes to team-level patterns. Can articulate the failure modes of AI-assisted workflows in their domain and has built mitigations into how they work.
+**Behavior:** Has internalized AI as a design variable in how they structure work. Contributes to team-level patterns. Articulates the failure modes of AI-assisted workflows in their domain and has built mitigations into how they work.
 
 **Observable signals:**
-- Proposes workflow changes that incorporate AI at the process level, not just task level
-- Spots org-level risks before they become incidents (e.g., identifies a class of code review that needs new norms given AI-generated PRs)
+- Proposes process-level workflow changes incorporating AI, beyond task-level uses
+- Spots org-level risks before they become incidents (identifies a class of code review needing new norms given AI-generated PRs)
 - Mentors Stage 1–2 engineers on specific, observable behaviors
 
-**Coaching target:** Partner with engineering leadership on policy. Contribute to cross-team standards. Actively reduce single-point-of-failure risk in AI-assisted workflows.
+**Coaching target:** Partner with engineering leadership on policy. Contribute to cross-team standards. Reduce single-point-of-failure risk in AI-assisted workflows.
 
 **Coaching question for 1:1s:**
 > "If I asked you to defend every line of that PR in a postmortem — including which parts the AI generated and why you accepted them — could you?"
 
-> **This last question is the "outsourcing judgment" test.** A Stage 1 engineer cannot answer it. A Stage 4 engineer has already asked it of themselves before pushing.
+> **The "outsourcing judgment" test.** A Stage 1 engineer cannot answer the question. A Stage 4 engineer has already asked it of themselves before pushing.
 
 ---
 
 ## Part 3: Role-Differentiated Use Cases
 
-AI tooling creates different kinds of leverage for ICs versus managers. Conflating these leads to either underutilization or misapplication.
+AI tooling creates different kinds of leverage for ICs and for managers. Conflating the two leads to either underutilization or misapplication.
 
 ### Individual Contributors
 
@@ -154,19 +152,19 @@ AI tooling creates different kinds of leverage for ICs versus managers. Conflati
 | 1:1 prep and note synthesis | Claude | Useful for pattern-finding across multiple 1:1 notes |
 | Job description drafting | Claude | Manager reviews and owns final version |
 | Roadmap communication | Claude | Drafts only; manager validates alignment to context |
-| Performance review drafting | Claude | **Use with caution.** AI as a starting point only; manager writes final evaluation independently |
+| Performance review drafting | Claude | **Use with caution.** AI drafts only; manager writes final evaluation independently |
 | Incident summary drafting | Claude | Useful for structure; manager reviews accuracy and tone |
 | Candidate evaluation | **Prohibited** | People decisions require human judgment; AI introduces bias amplification risk |
 
-> **Compliance note:** All AI-assisted manager outputs involving specific individuals (performance reviews, PIPs, compensation recommendations) must be reviewed and rewritten by the manager before submission. AI-assisted drafts must not be submitted as final without material revision.
+> **Compliance note:** Every AI-assisted manager output involving specific individuals (performance reviews, PIPs, compensation recommendations) requires manager review and rewrite before submission. AI-assisted drafts cannot ship as final without material revision.
 
 ---
 
 ## Part 4: Observability
 
-The rubric becomes actionable only when paired with signals that let managers and leaders see what's actually happening. Instrument at three levels.
+The rubric becomes actionable when paired with signals letting managers and leaders see what is happening. Instrument at three levels.
 
-> **Design pattern:** This mirrors the three-tier observability model (logs → metrics → traces) from SRE practice. See: [Google SRE Book, Chapter 6](https://sre.google/sre-book/monitoring-distributed-systems/) for the underlying observability framework applied here to human+AI systems.
+> **Design pattern:** Mirrors the three-tier observability model (logs → metrics → traces) from SRE practice. See: [Google SRE Book, Chapter 6](https://sre.google/sre-book/monitoring-distributed-systems/) for the underlying observability framework applied here to human+AI systems.
 
 ### Individual Level (opt-in)
 
@@ -180,11 +178,11 @@ AI Reflection (weekly, 2 minutes):
 - What would I do differently?
 ```
 
-This builds metacognitive fluency over time and surfaces coaching opportunities organically.
+The reflection builds metacognitive fluency over time and surfaces coaching opportunities.
 
 ### Team Level (manager-owned)
 
-Track directional signals, not vanity metrics. The goal is to identify outliers and trends, not to surveil individuals.
+Track directional signals over vanity metrics: identify outliers and trends; avoid surveilling individuals.
 
 | Signal | Source | Cadence | What It Tells You |
 |---|---|---|---|
@@ -201,19 +199,19 @@ Track directional signals, not vanity metrics. The goal is to identify outliers 
 
 Quarterly review covering:
 
-- Adoption distribution by role tier (staff vs. mid-level vs. junior — are there meaningful differences?)
+- Adoption distribution by role tier (staff vs. mid-level vs. junior — meaningful differences?)
 - Cross-team variance (which teams are outliers, and why?)
 - Policy compliance signals (are prohibited use cases surfacing in postmortems or reviews?)
 - Incident attribution trends (is the AI-assisted incident rate trending in any direction?)
-- Rubric distribution (aggregate self-assessments: where is the org on the fluency curve?)
+- Rubric distribution (aggregate self-assessments: where does the org sit on the fluency curve?)
 
 ---
 
 ## Part 5: Phased Rollout Gate Model
 
-Expansion to higher-risk workflows is gated on demonstrated fluency at the current stage. This is the sequencing mechanism that prevents organizations from skipping ahead of their actual capability.
+Expansion to higher-risk workflows gates on demonstrated fluency at the current stage. The sequencing prevents organizations from running ahead of their actual capability.
 
-> **Design pattern:** This is an application of the *strangler fig pattern* to organizational change — replacing existing workflows incrementally, validating each phase before expanding scope. See: [Martin Fowler, "Strangler Fig Application"](https://martinfowler.com/bliki/StranglerFigApplication.html) for the pattern; the principle transfers directly to phased AI adoption.
+> **Design pattern:** Applies the *strangler fig pattern* to organizational change — replacing existing workflows incrementally, validating each phase before expanding scope. See: [Martin Fowler, "Strangler Fig Application"](https://martinfowler.com/bliki/StranglerFigApplication.html) for the pattern; the principle transfers directly to phased AI adoption.
 
 ```
 Gate 0 → Gate 1
@@ -262,17 +260,16 @@ Any of the following automatically reverts a team to the previous gate pending r
 
 **What a Stage 2 engineer does:**
 - Reviews the full generated output line by line ✓
-- Catches that the generated HMAC signature verification logic uses a timing-unsafe string comparison ✓
-- Fixes it before review ✓
-- Notes it in the PR description: *"AI-generated skeleton; replaced signature verification with `hmac.compare_digest()` per timing-safe comparison requirements"* ✓
+- Catches the generated HMAC signature verification using a timing-unsafe string comparison ✓
+- Fixes the comparison before review ✓
+- Notes the fix in the PR description: *"AI-generated skeleton; replaced signature verification with `hmac.compare_digest()` per timing-safe comparison requirements"* ✓
 
 **What a Stage 1 engineer does:**
 - Commits the generated output after a quick read ✗
 - The timing-unsafe comparison ships to review
-- A reviewer catches it (best case) or it ships (worst case)
+- A reviewer catches the issue (best case) or it ships (worst case)
 
-**The coaching intervention:**
-The Stage 2 behavior is not because this engineer is smarter — it's because they've internalized the expectation that AI output requires validation proportional to the risk of the task. The rubric makes that expectation explicit and the manager can coach to it.
+**The coaching intervention:** Stage 2 engineers have internalized the expectation that AI output requires validation proportional to task risk. Stage 1 engineers have not. The rubric makes the expectation explicit so the manager can coach to it.
 
 ---
 
@@ -291,25 +288,25 @@ The Stage 2 behavior is not because this engineer is smarter — it's because th
 
 ## Appendix C: Demonstration artifacts
 
-> **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook) is a personal-project monorepo, not a production system at scale. The artifacts below illustrate the framework's mechanisms against an inspectable stack — they do not substitute for the production rollout experience documented in [ORIGINS.md](../ORIGINS.md). See [LINKING.md](../LINKING.md) for the full convention.
+> **Demonstration sandbox:** [lifting-logbook](https://github.com/brownm09/lifting-logbook) runs as a personal-project monorepo at single-operator scale. The artifacts below illustrate the framework's mechanisms against an inspectable stack; they do not substitute for the production rollout experience documented in [ORIGINS.md](../ORIGINS.md). See [LINKING.md](../LINKING.md) for the full convention.
 
-The personal-project rollout is the inverse of the org-scale rollouts described above: a single operator, no calibration cohort, no observability dashboard. The framework still applies — gate model collapses to "self-gate against the rubric," and the observability layer collapses to the artifacts a future reader could audit. Citation links pin to commit [`413f8a6`](https://github.com/brownm09/lifting-logbook/tree/413f8a62f43f12fa200be3e3307da7ef72c7b446); live-state links to `main`.
+The personal-project rollout inverts the org-scale rollouts described above: a single operator, no calibration cohort, no observability dashboard. The framework still applies. The gate model collapses to "self-gate against the rubric"; the observability layer collapses to the artifacts a future reader could audit. Citation links pin to commit [`413f8a6`](https://github.com/brownm09/lifting-logbook/tree/413f8a62f43f12fa200be3e3307da7ef72c7b446); live-state links to `main`.
 
 ### On policy-as-code and project-level AI configuration
 
-- **Project AI scaffolding** — [`CLAUDE.md`](https://github.com/brownm09/lifting-logbook/blob/main/CLAUDE.md) (live state). Project-local Claude Code configuration: platform constraints (Windows + Git Bash, no `jq`, npm workspaces), repo layout, and the testing command the global "Test before PR" rule depends on. Demonstrates the framework's Part 4 instrumentation principle at the smallest scale: every project carries the context an AI agent needs in version control, not in a human's head.
-- **Project automation hooks** — [`.claude/hook-config.json`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/.claude/hook-config.json) (citation, SHA-pinned) and [`.claude/propose.json`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/.claude/propose.json) (citation, SHA-pinned). Wire the project to its GitHub Project (epics + milestones) and to the proposal-scaffolding skill that drafts ADRs and design proposals against the repo's roadmap. Demonstrates the Gate 2 → Gate 3 prerequisite — agentic write workflows are only safe when the destination structure is itself codified.
+- **Project AI scaffolding** — [`CLAUDE.md`](https://github.com/brownm09/lifting-logbook/blob/main/CLAUDE.md) (live state). Project-local Claude Code configuration: platform constraints (Windows + Git Bash, no `jq`, npm workspaces), repo layout, and the testing command the global "Test before PR" rule depends on. Demonstrates the framework's Part 4 instrumentation principle at single-operator scale; every project carries the context an AI agent needs in version control where it remains durably retrievable.
+- **Project automation hooks** — [`.claude/hook-config.json`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/.claude/hook-config.json) (citation, SHA-pinned) and [`.claude/propose.json`](https://github.com/brownm09/lifting-logbook/blob/413f8a62f43f12fa200be3e3307da7ef72c7b446/.claude/propose.json) (citation, SHA-pinned). Wire the project to its GitHub Project (epics + milestones) and to the proposal-scaffolding skill drafting ADRs and design proposals against the repo's roadmap. Demonstrates the Gate 2 → Gate 3 prerequisite: agentic write workflows only become safe when the destination structure is itself codified.
 
 ### On the gate model and rollback discipline
 
-- **Architecture decision record series** — [`docs/adr/`](https://github.com/brownm09/lifting-logbook/tree/main/docs/adr) (live state). Every architectural decision the AI participated in scaffolding is captured as an ADR with an alternatives-considered section. Demonstrates the framework's Stage 4 "outsourcing judgment" test at the artifact level: the rationale for each AI-assisted decision is durably recorded and re-readable, not lost to chat history.
-- **Proposal lifecycle** — [`docs/proposals/`](https://github.com/brownm09/lifting-logbook/tree/main/docs/proposals) (live state). Each proposal is drafted with AI assistance, marked through `proposed → accepted → shipped` states, and linked from the implementing PR. Demonstrates the Gate 1 → Gate 2 prerequisite — medium-risk AI-assisted work requires a paper trail, even on a single-operator project.
+- **Architecture decision record series** — [`docs/adr/`](https://github.com/brownm09/lifting-logbook/tree/main/docs/adr) (live state). Every architectural decision the AI participated in scaffolding lands as an ADR with an alternatives-considered section. Demonstrates the framework's Stage 4 "outsourcing judgment" test at the artifact level; the rationale for each AI-assisted decision is durably recorded and re-readable, never lost to chat history.
+- **Proposal lifecycle** — [`docs/proposals/`](https://github.com/brownm09/lifting-logbook/tree/main/docs/proposals) (live state). Each proposal is drafted with AI assistance, marked through `proposed → accepted → shipped` states, and linked from the implementing PR. Demonstrates the Gate 1 → Gate 2 prerequisite: medium-risk AI-assisted work requires a paper trail, even on a single-operator project.
 
-**Global-layer counterpart — [`dev-env`](https://github.com/brownm09/dev-env) (live state).** Where lifting-logbook demonstrates project-level AI scaffolding, dev-env demonstrates the global layer: cross-device `CLAUDE.md` and `settings.json` symlinked from version control, pre-push and session-boundary hooks enforcing the workflow rules documented in Part 5, custom skills (`/propose`, `/review`, `/journal-compose`, `/research`) extending the agent's capabilities across every project, and autonomous scheduled routines (nightly journal composition, stale-worktree pruning). This is the Part 2 Stage 4 "Workflow Architect" pattern in practice — the operator has stopped configuring AI tools and started building infrastructure *for* AI tools. The signal a reader should take: the framework's Gate 2 → Gate 3 transition (agentic write workflows gated on codified destination structure) has a global equivalent, not just a per-project one.
+**Global-layer counterpart — [`dev-env`](https://github.com/brownm09/dev-env) (live state).** Where lifting-logbook demonstrates project-level AI scaffolding, dev-env demonstrates the global layer: cross-device `CLAUDE.md` and `settings.json` symlinked from version control, pre-push and session-boundary hooks enforcing the workflow rules documented in Part 5, custom skills (`/propose`, `/review`, `/journal-compose`, `/research`) extending the agent's capabilities across every project, and autonomous scheduled routines (nightly journal composition, stale-worktree pruning). The Part 2 Stage 4 "Workflow Architect" pattern in practice: the operator has stopped configuring AI tools and started building infrastructure *for* AI tools. The signal a reader should take: the framework's Gate 2 → Gate 3 transition (agentic write workflows gated on codified destination structure) has a global equivalent, beyond the per-project version.
 
-### What is missing — and what that demonstrates
+### What is missing — and what the absence demonstrates
 
-The personal-scale stack has no team-level pulse survey, no cross-team variance dashboard, no calibration cohort. That absence is itself a demonstration: the framework's org-level mechanisms (Part 4 *Organization Level*, Part 5 *Gate 3 sustained*) only cohere at organizational scale. A reader evaluating whether to apply this framework should treat the lifting-logbook artifacts as evidence of the per-engineer mechanics, and the [ORIGINS.md](../ORIGINS.md) entries (ActBlue, CTA) as the basis for the org-level claims.
+The personal-scale stack has no team-level pulse survey, no cross-team variance dashboard, no calibration cohort. The absence is itself a demonstration: the framework's org-level mechanisms (Part 4 *Organization Level*, Part 5 *Gate 3 sustained*) cohere only at organizational scale. A reader evaluating whether to apply this framework should treat the lifting-logbook artifacts as evidence of the per-engineer mechanics, and the [ORIGINS.md](../ORIGINS.md) entries (ActBlue, CTA) as the basis for the org-level claims.
 
 ---
 
@@ -321,4 +318,4 @@ The personal-scale stack has no team-level pulse survey, no cross-team variance 
 
 ---
 
-*This document is intended as a living reference. Open a PR with proposed changes; all policy updates require engineering leadership sign-off before merging.*
+*Living reference. Open a PR with proposed changes; all policy updates require engineering leadership sign-off before merging.*


### PR DESCRIPTION
Flag list for `ai-adoption/ai-adoption-readiness-framework.md` per the workflow in #12. Open as draft pending user dispositions; no file edits yet.

Rule basis: [`career-playbook/context/playbook_writer_briefing.md`](https://github.com/brownm09/career-playbook/blob/main/context/playbook_writer_briefing.md). FA anchors: [`career-playbook/context/accomplishments.md`](https://github.com/brownm09/career-playbook/blob/main/context/accomplishments.md).

---

## Part 1 — Factual-accuracy findings

### 🚩 Disposition needed

- [ ] **Line 22 — "introducing a formal fluency rubric" at CTA.** `accomplishments.md` (CTA row) cites a *"structured evaluation rubric for measuring impact"*. The file's Part 2 presents a four-stage **fluency rubric** (Naive User → Workflow Architect) measuring engineer behavior, not initiative impact. **Disposition options:**
  1. The Part 2 fluency rubric IS the CTA evaluation rubric — same instrument, framed for the playbook. No change; line 22 wording stands.
  2. The Part 2 fluency rubric is a synthesis Mike developed for this document; the CTA rubric measured initiative impact, not engineer fluency. Soften line 22 (e.g., *"introducing role-differentiated use cases and structured evaluation criteria"*) and the Part 2 framing.
  3. The CTA rubric was both — fluency AND impact. Keep line 22 wording; add one anchoring sentence to Part 2 introduction.

- [ ] **Line 20 — "track adoption patterns, friction points, and quality signals" at ActBlue.** `accomplishments.md` (ActBlue row, line 36) lists *"tracked adoption patterns"* explicitly. *"Friction points"* and *"quality signals"* are not in the anchor and read like a voice-rewrite tricolon expansion of the verified item. **Disposition options:**
  1. Confirm friction points and quality signals were tracked → anchored, stands.
  2. Only adoption patterns were tracked → cut the tricolon, leave *"track adoption patterns"*.

### Anchored — verified

- Line 20: "ActBlue Technical Services (2024–2025)" → matches Senior EM tier Aug 2024 – Aug 2025
- Line 20: "Piloted GitHub Copilot and Claude across ICs and engineering managers" → matches accomplishments line 36 *"Designed the pilot structure at ActBlue"*; scope (ICs + EMs) anchors to the directorate composition
- Line 20: "Observability was instrumented into the rollout from day one" → matches *"built observability into the rollout"*
- Line 22: "Community Tech Alliance (2025–2026)" → matches VP/Head tier Sep 2025 – Apr 2026
- Line 22: "separating use cases by role (IC vs. manager)" → matches *"separate use cases for engineers vs. managers"*
- Line 22: "sequencing Claude Code integration in phases gated on demonstrated organizational readiness" → matches *"phased Claude Code initiative... sequenced for organizational readiness"*

### Note for the FA pass

`accomplishments.md` line 131 explicitly flags a known false propagation: *"I defined separate use cases for ICs and managers and developed a structured evaluation rubric **at ActBlue**"* is partially true — these were developed at CTA, not ActBlue. The file currently attributes the CTA work to CTA correctly (line 22) and the ActBlue work to ActBlue (line 20). **No false attribution detected.** Flagged here so the disposition above is read in context.

---

## Part 2 — Voice findings

### Outright bans (counts across the file)

| Category | Count | Disposition |
|---|---|---|
| Copular `is`/`are` doing connective work | ~15 | Fix all unless measurement/fact carve-out applies |
| `that` as relative pronoun (banned outright per briefing Universal Self-Check) | 8 | Rewrite all |
| "X, not Y" / "not X, it's Y" graded comparison contrasts | ~10 | Rewrite all to direct claims |
| "rather than" constructions | 2 | Rewrite both |
| Em-dash budget exceeded (per-H2-section budget = 1) | Part 2: 3+; Part 5 + Appendix C: 4+ | Keep one highest-impact use per H2; convert rest to colons, commas, or sentence breaks |
| Abstract tricolon (3-item parallel of abstractions) | 3 | Rewrite to compressed pair or expand to concrete-item inventory of 4+ |
| Superlative (`smallest`, line 300) | 1 | Cut |
| Filler intensifier (`actually` ×2, `organically`, `Actively`) | 4 | Cut |
| "is the" construction | 5 | Rewrite per briefing |

Representative fixes (full list applied during edit pass):

- Line 5: copular `is` + em-dash connective. Recast around *"AI tooling adoption carries measurable ROI and a risk surface."*
- Line 24: "rather than" + framing. Recast around *"engineers outsourcing judgment to AI."*
- Line 57: copular stacking + "not X, it's Y" + banned `that`. Recast around *"The risk: subtle error surface, high blast radius."*
- Line 65: copular + "not X, it's Y" + em-dash. Recast around *"The rubric opens a coaching conversation."* (cut the negation)
- Line 71 (Stage 1 Behavior): three consecutive 5–8 word sentences. Cluster-rule fail. Vary lengths.
- Line 122: `that` rel pron + "not just" graded. Recast around *"process-level workflow changes incorporating AI, beyond task-level uses."*
- Line 275: triple-banned construction. Recast around *"Stage 2 engineers have internalized that AI output requires validation proportional to task risk. Stage 1 engineers have not."*

### Judgment calls

- [ ] **Meta-signaling.** Lines 24, 30, 65, 167, 213 restate adjacent evidence at higher abstraction or announce what is about to be shown. Test per briefing: remove the sentence — if the surrounding evidence is undiminished, cut. **Disposition:** Cut all (recommended) or keep specific ones for transitional load?
- [ ] **Wind-up openers.** Lines 30, 42, 137, 167, 213 open H2 sections with content-free topic sentences. Briefing's operational-substance opener check: replace with a specific named anchor or operational claim. **Disposition:** Approve recasting all H2 openers to operational-substance, or selectively?
- [ ] **Reader-org overclaim risk.** No outright fails (no *"your engineering org requires X"* present), but Line 5's *"The engineering leader's job is not to decide..."* asserts what *every* engineering leader's job is. Per briefing's reader-org overclaim ban (adapted from fit-bridge), playbook prose describes the practice and conditions; the reader judges applicability. **Disposition:** Recast to anchored form (*"At ActBlue and CTA, the decision was not whether to adopt..."*), or keep as universal claim?
- [ ] **Missing positive moves.** Per briefing's Positive Moves catalog: the file is heavy on declarative tables and bullet lists but light on definitional openers, semicolon cause-effect, and concrete-item inventories. **Disposition:** Approve adding positive moves where naturally fitting (no forced insertion), or strip-only pass with no positive-move additions?

---

## Part 3 — Cross-file grep results

Strings searched across the repo: `Piloted GitHub Copilot`, `Copilot and Claude`, `Claude Code integration`, `integration initiative`, `2024.?2025`, `2025.?2026`, `fluency rubric`, `gate model`.

**Files with hits (13):** `README.md`, `ORIGINS.md`, `operating-cadence/engineering-rhythm-of-business.md`, `transitions/new-hire-onboarding-framework.md` *(note: not in folder inventory — verify)*, `strategy/technical-strategy-template.md`, `people/headcount-capacity-planning.md`, `operating-cadence/engineering-okr-framework.md`, `metrics/head-of-engineering-dashboard.md`, `metrics/engineering-health-scorecard.md`, `leadership/rfc-design-doc-process.md`, `leadership/prd-lifecycle.md`, `leadership/ai-documentation-standards.md`, `ai-adoption/ai-adoption-readiness-framework.md` (this file).

**Propagation surfaces this PR would need to close:** depends on which claims change after dispositions. If Line 22's fluency-rubric framing changes (disposition option 2), check `leadership/ai-documentation-standards.md` and `ORIGINS.md`. Otherwise no cross-file changes triggered by this PR.

**Note:** A `transitions/` folder appeared in the grep but is not in the folder inventory in #12. Verify whether `transitions/new-hire-onboarding-framework.md` is in scope; if yes, add a 14th folder PR.

---

## Workflow

Per #12: this PR stays in draft until dispositions land. Apply 🚩 dispositions in a single comment. Once dispositions are recorded, the edit pass runs and PR moves to ready-for-review.

Refs #12.
