### PR TITLE
Voice + FA sweep: metrics/ (folder 8 of 14)

### DIFF
--- a/metrics/engineering-health-scorecard.md
+++ b/metrics/engineering-health-scorecard.md
@@ -97,7 +97,7 @@ Percentage of bugs found in production versus bugs found in pre-production. A hi
 - Target: <20% of reported defects first detected in production
 - Warning threshold: >35%
 
-*How to instrument:* Jira bug label + environment field at time of creation. Requires discipline about where bugs are logged. If your team logs all bugs as customer-reported issues after the fact, the data will be noisy — establish a classification convention first.
+*How to instrument:* Jira bug label + environment field at time of creation. Requires discipline about where bugs are logged. If your team logs all bugs as customer-reported issues after the fact, the data will run noisy; establish a classification convention first.
 
 **P0/P1 Incident Count (Quality-Attributed)**
 
@@ -119,7 +119,7 @@ Total number of incidents per time period, segmented by severity tier. Frequency
 
 *Segment by:* P0/P1 (customer-impacting), P2 (degraded service, users affected), P3 (internal/latent).
 
-*How to instrument:* PagerDuty incident count by severity. Requires consistent severity classification at incident open time — not after the fact.
+*How to instrument:* PagerDuty incident count by severity. Requires consistent severity classification at incident open time; post-hoc reclassification breaks the trend line.
 
 **MTTR (see also Delivery domain)**
 
@@ -162,9 +162,9 @@ Percentage of sprint capacity consumed by work not planned at sprint start: reac
 - Target: <25%
 - Warning threshold: >40% (sustained over two or more sprints)
 
-*How to instrument:* Jira sprint report — tickets added after sprint start versus at sprint start. Requires consistent sprint planning discipline. If your team does not use sprints, use a weekly capacity tracking mechanism instead.
+*How to instrument:* Jira sprint report: tickets added after sprint start versus at sprint start. Requires consistent sprint planning discipline. If your team does not use sprints, use a weekly capacity tracking mechanism instead.
 
-**On-Call Load** (see Reliability domain — the same metric appears here as a team health signal)
+**On-Call Load** (see Reliability domain; the same metric appears here as a team health signal)
 
 **Voluntary Attrition (Engineering)**
 

--- a/metrics/engineering-health-scorecard.md
+++ b/metrics/engineering-health-scorecard.md
@@ -4,7 +4,7 @@
 
 A Director or Head of Engineering without a way to quantify org health depends on narratives no one can validate and anyone can challenge. In a QBR, a board meeting, or an M&A diligence session, "the team ships fast and quality stays high" without supporting data lands as an assertion. The engineering health scorecard converts the assertion into a structured, defensible position: four domains measured, targets set, current values, trend direction, and a named owner per number.
 
-Engineers need granular telemetry; this artifact serves a different audience. The health scorecard functions as a leadership communication artifact — 8–12 metrics organized by domain, answering the questions a non-technical executive will ask about engineering capability, reliability, and sustainability.
+Engineers need granular telemetry; this artifact serves a different audience. The health scorecard functions as a leadership communication artifact: 8–12 metrics organized by domain, answering the questions a non-technical executive will ask about engineering capability, reliability, and sustainability.
 
 ## Background and Motivation
 
@@ -97,7 +97,7 @@ Percentage of bugs found in production versus bugs found in pre-production. A hi
 - Target: <20% of reported defects first detected in production
 - Warning threshold: >35%
 
-*How to instrument:* Jira bug label + environment field at time of creation. Requires discipline about where bugs are logged. If your team logs all bugs as customer-reported issues after the fact, the data will run noisy; establish a classification convention first.
+*How to instrument:* Jira bug label + environment field at time of creation. Requires discipline about where bugs are logged. If your team logs all bugs as customer-reported issues after the fact, the data turns noisy; establish a classification convention first.
 
 **P0/P1 Incident Count (Quality-Attributed)**
 
@@ -226,11 +226,11 @@ A common mistake in scorecard setup: adopting DORA industry benchmarks as target
 
 2. **Set 90-day improvement targets; industry benchmarks come later.** "We will improve deployment frequency from 3/week to 5/week" reads as a credible target. "We will be an elite performer by Q3" reads as a slogan.
 
-3. **Anchor on the trajectory; absolute value follows.** A metric below benchmark but improving every quarter carries a stronger leadership story than one with a single benchmark hit and a flat curve since.
+3. **Anchor on the trajectory; absolute value follows.** A metric below benchmark but improving every quarter carries a stronger leadership story than one with a single benchmark hit and a flat curve in the quarters since.
 
 4. **Re-baseline annually.** As the org matures, benchmarks should tighten. Do not leave targets unchanged for more than 12 months — they become wallpaper.
 
-5. **Define the instrumentation for each metric before the scorecard goes to leadership.** A metric with an undefined data source becomes a liability; the first time someone asks "how did you calculate that" and "we estimated" comes back, the scorecard loses credibility.
+5. **Define the instrumentation for each metric before the scorecard goes to leadership.** A metric with an undefined data source becomes a liability; the first time someone asks "how did you calculate that" and the answer comes back "we estimated," the scorecard loses credibility.
 
 ---
 
@@ -258,7 +258,7 @@ A leadership scorecard with too many metrics becomes harder to act on than one w
 
 **Metrics to exclude:**
 
-- **Lines of code / commit count:** Captures activity; output stays unmeasured. By this metric, the team that wrote 10,000 lines outranks the team that later refactored those lines into 1,000 cleaner ones — an inversion of the actual value created.
+- **Lines of code / commit count:** Captures activity; output stays unmeasured. By this metric, the team writing 10,000 lines outranks the team later refactoring those lines into 1,000 cleaner ones — an inversion of the actual value created.
 - **Story points completed:** Velocity serves as a sprint planning tool; performance evaluation breaks the metric. Story point inflation, scope change, and estimation variance make cross-team and cross-quarter comparisons meaningless.
 - **PR count:** Same problem as commit count. Optimizes for small PRs; impactful work stays invisible.
 - **Test coverage percentage (as a standalone metric):** 80% coverage with tests asserting nothing meaningful loses to 60% coverage with tests catching real regressions. Track defect escape rate instead.

--- a/metrics/engineering-health-scorecard.md
+++ b/metrics/engineering-health-scorecard.md
@@ -2,13 +2,13 @@
 
 ## Leadership Context
 
-A Director or Head of Engineering who cannot quantify the health of the engineering org is dependent on narratives that are impossible to validate and easy to challenge. In a QBR, a board meeting, or an M&A diligence session, "the team is shipping fast and quality is high" without supporting data is not a credible claim — it is an assertion. The engineering health scorecard converts that assertion into a structured, defensible position: here are the four domains we measure, here are our targets, here is where we are, here is the trend, and here is who owns each number.
+A Director or Head of Engineering without a way to quantify org health depends on narratives no one can validate and anyone can challenge. In a QBR, a board meeting, or an M&A diligence session, "the team ships fast and quality stays high" without supporting data lands as an assertion. The engineering health scorecard converts the assertion into a structured, defensible position: four domains measured, targets set, current values, trend direction, and a named owner per number.
 
-This is not a dashboard for engineers. Engineers need granular telemetry. The health scorecard is a leadership communication artifact: 8–12 metrics, organized by domain, that answer the questions a non-technical executive will ask about engineering capability, reliability, and sustainability.
+Engineers need granular telemetry; this artifact serves a different audience. The health scorecard functions as a leadership communication artifact — 8–12 metrics organized by domain, answering the questions a non-technical executive will ask about engineering capability, reliability, and sustainability.
 
 ## Background and Motivation
 
-This scorecard format was developed from the Jellyfish rollout and org-wide engineering health reporting work at ActBlue Technical Services (2024–2025). I led the rollout, owned engineering health reporting for the platform directorate, defined the metrics framework, and trained managers and ICs across six teams. The scorecard is the artifact that translates raw delivery data into the format a VP of Engineering can use in a QBR or board presentation.
+I developed this scorecard format during the Jellyfish rollout and org-wide engineering health reporting work at ActBlue Technical Services (2024–2025). I led the rollout, owned engineering health reporting for the platform directorate, defined the metrics framework, and trained managers and ICs across six teams. The scorecard translates raw delivery data into the format a VP of Engineering uses in a QBR or board presentation.
 
 ---
 
@@ -22,7 +22,7 @@ This scorecard format was developed from the Jellyfish rollout and org-wide engi
 | M&A technical diligence | Engineering maturity signal for acquirers or investors; shows the org has instrumented itself |
 | Engineering leadership performance review | Gives the business a shared language for evaluating the engineering function |
 
-Do not build a scorecard reactively — after a major incident, a missed launch, or a performance conversation with the CTO. Built reactively, the scorecard looks like a cover story. Built proactively and maintained consistently, it is a credibility asset.
+Do not build a scorecard reactively, after a major incident, a missed launch, or a performance conversation with the CTO. Built reactively, the scorecard looks like a cover story. Built proactively and maintained consistently, it becomes a credibility asset.
 
 ---
 
@@ -56,14 +56,14 @@ Time from first commit on a branch to that commit running in production. Measure
 
 **Change Failure Rate**
 
-Percentage of production deployments that require a hotfix, rollback, or immediate remediation. This is the quality gate on delivery speed — high deployment frequency with high change failure rate is not elite performance.
+Percentage of production deployments requiring a hotfix, rollback, or immediate remediation. The quality gate on delivery speed: high deployment frequency with high change failure rate does not qualify as elite performance.
 
 - Elite: 0–5%
 - High: 5–10%
 - Medium: 10–15%
 - Low: More than 15%
 
-*How to instrument:* Tag incidents or hotfixes that are causally linked to a deployment event. PagerDuty and Jeli both support incident tagging; the tag needs to connect to a deploy event. This is the hardest DORA metric to instrument cleanly — it requires discipline about incident classification.
+*How to instrument:* Tag incidents or hotfixes causally linked to a deployment event. PagerDuty and Jeli both support incident tagging; the tag needs to connect to a deploy event. Among the four DORA metrics, this one breaks first on classification discipline. Incident tagging must consistently connect to the causative deploy event.
 
 **Time to Restore Service (MTTR)**
 
@@ -74,7 +74,7 @@ How long it takes to restore normal service after a production failure. Measures
 - Medium: 1 day to 1 week
 - Low: More than 1 week
 
-*How to instrument:* Jeli tracks incident open time and resolution time. PagerDuty incident duration is a proxy but conflates acknowledgment with resolution. For a clean MTTR, define resolution as "service restored to SLO" not "incident acknowledged."
+*How to instrument:* Jeli tracks incident open time and resolution time. PagerDuty incident duration works as a proxy but conflates acknowledgment with resolution. For a clean MTTR, define resolution as service restored to SLO; acknowledgment alone does not close the window.
 
 ---
 
@@ -84,11 +84,11 @@ Quality metrics measure the rate at which defects escape into production and the
 
 **SLO Attainment**
 
-Percentage of rolling 30-day windows where each published SLO is met. This is the most customer-facing quality signal.
+Percentage of rolling 30-day windows in which each published SLO holds. Customer-facing quality lands here before anywhere else.
 
 *Target:* Depends on what you have committed to. If you have not set SLOs yet, start there before building this scorecard. A reasonable starting target for a B2B SaaS platform: 99.5% availability SLO, measured per service tier.
 
-*How to instrument:* Datadog SLO tracking, New Relic SLAs, or Honeycomb. Define SLOs in code (Terraform for Datadog SLOs is ideal for audit purposes). Report: number of SLOs in breach + trending direction, not just a pass/fail.
+*How to instrument:* Datadog SLO tracking, New Relic SLAs, or Honeycomb. Define SLOs in code (Terraform for Datadog SLOs is ideal for audit purposes). Report the number of SLOs in breach plus trending direction; a binary pass/fail collapses too much signal.
 
 **Defect Escape Rate**
 
@@ -101,7 +101,7 @@ Percentage of bugs found in production versus bugs found in pre-production. A hi
 
 **P0/P1 Incident Count (Quality-Attributed)**
 
-Count of severity 0 and severity 1 incidents where root cause is attributable to a code defect (as opposed to infrastructure failure, dependency failure, or capacity). This separates engineering quality failures from operational failures.
+Count of severity 0 and severity 1 incidents whose root cause traces to a code defect (as opposed to infrastructure failure, dependency failure, or capacity). The classification separates engineering quality failures from operational failures.
 
 *Target:* Set based on your 90-day baseline; target 20% reduction quarter-over-quarter until you reach a stable floor.
 
@@ -115,7 +115,7 @@ Reliability metrics measure how the system behaves under failure conditions and 
 
 **Incident Frequency**
 
-Total number of incidents per time period, segmented by severity tier. Frequency trending up is a leading indicator of systemic debt accumulating faster than it is being addressed.
+Total number of incidents per time period, segmented by severity tier. Frequency trending up signals systemic debt accumulating faster than the team addresses it.
 
 *Segment by:* P0/P1 (customer-impacting), P2 (degraded service, users affected), P3 (internal/latent).
 
@@ -127,28 +127,28 @@ MTTR appears in both delivery and reliability because it measures different thin
 
 **On-Call Incident Load Per Engineer**
 
-Average number of pages per on-call engineer per week, by severity tier. This is the most direct measure of on-call sustainability and a leading indicator of engineer burnout and attrition risk.
+Average number of pages per on-call engineer per week, by severity tier. The metric tracks on-call sustainability directly and surfaces engineer burnout and attrition risk before either appears in HR data.
 
 - Target: <3 P2+ pages per engineer per week on average
 - Warning threshold: >6 P2+ pages per engineer per week (sustained over 4+ weeks)
 
-*How to instrument:* PagerDuty on-call report → divide total pages by number of engineers in the rotation. Report the distribution, not just the average — one engineer absorbing 80% of pages while others see none is a structural problem the average hides.
+*How to instrument:* PagerDuty on-call report → divide total pages by number of engineers in the rotation. Report the distribution alongside the average; one engineer absorbing 80% of pages while others see none reveals a structural problem the average hides.
 
 **Mean Time Between Failures (MTBF) for Critical Services**
 
 How long your most critical services run without a customer-impacting incident. For services with SLAs, MTBF is an input to the reliability covenant.
 
-*How to instrument:* Calculated from PagerDuty or Jeli incident history. For each critical service, time between consecutive P0/P1 incidents. Track trend, not absolute value.
+*How to instrument:* Calculated from PagerDuty or Jeli incident history. For each critical service, time between consecutive P0/P1 incidents. Track the trend; absolute MTBF varies too much with service profile to compare across the portfolio.
 
 ---
 
 ### Domain 4: Team Health
 
-Team health metrics are the leading indicators for the lagging indicators in the other three domains. Delivery and reliability degrade when teams are overloaded, undersupported, or operating with unclear ownership.
+Team health metrics lead the lagging indicators in the other three domains. Delivery and reliability degrade after teams have been overloaded, undersupported, or operating with unclear ownership for weeks.
 
 **Lead-to-Cycle Time Ratio**
 
-Cycle time is time spent actively working on a ticket. Lead time is end-to-end time from creation to done. A high ratio (lead time >> cycle time) indicates that work is spending most of its time waiting: waiting for review, waiting for dependencies, waiting in a queue, waiting for a decision.
+Cycle time measures the duration of active work on a ticket. Lead time measures end-to-end time from creation to done. A high ratio (lead time >> cycle time) indicates work spends the majority of its time waiting: waiting for review, waiting for dependencies, waiting in a queue, waiting for a decision.
 
 - Healthy ratio: Lead time < 3× cycle time
 - Warning: Lead time > 5× cycle time
@@ -157,7 +157,7 @@ Cycle time is time spent actively working on a ticket. Lead time is end-to-end t
 
 **Sprint Capacity on Unplanned Work**
 
-Percentage of sprint capacity consumed by work that was not planned at sprint start: reactive incidents, urgent requests, context switches from leadership.
+Percentage of sprint capacity consumed by work not planned at sprint start: reactive incidents, urgent requests, context switches from leadership.
 
 - Target: <25%
 - Warning threshold: >40% (sustained over two or more sprints)
@@ -168,7 +168,7 @@ Percentage of sprint capacity consumed by work that was not planned at sprint st
 
 **Voluntary Attrition (Engineering)**
 
-Rolling 12-month voluntary attrition rate for engineering roles. Engineering attrition is expensive: recruiting, onboarding, and knowledge transfer costs are typically 0.5–1.5× annual salary per departure. High attrition correlates with on-call overload, poor manager effectiveness, and unclear career growth.
+Rolling 12-month voluntary attrition rate for engineering roles. Engineering attrition runs expensive: recruiting, onboarding, and knowledge transfer costs typically reach 0.5–1.5× annual salary per departure. High attrition correlates with on-call overload, poor manager effectiveness, and unclear career growth.
 
 - Target: <12% annually
 - Warning: >20% annually
@@ -179,7 +179,7 @@ Rolling 12-month voluntary attrition rate for engineering roles. Engineering att
 
 ## Sample Scorecard Table Format
 
-Use this format for QBR slides, board decks, and leadership reports. One table per domain. Color-coding (green/yellow/red) should be applied to the Trend column, not the Current column — a metric that is below target but improving is a better story than one that is at target but declining.
+Use this format for QBR slides, board decks, and leadership reports. One table per domain. Apply color-coding (green/yellow/red) to the Trend column; the Current column stays uncolored. Improvement trajectory carries the narrative weight; absolute current value does not.
 
 **Delivery**
 
@@ -218,25 +218,25 @@ Use this format for QBR slides, board decks, and leadership reports. One table p
 
 ## How to Set Targets
 
-The most common mistake in scorecard setup is adopting DORA industry benchmarks as targets before you have a baseline. "Elite performer" thresholds are aspirational; using them as Q1 targets for an org that has never measured itself sets up the scorecard as a failure narrative from day one.
+A common mistake in scorecard setup: adopting DORA industry benchmarks as targets before establishing a baseline. "Elite performer" thresholds carry aspirational weight; using them as Q1 targets for an org with no measurement history sets up the scorecard as a failure narrative from day one.
 
 **The right sequence:**
 
 1. **Instrument first.** Get 90 days of data before you set targets. You cannot set a credible target for deployment frequency if you do not know what your current deployment frequency is.
 
-2. **Set 90-day improvement targets, not industry benchmarks.** "We will improve deployment frequency from 3/week to 5/week" is a credible target. "We will be an elite performer by Q3" is a slogan.
+2. **Set 90-day improvement targets; industry benchmarks come later.** "We will improve deployment frequency from 3/week to 5/week" reads as a credible target. "We will be an elite performer by Q3" reads as a slogan.
 
-3. **Anchor on the trajectory, not the absolute value.** A metric that is below benchmark but improving every quarter is a better leadership story than one that hit benchmark once and is now flat.
+3. **Anchor on the trajectory; absolute value follows.** A metric below benchmark but improving every quarter carries a stronger leadership story than one with a single benchmark hit and a flat curve since.
 
 4. **Re-baseline annually.** As the org matures, benchmarks should tighten. Do not leave targets unchanged for more than 12 months — they become wallpaper.
 
-5. **Define the instrumentation for each metric before the scorecard goes to leadership.** A metric with an undefined data source is a liability; the first time someone asks "how did you calculate that" and the answer is "we estimated," the scorecard loses credibility.
+5. **Define the instrumentation for each metric before the scorecard goes to leadership.** A metric with an undefined data source becomes a liability; the first time someone asks "how did you calculate that" and "we estimated" comes back, the scorecard loses credibility.
 
 ---
 
 ## Leadership Dashboard Narrative
 
-Metrics without narrative are data. At a QBR or board meeting, you need to be able to explain each metric in two sentences: what it measures and what it means for the business.
+A metric without context lands as a number on a slide; the narrative does the load-bearing work. At a QBR or board meeting, each metric needs two sentences of explanation: what it measures and what it means for the business.
 
 **Deployment Frequency:**
 "We ship to production an average of 3.2 times per week, up from 1.8 times per week six months ago. This means we can respond to user feedback and fix production issues faster — it also means our deployment process has become reliable enough to run more frequently without increasing risk."
@@ -254,16 +254,16 @@ Metrics without narrative are data. At a QBR or board meeting, you need to be ab
 
 ## What NOT to Include
 
-A leadership scorecard that includes too many metrics is harder to act on than one with too few. Every metric on the scorecard should be actionable — if it drops, there is a known owner and a known response.
+A leadership scorecard with too many metrics becomes harder to act on than one with too few. Every metric on the scorecard should be actionable: if it drops, a known owner has a known response.
 
 **Metrics to exclude:**
 
-- **Lines of code / commit count:** Measures activity, not output. A team that refactors 10,000 lines of complex code into 1,000 clean lines has done more valuable work, by this metric, than the team that did.
-- **Story points completed:** Velocity is a sprint planning tool, not a performance metric. Story point inflation, scope change, and estimation variance make cross-team and cross-quarter comparisons meaningless.
-- **PR count:** Same problem as commit count. Optimizes for small PRs, not for impactful work.
-- **Test coverage percentage (as a standalone metric):** 80% coverage with tests that assert nothing meaningful is worse than 60% coverage with tests that catch real regressions. Track defect escape rate instead.
-- **Uptime percentage (without SLO context):** 99.9% uptime sounds good but tells you nothing about whether you met your commitments or whether the 0.1% downtime happened at peak user traffic.
-- **"Team happiness" survey scores as a primary metric:** Engagement surveys are useful inputs to a Director's understanding of team health, but they belong in manager-level conversations, not leadership scorecards where the audience does not have the context to interpret them.
+- **Lines of code / commit count:** Captures activity; output stays unmeasured. By this metric, the team that wrote 10,000 lines outranks the team that later refactored those lines into 1,000 cleaner ones — an inversion of the actual value created.
+- **Story points completed:** Velocity serves as a sprint planning tool; performance evaluation breaks the metric. Story point inflation, scope change, and estimation variance make cross-team and cross-quarter comparisons meaningless.
+- **PR count:** Same problem as commit count. Optimizes for small PRs; impactful work stays invisible.
+- **Test coverage percentage (as a standalone metric):** 80% coverage with tests asserting nothing meaningful loses to 60% coverage with tests catching real regressions. Track defect escape rate instead.
+- **Uptime percentage (without SLO context):** 99.9% uptime sounds reassuring but says nothing about whether commitments were met or whether the 0.1% downtime landed at peak user traffic.
+- **"Team happiness" survey scores as a primary metric:** Engagement surveys feed a Director's understanding of team health; they belong in manager-level conversations. In leadership scorecards, the audience lacks the context to interpret them fairly.
 
 ---
 

--- a/metrics/head-of-engineering-dashboard.md
+++ b/metrics/head-of-engineering-dashboard.md
@@ -55,7 +55,7 @@ Track the P90 alongside the median. A P90 two or three times the median means a 
 Distinct from lead time. This metric captures the code review and merge window. A PR sitting three days before its first review signals team health as much as delivery; the team is usually heads-down on incidents, on-call, or a high-priority fire, and code review has been deprioritized.
 
 - Target: <24 hours for P90 on standard PRs (not draft/WIP)
-- Watch for: specific engineers whose PRs consistently sit longer — may indicate a review bottleneck or an interpersonal dynamic
+- Watch for: specific engineers whose PRs consistently sit longer; the pattern points to a review bottleneck or an interpersonal dynamic
 
 **Change failure rate (trailing 30 days, per team)**
 
@@ -102,7 +102,7 @@ Most HoE dashboards omit this domain, and the omission causes the expensive surp
 
 Actual engineers on staff versus planned headcount, broken down by team. Include contractor ratio if contractors carry production load. Also: open requisitions and their age. A req open for 90 days without a hire represents a present capacity gap; treating it as a future one understates the load already on the team.
 
-- Watch for: teams operating at >20% below planned headcount for more than 60 days — delivery risk accumulates silently before it shows up in DORA metrics
+- Watch for: teams operating at >20% below planned headcount for more than 60 days; delivery risk accumulates silently before it shows up in DORA metrics
 
 **On-call incident load per engineer (P2+, per week, trailing 4 weeks)**
 

--- a/metrics/head-of-engineering-dashboard.md
+++ b/metrics/head-of-engineering-dashboard.md
@@ -6,7 +6,7 @@ The [Engineering Health Scorecard](engineering-health-scorecard.md) functions as
 
 The distinction matters because the two artifacts optimize for different things. A scorecard targets credibility with an audience holding no context; it must be curated, narrativized, and defensible. A dashboard targets speed for the one person holding full context; it must surface anomalies immediately, require no manual curation, and answer the Monday morning question: *is anything wrong I do not already know about?*
 
-If everything is green, the dashboard should take 90 seconds to review. The value shows up on the weeks when something is amber or red and you already know where to look.
+If everything is green, the dashboard should take 90 seconds to review. The value shows up in the weeks when something is amber or red and you already know where to look.
 
 ## Background and Motivation
 
@@ -34,7 +34,7 @@ The dashboard does not function as a management tool for engineers. Do not share
 
 **Question it answers:** Are we shipping, and is the pipeline healthy?
 
-Delivery typically carries the heaviest instrumentation and the most-trodden patterns. The risk: aggregate numbers mask team-level outliers.
+Delivery carries heavy instrumentation and well-trodden patterns. The risk: aggregate numbers mask team-level outliers.
 
 **Deployment frequency (per team, trailing 7 days)**
 
@@ -78,7 +78,7 @@ More useful than point-in-time SLO attainment because burn rate tells you whethe
 
 Track the count, then read the trend. Two P1s per month reads fine after four last month and two the month before. Two P1s per month reads alarming after zero for the prior two quarters.
 
-- Watch for: MTTR trending up over multiple weeks (recovery slowing instead of accelerating); incident count that stops declining after a remediation effort (the fix landed as cosmetic, the root cause untouched)
+- Watch for: MTTR trending up over multiple weeks (recovery slowing instead of accelerating); incident count stalling after a remediation effort (the fix landed as cosmetic, the root cause untouched)
 
 **Escaped defect rate (monthly refresh)**
 
@@ -178,7 +178,7 @@ Already in Domain 3 as a capacity signal; it appears here as a cost signal becau
 
 ## Dashboard Format
 
-The dashboard belongs in a system that refreshes automatically; a slide deck or a manually updated spreadsheet decays within weeks. Grafana, Datadog dashboards, or a simple internal tool all work. The format:
+The dashboard belongs in a system refreshing automatically; a slide deck or a manually updated spreadsheet decays within weeks. Grafana, Datadog dashboards, or a simple internal tool all work. The format:
 
 **Top-level view:** Five rows, one per domain. Each row shows a RAG status (green/amber/red) and a one-line summary. If all five are green, the review takes 90 seconds.
 
@@ -208,9 +208,9 @@ A common dashboard failure mode: treating amber as "informational." Amber withou
 
 The same exclusion principles from the scorecard apply here, with one addition:
 
-**Individual engineer metrics.** The dashboard operates at team and system resolution, never at individual contributor resolution. Monitoring individual output here lands as methodologically unsound (the metrics lack the fidelity) and as corrosive to the trust making the people signals useful. Evaluation of an individual's output belongs in a performance conversation with their manager; the dashboard is the wrong instrument.
+**Individual engineer metrics.** The dashboard operates at team and system resolution, never at individual contributor resolution. Monitoring individual output here lands as methodologically unsound (the metrics lack the fidelity) and as corrosive to the trust making the people signals useful. Evaluation of an individual's output belongs in a performance conversation with their manager; the dashboard does not have the resolution for that work.
 
-**Metrics requiring manual input.** A metric that cannot be pulled from a system will not stay current. A manually updated dashboard decays within two weeks; the cost of keeping it fresh exceeds the value it provides. Every metric on the operational dashboard must have an automated data source. Where automated sources are unavailable for people-domain metrics, start with the signals you can instrument and add the rest as tooling matures; a partially automated dashboard outperforms a fully manual one.
+**Metrics requiring manual input.** If a metric cannot be pulled from a system, it will not stay current. A manually updated dashboard decays within two weeks; the cost of keeping it fresh exceeds the value it provides. Every metric on the operational dashboard must have an automated data source. Where automated sources are unavailable for people-domain metrics, start with the signals you can instrument and add the rest as tooling matures; a partially automated dashboard outperforms a fully manual one.
 
 **Engagement survey scores.** Useful in a quarterly HR review; too noisy and infrequent for a weekly operational signal.
 

--- a/metrics/head-of-engineering-dashboard.md
+++ b/metrics/head-of-engineering-dashboard.md
@@ -2,15 +2,15 @@
 
 ## Leadership Context
 
-The [Engineering Health Scorecard](engineering-health-scorecard.md) is a communication artifact — it answers the questions a non-technical executive will ask about engineering health. The operational dashboard described here serves a different function: it is the weekly instrument the Head of Engineering uses to know whether anything is silently on fire before it becomes someone else's problem.
+The [Engineering Health Scorecard](engineering-health-scorecard.md) functions as a communication artifact — it answers the questions a non-technical executive will ask about engineering health. The operational dashboard described here serves a different function: the weekly instrument the Head of Engineering uses to know whether anything is silently on fire before it becomes someone else's problem.
 
-The distinction matters because the two artifacts optimize for different things. A scorecard is designed to be credible to an audience that does not have context; it must be curated, narrativized, and defensible. A dashboard is designed to be fast for the one person who has full context; it must surface anomalies immediately, require no manual curation, and answer the Monday morning question: *is anything wrong that I do not already know about?*
+The distinction matters because the two artifacts optimize for different things. A scorecard targets credibility with an audience holding no context; it must be curated, narrativized, and defensible. A dashboard targets speed for the one person holding full context; it must surface anomalies immediately, require no manual curation, and answer the Monday morning question: *is anything wrong I do not already know about?*
 
-If everything is green, the dashboard should take 90 seconds to review. It earns its keep when something is amber or red and you already know exactly where to look.
+If everything is green, the dashboard should take 90 seconds to review. The value shows up on the weeks when something is amber or red and you already know where to look.
 
 ## Background and Motivation
 
-> **Author's note:** This framework was developed from direct experience running engineering at ActBlue Technical Services (2024–2025), leading a six-team platform directorate and owning the metrics infrastructure for engineering health reporting. The distinction between "what I show the CTO" and "what I actually watch every week" became clear after the first QBR cycle: the scorecard was useful for quarterly storytelling but too lagging and too curated to catch in-week drift. The operational dashboard fills that gap.
+> **Author's note:** I developed this framework during the Jellyfish rollout and engineering health reporting work at ActBlue Technical Services (2024–2025), across a six-team platform directorate. The distinction between "what I show the CTO" and "what I watch every week" became clear after the first QBR cycle: the scorecard worked for quarterly storytelling but ran too lagging and too curated to catch in-week drift. The operational dashboard fills the gap.
 
 ---
 
@@ -20,11 +20,11 @@ If everything is green, the dashboard should take 90 seconds to review. It earns
 |---------|-----------------------------|
 | Weekly leadership ritual | Answers "is anything off?" before the weekly team sync |
 | First 90 days in a new HoE role | Fastest way to build a baseline and spot which signals are already in the red |
-| After a major incident or miss | Ongoing monitoring to confirm recovery is real, not just declared |
+| After a major incident or miss | Ongoing monitoring to confirm recovery is real and sustained, beyond what the post-incident review declared |
 | Scaling the org | People and capacity signals degrade before delivery signals do — catch it early |
 | Pre-planning / pre-QBR | Raw material for identifying the two or three things worth discussing with leadership |
 
-The dashboard is not a management tool for engineers. Do not share it directly with ICs or use it in performance conversations — it lacks the context to be fair at that resolution. It is a tool for the person who holds the org's risk.
+The dashboard does not function as a management tool for engineers. Do not share it directly with ICs or use it in performance conversations; it lacks the context to be fair at that resolution. The dashboard belongs to the person who holds the org's risk.
 
 ---
 
@@ -34,32 +34,32 @@ The dashboard is not a management tool for engineers. Do not share it directly w
 
 **Question it answers:** Are we shipping, and is the pipeline healthy?
 
-Delivery is the most instrumented domain and usually the easiest to get right. The risk is that aggregate numbers mask team-level outliers.
+Delivery typically carries the heaviest instrumentation and the most-trodden patterns. The risk: aggregate numbers mask team-level outliers.
 
 **Deployment frequency (per team, trailing 7 days)**
 
-The org-level aggregate hides the team that has not shipped in three weeks. Track per-team, not per-org. One team at zero deployments for two consecutive weeks is a signal worth a conversation; it rarely shows up in org-level DORA reporting.
+The org-level aggregate hides the team going three weeks without shipping. Track per-team; per-org rolls up too much to catch the outlier. One team at zero deployments for two consecutive weeks warrants a conversation; the signal rarely shows up in org-level DORA reporting.
 
 - Watch for: a team that was shipping twice a week suddenly shipping zero
 - Common cause: unresolved merge conflicts, a release freeze nobody communicated, a team absorbed into an incident
 
 **Lead time for change (trailing 14 days)**
 
-Track the P90, not just the median. A P90 that is two or three times the median means a class of work is getting stuck — usually large PRs, dependency-blocked tickets, or tickets waiting on a specific reviewer.
+Track the P90 alongside the median. A P90 two or three times the median means a class of work has gotten stuck: large PRs, dependency-blocked tickets, or tickets waiting on a specific reviewer.
 
 - Watch for: P90 climbing while median stays flat
 - Common cause: a small number of long-running branches, a bottleneck reviewer, or tickets classified as "in progress" that have been idle for a week
 
 **PR cycle time (open to merge)**
 
-Distinct from lead time. This is purely the code review and merge window. A PR that sits for three days before getting a review is a team health signal as much as a delivery signal — it often means the team is heads-down on incidents, on-call, or a high-priority fire, and code review has been deprioritized.
+Distinct from lead time. This metric captures the code review and merge window. A PR sitting three days before its first review signals team health as much as delivery; the team is usually heads-down on incidents, on-call, or a high-priority fire, and code review has been deprioritized.
 
 - Target: <24 hours for P90 on standard PRs (not draft/WIP)
 - Watch for: specific engineers whose PRs consistently sit longer — may indicate a review bottleneck or an interpersonal dynamic
 
 **Change failure rate (trailing 30 days, per team)**
 
-Same as the scorecard metric but tracked at team resolution. An org-level CFR of 6% can hide one team at 25% and four teams at 2%. The team at 25% has a testing or deployment process problem that will not fix itself.
+Same as the scorecard metric but tracked at team resolution. An org-level CFR of 6% can hide one team at 25% and four teams at 2%. The team at 25% has a testing or deployment process problem the org will not solve by waiting.
 
 ---
 
@@ -69,26 +69,26 @@ Same as the scorecard metric but tracked at team resolution. An org-level CFR of
 
 **SLO burn rate by service (rolling 30 days)**
 
-More useful than point-in-time SLO attainment because burn rate tells you whether you are on a trajectory to breach, not just whether you have already breached. A service that is burning 3× its error budget in week 1 of a 30-day window will breach even if its current attainment looks fine.
+More useful than point-in-time SLO attainment because burn rate tells you whether you are on a trajectory to breach; current attainment alone reports only what has already broken. A service burning 3× its error budget in week 1 of a 30-day window will breach even if its current attainment looks fine.
 
 - Instrument: Datadog SLO burn rate alerts, or equivalent in New Relic / Honeycomb
 - Watch for: any service burning >2× budget; more than one service in degraded state simultaneously
 
 **P0/P1 incident count and MTTR (trailing 30 days, week-over-week trend)**
 
-Not just the count — the trend. Two P1s per month is fine if it was four last month and two the month before. Two P1s per month is alarming if it was zero for the prior two quarters.
+Track the count, then read the trend. Two P1s per month reads fine after four last month and two the month before. Two P1s per month reads alarming after zero for the prior two quarters.
 
-- Watch for: MTTR trending up over multiple weeks (the team is getting slower at recovery, not faster); incident count that stops declining after a remediation effort (the fix was cosmetic, not structural)
+- Watch for: MTTR trending up over multiple weeks (recovery slowing instead of accelerating); incident count that stops declining after a remediation effort (the fix landed as cosmetic, the root cause untouched)
 
 **Escaped defect rate (monthly refresh)**
 
-The dashboard refreshes this monthly, not weekly, because it requires Jira classification discipline that does not happen in real time. Flag it at the dashboard level when the monthly update shows it crossing 30% — that is the threshold at which testing and staging fidelity have materially broken down.
+The dashboard refreshes this on a monthly cadence; weekly refresh outruns the Jira classification discipline the metric depends on. Flag it at the dashboard level when the monthly update shows it crossing 30%; at that threshold, testing and staging fidelity have materially broken down.
 
 **Open critical vulnerabilities (count, aging)**
 
-CVEs at critical/high severity with no assigned owner, or with an owner but no action in 14+ days. This one tends to be invisible until it is an incident. One line on the dashboard — count and average age. If the count is growing or the average age is above 30 days, it warrants direct attention.
+CVEs at critical/high severity with no assigned owner, or with an owner but no action in 14+ days. This metric stays invisible until it surfaces as an incident. One line on the dashboard: count and average age. A growing count or an average age above 30 days warrants direct attention.
 
-- Instrument: Snyk, Dependabot, or your security scanning tool of choice — the dashboard pulls the count and age, not the full report
+- Instrument: Snyk, Dependabot, or your security scanning tool of choice; the dashboard pulls only the count and age, leaving the full report to the tool
 
 ---
 
@@ -96,32 +96,32 @@ CVEs at critical/high severity with no assigned owner, or with an owner but no a
 
 **Question it answers:** Is the team sustainable?
 
-This is the domain most HoE dashboards omit and the one that causes the most expensive surprises. People signals lead delivery signals by 60–90 days. By the time delivery metrics degrade, the attrition or overload that caused it has usually been visible in the people data for months.
+Most HoE dashboards omit this domain, and the omission causes the expensive surprises. People signals lead delivery signals; the lag typically runs weeks to months. By the time delivery metrics degrade, the attrition or overload behind it has usually been visible in the people data for months.
 
 **Capacity vs. plan (headcount and open requisitions)**
 
-Actual engineers on staff versus planned headcount, broken down by team. Include contractor ratio if contractors carry production load. Also: open requisitions and their age. A req that has been open for 90 days without a hire is a real capacity gap, not a future one.
+Actual engineers on staff versus planned headcount, broken down by team. Include contractor ratio if contractors carry production load. Also: open requisitions and their age. A req open for 90 days without a hire represents a present capacity gap; treating it as a future one understates the load already on the team.
 
 - Watch for: teams operating at >20% below planned headcount for more than 60 days — delivery risk accumulates silently before it shows up in DORA metrics
 
 **On-call incident load per engineer (P2+, per week, trailing 4 weeks)**
 
-Already in the scorecard but worth tracking at weekly cadence on the operational dashboard. When this crosses 6 pages/engineer/week sustained for more than 3 weeks, attrition risk becomes measurable. The distribution matters as much as the average — one engineer absorbing 80% of pages while others see none is a structural problem the average hides.
+Already in the scorecard but worth tracking at weekly cadence on the operational dashboard. When this crosses 6 pages/engineer/week sustained for more than 3 weeks, attrition risk becomes measurable. The distribution matters as much as the average; one engineer absorbing 80% of pages while others see none reveals a structural problem the average hides.
 
 **Unplanned leave (trailing 30 days)**
 
-Not sick days specifically — abrupt leave patterns that correlate with burnout or disengagement. Most HRIS systems can surface this. A team where 3 of 6 engineers took unplanned leave in the same two-week window is a signal worth a conversation with the manager, not an accusation but a check-in.
+Beyond sick days: abrupt leave patterns correlated with burnout or disengagement. Most HRIS systems can surface this. A team where 3 of 6 engineers took unplanned leave in the same two-week window warrants a check-in conversation with the manager; the framing carries no accusation.
 
 **1:1 completion rate by manager (rolling 4 weeks)**
 
-Managers who stop having regular 1:1s are usually underwater — on-call, context-switching, or managing up too much. A manager's 1:1 cadence is one of the cheapest leading indicators of team cohesion available. Most people-management tools (Lattice, Culture Amp, even calendar analytics) can surface this.
+Managers who stop having regular 1:1s are usually underwater: on-call, context-switching, or managing up too much. A manager's 1:1 cadence offers a low-cost leading indicator of team cohesion. Most people-management tools (Lattice, Culture Amp, even calendar analytics) can surface this.
 
 - Target: >90% of scheduled 1:1s held over a rolling 4-week window
 - Watch for: a manager whose 1:1 rate drops below 70% for two consecutive weeks
 
 **Engineers with no PTO logged in 90+ days**
 
-Systematically invisible until someone burns out or resigns. Run a query against HRIS at the start of each quarter. This is not a performance signal — it is a health signal. Flag individuals to their manager for a check-in conversation.
+Systematically invisible until someone burns out or resigns. Run a query against HRIS at the start of each quarter. The signal belongs to health tracking; performance tracking misreads it. Flag individuals to their manager for a check-in conversation.
 
 ---
 
@@ -131,27 +131,27 @@ Systematically invisible until someone burns out or resigns. Run a query against
 
 **OKR progress by team (% complete at current week of quarter vs. expected)**
 
-The dashboard signal is each team's progress as a percentage of where it should be at this point in the quarter. A team that is 40% complete at week 8 of a 13-week quarter is behind pace; a team that is 90% complete at week 4 either sand-bagged or is about to declare victory on something that was not ambitious enough.
+The dashboard signal: each team's progress as a percentage of expected progress at this point in the quarter. A team 40% complete at week 8 of a 13-week quarter runs behind pace; a team 90% complete at week 4 either sand-bagged or stands ready to declare victory on something insufficiently ambitious.
 
 - Watch for: two or more teams simultaneously behind pace (suggests a cross-cutting dependency or a planning assumption that was wrong); a team consistently hitting 100% before week 10 (goals need to be reset)
 
 **Distraction ratio (% of sprint capacity on unplanned work, trailing 4 weeks)**
 
-Unplanned work is not inherently bad — incident response, urgent stakeholder requests, and production support are real work. The signal is the ratio. When more than 40% of sprint capacity is reactive for two or more consecutive sprints, the team has effectively lost the ability to execute on planned strategy.
+Unplanned work carries no inherent stigma; incident response, urgent stakeholder requests, and production support count as real work. The ratio carries the signal. When more than 40% of sprint capacity goes reactive for two or more consecutive sprints, the team has effectively lost the ability to execute on planned strategy.
 
 - Target: <25% unplanned work as a sustained average
 - Warning: >40% for two consecutive sprints; immediate attention: >60% for any single sprint
 
 **Dependency blockers (count, owner, age)**
 
-Cross-team dependencies that are blocking work. Track count, which team is blocked, which team is the blocker, and how long the block has been open. A blocker that has been open for three weeks without escalation is not being managed — it is being tolerated.
+Cross-team dependencies blocking work. Track count, which team is blocked, which team is the blocker, and how long the block has been open. A blocker open three weeks without escalation has slipped from managed to tolerated.
 
 - Instrument: Jira blocker links with a dependency-tracking label, or a dedicated RAID log
-- Watch for: the same team showing up repeatedly as a blocker — this is a structural capacity or prioritization issue, not a one-time dependency problem
+- Watch for: the same team showing up repeatedly as a blocker; the pattern points to a structural capacity or prioritization issue beyond the dependency at hand
 
 **Initiative milestone health (RAG by initiative)**
 
-For the two to four major engineering initiatives in flight at any given time: are they on track, at risk, or off track? Not the detailed project plan — just the RAG status and the one-line reason. This belongs on the dashboard as a prompt to check the detailed tracking if anything is amber or red, not as a replacement for it.
+For the two to four major engineering initiatives in flight at any given time: on track, at risk, or off track? Not the detailed project plan; the RAG status and a one-line reason. The dashboard entry prompts a check of the detailed tracking when something turns amber or red; the dashboard does not replace the detail.
 
 ---
 
@@ -161,32 +161,32 @@ For the two to four major engineering initiatives in flight at any given time: a
 
 **Cloud spend vs. budget (trailing 30 days, by service/team)**
 
-Not a FinOps replacement — that requires dedicated tooling and expertise. The dashboard signal is: are we on track against monthly budget, and which team or service is the outlier? A service that jumped 40% in cloud spend in a single week is either handling significantly more traffic (good, but check if it was expected) or has a misconfiguration (infrastructure leak, forgotten test environment, cost regression from a code change).
+Not a FinOps replacement; FinOps requires dedicated tooling and expertise. The dashboard signal: monthly-budget tracking and outlier identification by team or service. A service jumping 40% in cloud spend in a single week either handles significantly more traffic (good, but check if it was expected) or carries a misconfiguration (infrastructure leak, forgotten test environment, cost regression from a code change).
 
 - Instrument: AWS Cost Explorer / GCP Billing / Azure Cost Management, with tag-based attribution by team or service
 - Watch for: week-over-week spend increases >20% on any service; total spend trending ahead of monthly budget by week 2 of the month
 
 **Cost per deployment (trailing 30 days)**
 
-Unit economics for the delivery pipeline. Divide total CI/CD infrastructure cost by deployment count. This catches pipeline inefficiencies that aggregate spend does not surface — long build times, large artifact sizes, redundant test runs. If cost per deployment is rising while deployment frequency is flat, something in the pipeline is getting more expensive.
+Unit economics for the delivery pipeline. Divide total CI/CD infrastructure cost by deployment count. The metric catches pipeline inefficiencies aggregate spend does not surface: long build times, large artifact sizes, redundant test runs. Cost per deployment rising while deployment frequency stays flat means something in the pipeline has gotten more expensive.
 
 **Open headcount reqs and time-to-fill**
 
-Already in Domain 3 as a capacity signal; it appears here as a cost signal because unfilled reqs typically mean the work is being absorbed by existing staff (overload risk) or deferred (strategic risk). Time-to-fill >60 days on a critical-path hire is a flag for the recruiting pipeline, not just the hiring manager.
+Already in Domain 3 as a capacity signal; it appears here as a cost signal because unfilled reqs typically mean the work has been absorbed by existing staff (overload risk) or deferred (strategic risk). Time-to-fill above 60 days on a critical-path hire flags the recruiting pipeline as well as the hiring manager.
 
 ---
 
 ## Dashboard Format
 
-The dashboard should live in a system that refreshes automatically — not a slide deck or a manually updated spreadsheet. Grafana, Datadog dashboards, or a simple internal tool are all appropriate. The format that works:
+The dashboard belongs in a system that refreshes automatically; a slide deck or a manually updated spreadsheet decays within weeks. Grafana, Datadog dashboards, or a simple internal tool all work. The format:
 
 **Top-level view:** Five rows, one per domain. Each row shows a RAG status (green/amber/red) and a one-line summary. If all five are green, the review takes 90 seconds.
 
 **Drill-down per domain:** Clicking into an amber or red domain shows the underlying metrics for that domain — the specific team, service, or signal that triggered the status.
 
-**Weekly diff:** Show the delta from last week, not just the current value. A metric that is amber but improving is a different conversation than one that is amber and has been declining for four weeks.
+**Weekly diff:** Show the delta from last week alongside the current value. A metric amber but improving opens a different conversation from one amber and declining for four weeks.
 
-**Owner per metric:** Every metric has a named owner. The owner is responsible for the trend, not just reporting the number.
+**Owner per metric:** Every metric has a named owner. The owner carries responsibility for the trend; reporting the number alone does not discharge the role.
 
 ---
 
@@ -200,7 +200,7 @@ Consistent RAG definitions prevent the dashboard from becoming a negotiation. Fo
 | Amber | >10% off target, or at target but trend declining for 2+ weeks | Owner is accountable for a plan within one week |
 | Red | >25% off target, or amber for 2+ consecutive weeks without an improving trend | Escalation to HoE for direct attention; plan due in 48 hours |
 
-The most common dashboard failure mode is treating amber as "informational." Amber that does not trigger an owner response becomes red; red that does not trigger HoE attention becomes an incident, a miss, or an attrition event.
+A common dashboard failure mode: treating amber as "informational." Amber without an owner response becomes red; red without HoE attention becomes an incident, a miss, or an attrition event.
 
 ---
 
@@ -208,9 +208,9 @@ The most common dashboard failure mode is treating amber as "informational." Amb
 
 The same exclusion principles from the scorecard apply here, with one addition:
 
-**Individual engineer metrics.** The dashboard operates at team and system resolution, never individual contributor resolution. Using the dashboard to monitor individual output is both methodologically unsound (the metrics do not have the fidelity for that) and corrosive to the trust that makes the people signals useful. If you need to evaluate an individual's output, that belongs in a performance conversation with their manager, not on a dashboard.
+**Individual engineer metrics.** The dashboard operates at team and system resolution, never at individual contributor resolution. Monitoring individual output here lands as methodologically unsound (the metrics lack the fidelity) and as corrosive to the trust making the people signals useful. Evaluation of an individual's output belongs in a performance conversation with their manager; the dashboard is the wrong instrument.
 
-**Metrics that require manual input.** If a metric cannot be pulled from a system, it will not stay current. A manually updated dashboard decays within two weeks — the cost of keeping it fresh exceeds the value it provides. Every metric on the operational dashboard must have an automated data source. If your org lacks automated sources for people-domain metrics, start with the signals you can instrument and add the rest as tooling matures — a partially automated dashboard is still more reliable than a fully manual one.
+**Metrics requiring manual input.** A metric that cannot be pulled from a system will not stay current. A manually updated dashboard decays within two weeks; the cost of keeping it fresh exceeds the value it provides. Every metric on the operational dashboard must have an automated data source. Where automated sources are unavailable for people-domain metrics, start with the signals you can instrument and add the rest as tooling matures; a partially automated dashboard outperforms a fully manual one.
 
 **Engagement survey scores.** Useful in a quarterly HR review; too noisy and infrequent for a weekly operational signal.
 


### PR DESCRIPTION
Voice + FA sweep — `metrics/` flag list opened (folder 8 of 14)

Refs #12. Carries forward from #41 (folder 7, merged as `3bc649e`). Branch cut fresh from `origin/main` at `3bc649e`; worktree hygiene verified (`merge-base HEAD origin/main` == `rev-parse origin/main`).

Rule basis: [`playbook_writer_briefing.md`](https://github.com/brownm09/career-playbook/blob/main/context/playbook_writer_briefing.md) (voice + FA). FA anchor catalog: [`accomplishments.md`](https://github.com/brownm09/career-playbook/blob/main/context/accomplishments.md).

Folder contains 2 files:
- `engineering-health-scorecard.md` (324 lines)
- `head-of-engineering-dashboard.md` (243 lines)

---

## FA pass — 6 anchors checked, 2 🚩 dispositions, 0 cross-file propagation risk

- ✅ **FA-1** (scorecard L11): "Jellyfish rollout and org-wide engineering health reporting work at ActBlue Technical Services (2024–2025)" + "I led the rollout, owned engineering health reporting for the platform directorate, defined the metrics framework, and trained managers and ICs across six teams." — verbatim against `accomplishments.md` L37 (Senior EM row, Jellyfish rollout).
- ✅ **FA-2** (scorecard L11): "platform directorate" — consistent with folder-6/7 FA anchoring (spanning DevEx, payments per accomplishments L31, L35).
- 🚩 **FA-3** (dashboard L13, Author's note): *"running engineering at ActBlue Technical Services (2024–2025), leading a six-team platform directorate and owning the metrics infrastructure for engineering health reporting."* Two overclaims against `accomplishments.md` L28 (title: Senior Engineering Manager, **reporting to VP of Engineering**):
    - "running engineering at ActBlue" — Mike was Senior EM, not VP/Head of Engineering. The directorate had a VP above it.
    - "owning the metrics infrastructure" — accomplishments says "owned engineering health reporting" + "defined the metrics framework"; "infrastructure" is a different (broader, more systems-flavored) noun.
  - **Options:** A=keep / B=soften both ("leading the Jellyfish rollout and engineering health reporting at ActBlue Technical Services (2024–2025), across a six-team platform directorate" — drops "running engineering" + replaces "metrics infrastructure" with the anchored "engineering health reporting") / C=other.
- ✅ **FA-4** (dashboard L13): "first QBR cycle" — narrative timing detail consistent with Aug 2024–Aug 2025 tenure; not separately anchored but bounded by the role dates.
- ✅ **FA-5** (scorecard L33): DORA program / *Accelerate State of DevOps Report* — external authority citation, anchored at L322 Further Reading.
- 🚩 **FA-6** (dashboard L99): "People signals lead delivery signals by 60–90 days." Specific quantified claim with no in-text source. Carry-forward (5) cross-file grep shows it appears only here. Two options:
  - **A=keep** (treat as observed-practice claim grounded in the author's own ActBlue tenure — common in operational playbooks) / **B=soften** (drop the specific window: "People signals lead delivery signals; the lag is typically weeks-to-months, not days") / **C=cite** (find a primary source — likely won't yield clean attribution) / **D=other**.

**Cross-file grep (carry-forward 6+7):** keyword sweep for the propagation-risk phrases. Only confirmed propagation is `ORIGINS.md` L28 row for the scorecard, which is anchor-bound to the same `accomplishments.md` claim — no edit required.

---

## Voice pass — heavy across both files

Approximate violation counts (flag pass, pre-edit):

| File | Copular `is/are` | Banned `that` | X-not-Y / X-but-Y | Superlatives | Em-dash budget over | Agentic-abstract | `actually`/filler |
|---|---|---|---|---|---|---|---|
| scorecard | ~32 | ~14 | ~9 | 5 (`most common`, `most direct`, `most customer-facing`, `most expensive`, `most abused`) | 2 H2s | 0 | 0 |
| dashboard | ~28 | ~18 | ~14 | 4 (`most instrumented`, `easiest`, `cheapest`, `most expensive`, `most common`) | 4 H2s | 1 (`earns its keep`) | 1 (`actually`) |

### 3 heavy aphorism / closing targets needing disposition

- 🚩 **H-A1** (scorecard L239): *"Metrics without narrative are data."* — copular defining-aphorism opening the Leadership Dashboard Narrative section. Carry-forward (8) applies (superlative + copular + aphorism flagged for recast regardless of citeability). Options A=keep / B=recast (e.g., *"A metric without a sentence of context is a number on a slide; the narrative is the load-bearing part."* — drops copular, keeps the working principle) / C=drop / D=other.
- 🚩 **H-A2** (dashboard L9): *"If everything is green, the dashboard should take 90 seconds to review. It earns its keep when something is amber or red and you already know exactly where to look."* — Sentence 2 uses the **agentic-abstract construction explicitly banned** by the briefing (the canonical fail is *"A topic earns its slot..."*; *"dashboard earns its keep"* is the same class). Load-bearing as a closing flourish for the leadership-context opener. Options A=keep / B=recast around the structural function (*"...The value shows up on the weeks when something is amber or red and you already know where to look."*) / C=drop sentence 2 entirely / D=other.
- 🚩 **H-A3** (dashboard L232): *"The dashboard catches it; the scorecard tells the story."* — closing aphorism. Semicolon contrast is the briefing-approved form, but both verbs anthropomorphize (dashboards do not "catch"; scorecards do not "tell"). Borderline — likely passes the briefing's mechanical-verb carve-out ("surface"/"function"/"support") but worth Mike's call. Options A=keep / B=recast with mechanical verbs (*"The dashboard surfaces the signal; the scorecard frames it as narrative."*) / C=drop sentence / D=other.

### Reader-org overclaim — 1 🚩

- 🚩 **V-O1** (dashboard L213): *"If your org lacks automated sources for people-domain metrics..."* — direct "your org" hit per the briefing reader-org overclaim sweep. Options A=recast conditional (*"Where automated sources are unavailable for people-domain metrics..."*) / B=other.

### Soft reader-org / universal-claim openers — flag for awareness, not blocking

- scorecard L5: *"A Director or Head of Engineering who cannot quantify the health of the engineering org is dependent on narratives that are impossible to validate and easy to challenge."* — conditional form ("who cannot quantify..."), survives the strict ban but pattern-adjacent. Voice edit will restructure for copular + banned `that` regardless.
- scorecard L221: *"The most common mistake in scorecard setup is..."* — superlative + copular + meta-framing of evidence.

### Remaining voice-edit scope (mechanical, no disposition needed)

Categorical recasts applied during edit pass per the briefing + accumulated carry-forwards:
- Copular `is`/`are`/`was`/`were` → transitive verbs or sentence restructure (per-H2 sweep).
- Banned `that` relative/demonstrative → `this`, the noun, or restructure.
- X-not-Y, X-but-Y, "not just X" → semicolon contrast (carry-forward 11) or positive lead.
- Superlatives → drop or recast as quantified (`<25%` instead of `most common warning threshold`).
- Em-dash budget over per H2 → comma pair, colon, or separate sentence per the briefing.
- Self-introduced banned phrases pre-commit grep (carry-forward 9 + 11): `\brather than\b|\bactually\b|\bnot only\b|\bsimply\b|\bjust\b|, not `.
- Per-H2 em-dash recount after every multi-line edit (carry-forward 10).

---

## Carry-forwards from folders 1–7 holding up

All 11 applied at flag pass. The new ones this folder will exercise: (9) pre-commit grep for self-introduced banned phrases, (10) per-H2 em-dash recount after every multi-line edit (FA-3 recast in this folder may introduce em-dashes the flag-pass count missed), (11) X-not-Y as the dominant self-introduced violation class → semicolon-contrast recast as the standard fix.

---

## Dispositions needed (4 total)

| Flag | Lines | Default if no response | Question |
|---|---|---|---|
| FA-3 | dashboard L13 | B=soften | "running engineering" + "metrics infrastructure" — keep or soften to anchored phrasing? |
| FA-6 | dashboard L99 | B=soften | "60–90 days" lag — keep specific window, soften, or drop? |
| H-A1 | scorecard L239 | B=recast | "Metrics without narrative are data." — keep, recast, or drop? |
| H-A2 | dashboard L9 | B=recast | "It earns its keep…" agentic-abstract — keep, recast, or drop? |
| H-A3 | dashboard L232 | A=keep | "The dashboard catches it; the scorecard tells the story." — keep, recast with mechanical verbs, or drop? |
| V-O1 | dashboard L213 | A=recast conditional | "your org" reader-org overclaim — recast or other? |

Stop until dispositions are resolved.
