### PR TITLE
Voice + FA sweep: program-management/ (folder 12 of 14)

### DIFF
--- a/program-management/change-management-framework.md
+++ b/program-management/change-management-framework.md
@@ -2,7 +2,7 @@
 
 ## Leadership Context
 
-The most common reason technical and organizational changes fail is not technical — it is that people do not know why the change is happening, do not trust the process, or cannot see what the change means for them. A migration that is technically complete but operationally unused has not succeeded. A reorg that was announced but never reinforced reverts within a quarter. This framework applies to the transitions that engineering leaders must manage at the org level: infrastructure migrations, process overhauls, tooling consolidations, and organizational restructuring. The business outcomes at stake are adoption rate (does the change actually stick?), rollback risk (do we have to undo it?), and people trust during uncertainty (do teams remain productive through the transition?). All three are leadership problems before they are technical ones.
+When technical and organizational changes fail, the root cause is rarely technical; people do not know why the change is happening, do not trust the process, or cannot see what the change means for them. A migration that is technically complete but operationally unused has not succeeded. A reorg that was announced but never reinforced reverts within a quarter. This framework applies to the transitions that engineering leaders must manage at the org level: infrastructure migrations, process overhauls, tooling consolidations, and organizational restructuring. The business outcomes at stake are adoption rate (does the change stick?), rollback risk (do we have to undo it?), and people trust during uncertainty (do teams remain productive through the transition?). All three are leadership problems before they are technical ones.
 
 ## Background and Motivation
 
@@ -18,7 +18,7 @@ Apply this framework when:
 
 - A reorg or role change affects more than one team
 - A major technology migration requires teams to change how they work (new CI/CD platform, new data stack, new observability tooling)
-- A process change is being mandated rather than adopted voluntarily (new incident process, new code review standard, new release gate)
+- A process change is being mandated, not voluntarily adopted (new incident process, new code review standard, new release gate)
 - A tooling consolidation eliminates or replaces a tool that teams rely on
 - A compliance-driven change requires behavioral change from engineers (new secret management process, new data handling policy)
 
@@ -28,15 +28,15 @@ For incremental improvements adopted at a team's own pace, the overhead of a str
 
 ## Change Types and Their Distinct Needs
 
-Not all changes are managed the same way. The type of change determines which levers matter most.
+Not all changes are managed the same way. The type of change determines which levers carry the load.
 
 ### Technical Changes: Migrations and Deprecations
 
 **Examples:** Cloud provider migration, CI/CD platform replacement, observability tooling consolidation, database engine upgrade.
 
-**Primary risks:** Technical continuity (does the new thing work as well as the old thing?), adoption (do teams actually switch, or do they maintain parallel workflows indefinitely?), and knowledge gaps (do teams know how to operate the new system?).
+**Primary risks:** Technical continuity (does the new thing work as well as the old thing?), adoption (do teams switch, or do they maintain parallel workflows indefinitely?), and knowledge gaps (do teams know how to operate the new system?).
 
-**What matters most:** A clear cutover date with enforcement, hands-on enablement (documentation alone is insufficient for tooling changes), and a deprecation timeline that is announced well in advance and honored.
+**What carries the load:** A clear cutover date with enforcement, hands-on enablement (documentation alone is insufficient for tooling changes), and a deprecation timeline that is announced well in advance and honored.
 
 **What does not work:** Soft deadlines ("we'd like to be on the new platform by Q3"), migrations where the old system remains fully available indefinitely, and training that consists of a one-time Zoom session with no follow-up.
 
@@ -46,7 +46,7 @@ Not all changes are managed the same way. The type of change determines which le
 
 **Primary risks:** Compliance theater (teams perform the process without internalizing it), inconsistent adoption across teams, and rollback by attrition (the process is followed for 6 weeks, then quietly abandoned).
 
-**What matters most:** A compelling "why" that connects the process change to outcomes that matter to engineers (not just to leadership), visible enforcement without micromanagement, and feedback loops that allow the process to evolve based on experience.
+**What carries the load:** A compelling "why" that connects the process change to outcomes engineers care about (the compliance rationale alone does not land with the people doing the work), visible enforcement without micromanagement, and feedback loops that allow the process to evolve based on experience.
 
 **What does not work:** Process changes announced as mandates with no rationale, processes that add work without visible benefit to the people doing the work, and changes that are never reinforced after the initial announcement.
 
@@ -56,9 +56,9 @@ Not all changes are managed the same way. The type of change determines which le
 
 **Primary risks:** Productivity loss during transition, talent attrition from people who feel their role was diminished, and loss of informal coordination that was built around the previous structure.
 
-**What matters most:** Individual conversations with directly affected people before the announcement, honest answers to the questions people actually have (career impact, team relationships, reporting structure), and a post-announcement stabilization period with explicit leadership presence.
+**What carries the load:** Individual conversations with directly affected people before the announcement, honest answers to the real questions people have (career impact, team relationships, reporting structure), and a post-announcement stabilization period with explicit leadership presence.
 
-**What does not work:** "Change by announcement" — communicating a reorg in a large group meeting or email with no prior individual outreach to affected people. This approach prioritizes operational efficiency over the people most affected and is consistently the primary source of attrition during reorgs.
+**What does not work:** "Change by announcement" — communicating a reorg in a large group meeting or email with no prior individual outreach to affected people. This approach prioritizes operational efficiency over the people it affects and is consistently the primary source of attrition during reorgs.
 
 ---
 
@@ -76,7 +76,7 @@ Not all changes are managed the same way. The type of change determines which le
 
 **Output:** A 1-page change brief: problem, case for change, success criteria, scope, stakeholders, and non-negotiables.
 
-**Common mistake at this phase:** Designing the change before diagnosing the current state. The result is a change that solves the problem leadership perceives, not the problem that is actually causing friction.
+**Common mistake at this phase:** Designing the change before diagnosing the current state. The result is a change that solves the problem leadership perceives while leaving the real source of friction in place.
 
 ### Phase 2: Design
 
@@ -105,7 +105,7 @@ Not all changes are managed the same way. The type of change determines which le
 
 **Output:** Stakeholder alignment confirmation. Each decision-maker and influencer has been briefed, their concerns have been heard and addressed (or explicitly acknowledged as unable to be addressed with reasoning), and they are prepared to support the change within their teams.
 
-**The alignment trap:** Alignment does not mean consensus. Some changes will not have consensus. Alignment means the affected people have been heard, their concerns are understood, and the decision has been made with that input incorporated. Waiting for everyone to agree produces paralysis. The goal is informed commitment, not universal approval.
+**The alignment trap:** Alignment does not mean consensus. Some changes will not have consensus. Alignment means the affected people have been heard, their concerns are understood, and the decision has been made with that input incorporated. Waiting for everyone to agree produces paralysis. The goal is informed commitment; universal approval is a different and unreachable bar.
 
 ### Phase 4: Execute
 
@@ -126,7 +126,7 @@ Not all changes are managed the same way. The type of change determines which le
 **Goal:** Embed the change into normal operations so it persists without ongoing active management.
 
 **Activities:**
-- Update team norms, documentation, and onboarding materials to reflect the new state as the default (not "the new process" — just "the process")
+- Update team norms, documentation, and onboarding materials to reflect the new state as the default (not "the new process" — "the process")
 - Remove the old state: if the old tool is still available, some people will continue using it. Deprecate and remove on the timeline committed in Phase 2.
 - Recognize and celebrate adoption publicly — name teams and individuals who have successfully adopted the change; this signals that the change is permanent
 - Close the feedback loop: what concerns were raised during execution? What was addressed? What was not addressed and why? Publish a brief summary.
@@ -147,7 +147,7 @@ Resistance to change comes from three root causes. Diagnosing the actual cause d
 **Underlying cause:** The "why" was communicated once, in a broad announcement, and did not connect to things the person cares about. Engineers who are skeptical of management decisions filter announcements for subtext. If the "why" does not ring true, they discount it.
 
 **Response:**
-- Communicate the case for change at the team level, not just in an all-hands. The team lead walking through the "why" is more credible than a VP email.
+- Communicate the case for change at the team level; an all-hands alone does not land it. The team lead walking through the "why" carries more credibility than a VP email.
 - Connect to outcomes that matter to the affected engineers: if the migration reduces deploy time from 45 minutes to 8 minutes, that is the "why" for engineers, not the compliance rationale.
 - Repeat the "why" in multiple formats (written, verbal, in 1:1s for skeptics) for the first 4 weeks.
 
@@ -199,7 +199,7 @@ Unstructured feedback ("if you have concerns, reach out to the team") produces o
 
 2. **Async Q&A doc:** A shared document where anyone can add questions anonymously. The program lead answers weekly. Visible to all. This is the most efficient format for high-volume changes — questions cluster, and answering one question answers many people simultaneously.
 
-3. **Team lead feedback loop:** Team leads collect concerns from their teams and bring them to the weekly sync. This works well for concerns that require discussion rather than a direct answer.
+3. **Team lead feedback loop:** Team leads collect concerns from their teams and bring them to the weekly sync. This works well for concerns that require discussion; a direct written answer would not resolve them.
 
 **What to do with feedback:**
 
@@ -271,13 +271,13 @@ This single-question survey takes 10 seconds to answer, produces actionable sign
 
 ## Common Failure Modes
 
-**Change by announcement.** The change is communicated in a company-wide email or all-hands, and the assumption is that awareness equals adoption. It does not. Announcement is Phase 3; execution and reinforcement are where change actually happens. Orgs that confuse announcement with execution consistently see changes fail to stick.
+**Change by announcement.** The change is communicated in a company-wide email or all-hands, and the assumption is that awareness equals adoption. It does not. Announcement is Phase 3; execution and reinforcement are where change happens. Orgs that confuse announcement with execution consistently see changes fail to stick.
 
-**Skipping the "why."** Mandating a change without a credible rationale creates compliance without commitment. Engineers who do not understand the "why" will find workarounds, perform the process in letter rather than spirit, or leave when the first compelling alternative arises. The "why" is not a courtesy — it is a precondition for adoption.
+**Skipping the "why."** Mandating a change without a credible rationale creates compliance without commitment. Engineers who do not understand the "why" will find workarounds, perform the process in letter while abandoning the spirit, or leave when a compelling alternative arises. The "why" is a precondition for adoption, not a courtesy.
 
 **Launching too many changes simultaneously.** Every change competes for organizational attention. An org in the middle of a reorg, a major platform migration, and a new incident process simultaneously is an org where all three changes will be slower, messier, and more expensive than any one would be alone. Sequence changes deliberately. The rule of thumb: no more than one high-friction change per team at a time.
 
-**The support that does not get delivered.** The change plan committed to office hours, champions, and training. The office hours had low attendance after week 2, so they were cancelled. The champions program was never actually resourced. The training was a one-time session that is no longer discoverable. Support commitments that are not delivered signal that the commitment was performative — and erode trust in the next change process.
+**The support that does not get delivered.** The change plan committed to office hours, champions, and training. The office hours had low attendance after week 2, so they were cancelled. The champions program was never resourced. The training was a one-time session that is no longer discoverable. Support commitments that are not delivered signal that the commitment was performative — and erode trust in the next change process.
 
 **Measuring the wrong thing.** Tracking completion ("the migration is 80% done") instead of adoption ("80% of teams are operating in the new state"). A migration that is technically 80% complete but has 30% adoption is failing in the metric that matters. Adoption is the outcome; completion is a leading indicator.
 

--- a/program-management/change-management-framework.md
+++ b/program-management/change-management-framework.md
@@ -273,7 +273,7 @@ This single-question survey takes 10 seconds to answer, produces actionable sign
 
 **Change by announcement.** The change is communicated in a company-wide email or all-hands, and the assumption is that awareness equals adoption. It does not. Announcement is Phase 3; execution and reinforcement are where change happens. Orgs that confuse announcement with execution consistently see changes fail to stick.
 
-**Skipping the "why."** Mandating a change without a credible rationale creates compliance without commitment. Engineers who do not understand the "why" will find workarounds, perform the process in letter while abandoning the spirit, or leave when a compelling alternative arises. The "why" is a precondition for adoption, not a courtesy.
+**Skipping the "why."** Mandating a change without a credible rationale creates compliance without commitment. Engineers who do not understand the "why" will find workarounds, follow the letter of the process while violating its spirit, or leave when a compelling alternative arises. The "why" is a precondition for adoption, not a courtesy.
 
 **Launching too many changes simultaneously.** Every change competes for organizational attention. An org in the middle of a reorg, a major platform migration, and a new incident process simultaneously is an org where all three changes will be slower, messier, and more expensive than any one would be alone. Sequence changes deliberately. The rule of thumb: no more than one high-friction change per team at a time.
 

--- a/program-management/launch-readiness-checklist.md
+++ b/program-management/launch-readiness-checklist.md
@@ -125,7 +125,7 @@ A launch without a rollout plan is a binary on/off event. Most non-trivial launc
 - [ ] Canary success criteria defined: which metrics must be healthy at canary scale before expanding rollout? (e.g., "error rate below 0.1%, p99 latency below 300ms, zero payment failures in the cohort")
 - [ ] Canary hold period defined: how long does the launch stay at canary scale before expanding? (minimum 1 hour for low-risk; 24–48 hours for high-risk)
 - [ ] Rollback trigger defined and documented: what specific metric or event causes the team to roll back, and who makes that call?
-- [ ] Rollback procedure tested in addition to written — a person has run through the rollback procedure in staging and confirmed it works within the target time window
+- [ ] Rollback procedure tested end-to-end — a person has run through the rollback procedure in staging and confirmed it works within the target time window
 - [ ] Full rollout schedule defined: canary → partial (25–50%) → full, with time estimates between each phase
 
 **Owner:** Engineering lead, confirmed by TPM.

--- a/program-management/launch-readiness-checklist.md
+++ b/program-management/launch-readiness-checklist.md
@@ -2,11 +2,11 @@
 
 ## Leadership Context
 
-The decision to launch is a leadership decision, not an engineering decision — and the quality of that decision depends on the quality of the information provided. Unstructured go/no-go conversations produce launches that slip because no one owned the call, launches that proceed when they should not because the relevant concern was never surfaced, and launches that generate on-call crises because operational readiness was assumed rather than verified. This playbook establishes a structured gate framework that gives the person making the go/no-go call a complete picture across eight readiness domains, a documented record of who accepted which risks, and a launch day sequence with explicit decision points. When a launch fails, the gate record answers the question executives will ask: what did we know, and what did we decide?
+The decision to launch belongs with leadership; engineering provides the information that decision rests on, and the quality of the decision depends on the quality of that information. Unstructured go/no-go conversations produce launches that slip because no one owned the call, launches that proceed when they should not because the relevant concern was never surfaced, and launches that generate on-call crises because operational readiness was assumed without being verified. This playbook establishes a structured gate framework that gives the person making the go/no-go call a complete picture across eight readiness domains, a documented record of who accepted which risks, and a launch day sequence with explicit decision points. When a launch fails, the gate record answers the question executives will ask: what did we know, and what did we decide?
 
 ## Background and Motivation
 
-This checklist was developed from the launch readiness work on the payment processor migration to Stripe at ActBlue Technical Services (2022–2025). I led the program and defined scope and sequencing; my team executed the migration. Outcome: 2,600+ entity accounts migrated; payments codebase shrunk by 7,000+ lines. The eight readiness domains reflect the failure modes that payment-path releases expose — surfaced through hands-on launch management rather than derived from a template.
+This checklist was developed from the launch readiness work on the payment processor migration to Stripe at ActBlue Technical Services (2022–2025). I led the program and defined scope and sequencing; my team executed the migration. Outcome: 2,600+ entity accounts migrated; payments codebase shrunk by 7,000+ lines. The eight readiness domains reflect the failure modes payment-path releases expose — surfaced through hands-on launch management, not derived from a template.
 
 ## When to Use This
 
@@ -18,7 +18,7 @@ Apply this launch gate framework for:
 - Launches coordinated with a customer, partner, or press announcement
 - Any release that, if it fails, would require an all-hands incident response
 
-Do not apply this framework to routine weekly deployments of well-tested features to existing surfaces. The overhead of a full gate process should be reserved for launches with meaningful blast radius. For routine releases, the CI/CD pipeline governance guide provides the right level of controls.
+Do not apply this framework to routine weekly deployments of well-tested features to existing surfaces. The overhead of a full gate process should be reserved for launches with meaningful blast radius. For routine releases, the CI/CD pipeline governance guide provides the appropriate level of controls.
 
 **Minimum threshold:** If rollback would take more than 30 minutes, run the gate process.
 
@@ -34,7 +34,7 @@ Code complete means all features in the launch scope have been merged, reviewed,
 - [ ] All launch-scope features merged and code-reviewed (no open PRs in scope)
 - [ ] Unit test coverage at or above team threshold (define threshold before launch date, not the day before)
 - [ ] Integration tests passing in staging environment
-- [ ] Performance benchmarks run and results reviewed — p50, p95, p99 latency under load conditions that represent the expected launch traffic, not just typical traffic
+- [ ] Performance benchmarks run and results reviewed — p50, p95, p99 latency under load conditions that represent expected launch traffic, not typical traffic
 - [ ] Load test completed at 2× expected peak traffic (or rationale documented for why this threshold is appropriate)
 - [ ] No P0 or P1 bugs open in launch scope; P2 bugs reviewed and either resolved or waivered with rationale
 - [ ] Feature flags configured correctly for launch state (confirm flags are in the expected position for launch, not left in a test state)
@@ -45,7 +45,7 @@ Code complete means all features in the launch scope have been merged, reviewed,
 
 ### Domain 2: Operations
 
-A feature that works but cannot be operated is not ready to launch. Operations readiness covers the tooling and documentation that the team will use after the launch, not just the launch itself.
+A feature that works but cannot be operated is not ready to launch. Operations readiness covers the tooling and documentation the team will use after the launch — the post-launch operating model, not the launch event.
 
 **Checklist:**
 - [ ] Runbooks written for the top 3–5 expected failure modes of the launched feature
@@ -68,7 +68,7 @@ Security review is not a checkbox that legal requires. It is the domain where un
 - [ ] Threat model reviewed and updated for the launched feature (if the feature processes new data types, integrates a new third party, or changes authentication/authorization logic — a fresh threat model is required)
 - [ ] Pen test scope defined: if the launch is compliance-relevant or involves a new attack surface, define what will be tested and by whom, even if the pen test runs post-launch
 - [ ] Dependency vulnerability scan completed and results reviewed (SCA); critical and high CVEs either remediated or waivered with expiration date
-- [ ] Authentication and authorization behavior verified in staging — test the paths that should fail, not just the paths that should succeed
+- [ ] Authentication and authorization behavior verified in staging — test the paths that should fail in addition to the paths that should succeed
 - [ ] Secrets management confirmed: no credentials, tokens, or API keys in application code or pipeline configuration
 - [ ] Data encryption confirmed: data at rest and in transit are encrypted per the organization's baseline
 - [ ] Access control review: who can access what the feature exposes, and does that match the intended design?
@@ -95,7 +95,7 @@ Customer support is the first team to feel the blast from a launch failure and t
 
 **Checklist:**
 - [ ] Support team trained on the feature before launch: what it does, what the expected user experience is, what the common error states look like, and how to interpret them
-- [ ] Escalation path defined: what questions or issues does support escalate to engineering, and to whom specifically? Named escalation contacts, not just "the engineering team"
+- [ ] Escalation path defined: what questions or issues does support escalate to engineering, and to whom specifically? Named escalation contacts, not "the engineering team"
 - [ ] Known issues documented for support: the bugs that exist and will not be fixed before launch — support needs to know about these before customers report them
 - [ ] Internal knowledge base or FAQ updated (if the feature changes existing workflows)
 - [ ] Support SLA impact assessed: will this launch meaningfully increase ticket volume? If yes, capacity planning completed
@@ -125,7 +125,7 @@ A launch without a rollout plan is a binary on/off event. Most non-trivial launc
 - [ ] Canary success criteria defined: which metrics must be healthy at canary scale before expanding rollout? (e.g., "error rate below 0.1%, p99 latency below 300ms, zero payment failures in the cohort")
 - [ ] Canary hold period defined: how long does the launch stay at canary scale before expanding? (minimum 1 hour for low-risk; 24–48 hours for high-risk)
 - [ ] Rollback trigger defined and documented: what specific metric or event causes the team to roll back, and who makes that call?
-- [ ] Rollback procedure tested: not just written — a person has run through the rollback procedure in staging and confirmed it works within the target time window
+- [ ] Rollback procedure tested in addition to written — a person has run through the rollback procedure in staging and confirmed it works within the target time window
 - [ ] Full rollout schedule defined: canary → partial (25–50%) → full, with time estimates between each phase
 
 **Owner:** Engineering lead, confirmed by TPM.
@@ -224,7 +224,7 @@ No verbal waivers. If it is not in the waiver log, it is not waivered — it is 
 ### T-0: Launch Begins
 
 - [ ] Deploy initiated by designated engineer
-- [ ] Canary traffic confirmed routing to new version (verify in monitoring, not just in the deployment tool)
+- [ ] Canary traffic confirmed routing to new version (verify in monitoring; the deployment tool alone is insufficient)
 - [ ] First 5-minute check: error rate, latency, primary success metric — compare to baseline
 - [ ] Internal announcement sent
 - [ ] Clock starts on canary hold period
@@ -288,7 +288,7 @@ Attendees: full domain owner group. 60 minutes.
 
 **Go/no-go by committee with no one owning the call.** The meeting ends with "we think we're good" and no one wrote down who said go. When the launch fails, no one remembers who made the call. Designate the decision-maker before the gate process begins. Record their decision.
 
-**Operations readiness treated as post-launch work.** "We'll add proper monitoring after we see how it behaves in production." This is not a plan — it is an intention to operate blind and learn from failures rather than from metrics. Monitoring and alerting are launch requirements, not follow-on items.
+**Operations readiness treated as post-launch work.** "We'll add proper monitoring after we see how it behaves in production." This is not a plan — it is an intention to operate blind and learn from failures because the metrics that would have prevented them do not exist yet. Monitoring and alerting are launch requirements, not follow-on items.
 
 **The readiness gate that is really a status broadcast.** Domain owners show up, report green across all domains, and the meeting ends in 10 minutes. No one asked hard questions. The gate is serving as a ceremony, not as a real control. A well-run gate asks: what could still go wrong, who would know first, and what would we do about it? If the answer to all three is clear, the gate is doing its job.
 

--- a/program-management/program-planning-playbook.md
+++ b/program-management/program-planning-playbook.md
@@ -2,7 +2,7 @@
 
 ## Leadership Context
 
-Multi-team technical programs are where engineering leadership makes or breaks delivery credibility with the business. When a program slips, the root cause is almost never a technical problem — it is a planning problem: scope that was never agreed to, dependencies that were invisible until they were blocking, and milestone dates that were set to satisfy a deadline rather than reflect actual sequencing. This playbook documents how to scope, launch, and run a program in a way that gives executives accurate visibility and gives engineers clear ownership. The output is not a Gantt chart — it is a shared understanding of what "done" means and what it will take to get there.
+Multi-team technical programs are where engineering leadership makes or breaks delivery credibility with the business. When a program slips, the root cause is rarely technical; it is a planning problem: scope that was never agreed to, dependencies that were invisible until they were blocking, and milestone dates that were set to satisfy a deadline without reflecting real sequencing. This playbook documents how to scope, launch, and run a program in a way that gives executives accurate visibility and gives engineers clear ownership. The output is not a Gantt chart — it is a shared understanding of what "done" means and what it will take to get there.
 
 ## Background and Motivation
 
@@ -114,7 +114,7 @@ A milestone is a defined, verifiable state — not "in progress" or "mostly done
 The kickoff is not a presentation. It is the single meeting where alignment becomes real or does not happen at all. Three things must be true when the kickoff ends:
 
 1. **Every team knows what they own.** If someone can leave the kickoff unsure of what they are responsible for, the kickoff failed.
-2. **Every team knows the first dependency they have on another team.** Not all dependencies — just the first one. This surfaces blocking relationships early enough to resolve them.
+2. **Every team knows the first dependency they have on another team.** Not all dependencies — the first one. This surfaces blocking relationships early enough to resolve them.
 3. **Everyone has seen and can challenge the success criteria.** If success criteria are defined by leadership and shown to the room for the first time in the kickoff, the room will nod and then go build something different. The kickoff is where criteria get challenged and confirmed.
 
 ### Pre-Read (Required)
@@ -132,11 +132,11 @@ Send at least 48 hours before. Must include: program brief (all sections), miles
 
 ### Anti-Patterns
 
-**The kickoff that is really a status update.** If the teams have been working for weeks before the kickoff, you are not doing a kickoff — you are doing a retroactive alignment meeting. Kickoff happens before execution begins.
+**The kickoff that is really a status update.** If the teams have been working for weeks before the kickoff, you are running a retroactive alignment meeting under the kickoff label. Kickoff happens before execution begins.
 
 **Presenting a plan to the room instead of building one.** Handing teams a completed Gantt chart and asking for questions signals that the planning is done and they are here to receive it. Alignment built this way does not last past the first dependency conflict.
 
-**Skipping the dependency walkthrough.** Teams consistently underestimate how coupled their work is until they are forced to name their dependencies out loud. The dependency walkthrough is the most valuable 20 minutes in the kickoff.
+**Skipping the dependency walkthrough.** Teams consistently underestimate how coupled their work is until they are forced to name their dependencies out loud. The dependency walkthrough is the highest-leverage 20 minutes in the kickoff.
 
 **The 3-hour kickoff.** Attention collapses after 90 minutes. If there is more content than fits in 90 minutes, cut the content — not the time limit.
 
@@ -258,7 +258,7 @@ Categories:
 
 **Meeting:**
 - 30 min: Review and cluster submitted items. Identify themes.
-- 30 min: Discuss the top 3–5 themes in depth. Name the root cause, not just the symptom.
+- 30 min: Discuss the top 3–5 themes in depth. Name the root cause, not the symptom.
 - 20 min: Produce 3–5 concrete changes to make to the next program. Each change has an owner.
 - 10 min: Executive sponsor join. Share top 3 themes and changes. Get feedback.
 
@@ -270,7 +270,7 @@ Categories:
 
 **Scope creep without scope decisions.** New work enters the program because no one said no. The fix is a documented scope boundary in the brief, and a process for approving scope changes. Any scope addition must name what it displaces (another deliverable, a date, or team capacity). Scope additions that displace nothing are not real additions — they are magical thinking.
 
-**Phantom dependencies.** Dependencies that are listed but not actively managed. The dependency matrix says Team A needs output from Team B by March 15, but no one has spoken to Team B about it since the kickoff. Phantom dependencies surface at the worst moment: when Team A goes to use the output and it does not exist. Fix: weekly dependency review with explicit confirmation from the producing team.
+**Phantom dependencies.** Dependencies that are listed but not actively managed. The dependency matrix says Team A needs output from Team B by March 15, but no one has spoken to Team B about it since the kickoff. Phantom dependencies surface late — when Team A goes to use the output and it does not exist. Fix: weekly dependency review with explicit confirmation from the producing team.
 
 **The coordinator tax.** When the TPM becomes the information bottleneck — all updates flow through them, all decisions wait for them, all coordination is synchronous with them in the loop. The right model is a program infrastructure that enables asynchronous coordination: a shared status document that teams update directly, a RAID log that any lead can update, and a sync format that surfaces only what requires the group's attention. A TPM who is needed for every communication is a single point of failure, not a coordination asset.
 

--- a/program-management/program-planning-playbook.md
+++ b/program-management/program-planning-playbook.md
@@ -136,7 +136,7 @@ Send at least 48 hours before. Must include: program brief (all sections), miles
 
 **Presenting a plan to the room instead of building one.** Handing teams a completed Gantt chart and asking for questions signals that the planning is done and they are here to receive it. Alignment built this way does not last past the first dependency conflict.
 
-**Skipping the dependency walkthrough.** Teams consistently underestimate how coupled their work is until they are forced to name their dependencies out loud. The dependency walkthrough is the highest-leverage 20 minutes in the kickoff.
+**Skipping the dependency walkthrough.** Teams consistently underestimate how coupled their work is until they are forced to name their dependencies out loud. Run the dependency walkthrough; it surfaces more coordination risk per minute than any other kickoff segment.
 
 **The 3-hour kickoff.** Attention collapses after 90 minutes. If there is more content than fits in 90 minutes, cut the content — not the time limit.
 

--- a/program-management/raid-dependency-tracking.md
+++ b/program-management/raid-dependency-tracking.md
@@ -2,7 +2,7 @@
 
 ## Leadership Context
 
-The RAID log is the artifact that separates programs that surface problems early from programs that discover them when they are already blocking. Every multi-team program accumulates risks, makes assumptions, generates issues, and creates dependencies — the question is whether they are tracked in a structured format that enables proactive management, or scattered across Slack threads and meeting notes where they become invisible until they cause damage. A maintained RAID log is also the primary input for board-level or executive program reporting: when a VP asks "what are our biggest risks heading into Q4?", the RAID log should produce that answer in minutes, not require a frantic synthesis session the night before.
+The RAID log is the artifact that separates programs that surface problems early from programs that discover them when they are already blocking. Every multi-team program accumulates risks, makes assumptions, generates issues, and creates dependencies — the question is whether they are tracked in a structured format that enables proactive management, or scattered across Slack threads and meeting notes where they become invisible until they cause damage. A maintained RAID log is also the primary input for board-level or executive program reporting: when a VP asks "what are our top risks heading into Q4?", the RAID log should produce the answer in minutes, without requiring a frantic synthesis session the night before.
 
 ## Background and Motivation
 
@@ -23,7 +23,7 @@ Do not wait for a problem to materialize before creating the RAID log. The log i
 
 ## RAID Defined
 
-RAID stands for Risks, Assumptions, Issues, Dependencies. Each category has a distinct meaning; putting items in the wrong category is one of the most common RAID log failures because it obscures what action is needed.
+RAID stands for Risks, Assumptions, Issues, Dependencies. Each category has a distinct meaning; putting items in the wrong category is a recurring RAID log failure because it obscures what action is needed.
 
 ### Risks
 
@@ -38,7 +38,7 @@ A risk is a condition that may occur in the future and would negatively affect t
 
 ### Assumptions
 
-An assumption is something the program plan takes as true that has not been explicitly confirmed. Every program plan is built on assumptions. The RAID log makes them explicit so they can be validated on a schedule rather than discovered when they turn out to be wrong.
+An assumption is something the program plan takes as true that has not been explicitly confirmed. Every program plan is built on assumptions. The RAID log makes them explicit so they can be validated on a schedule, not discovered after they turn out to be wrong.
 
 **Examples:**
 - We are assuming the compliance vendor can complete their review in 3 weeks based on past engagements.
@@ -224,7 +224,7 @@ A RAID log that is being actively maintained looks different from one that is be
 - Dependency matrix has all 🟢 entries for more than 3 consecutive weeks during a complex integration phase — this is statistically unlikely if the program is real
 - No one can tell you what R-003 is without opening the document
 
-**What to do when the RAID log has gone stale:** Do not reboot the log in a meeting. Call each workstream lead individually, ask them to walk you through their current status from memory, and update the log based on what you learn. The stale log is a symptom — the cause is usually that leads feel the log is a reporting artifact rather than a decision-support tool. Fix the perception, not just the document.
+**What to do when the RAID log has gone stale:** Do not reboot the log in a meeting. Call each workstream lead individually, ask them to walk you through their current status from memory, and update the log based on what you learn. The stale log is a symptom — the cause is usually that leads feel the log is a reporting artifact, not a decision-support tool. Fix the perception; updating the document alone will not hold.
 
 ---
 
@@ -236,7 +236,7 @@ For programs with 5+ workstreams, the RAID log becomes unwieldy if all items are
 
 **Tag by program phase.** Add a "Phase" column (Planning, Execution, Integration, Launch, Post-Launch). Filter by phase to understand what is relevant now vs. what is upcoming.
 
-**Separate vendor/external dependencies.** External dependencies have different management paths — you cannot directly resolve them. Create a dedicated section or tab for vendor and third-party dependencies and manage them through a relationship owner rather than the standard workstream lead path.
+**Separate vendor/external dependencies.** External dependencies have different management paths — you cannot directly resolve them. Create a dedicated section or tab for vendor and third-party dependencies and manage them through a relationship owner; the standard workstream lead path does not fit.
 
 **Link to source systems.** Where a risk or issue has a corresponding Jira ticket, engineering incident, or legal review document, link directly from the RAID log entry. This reduces the double-maintenance burden and makes it easier for leads to update status where they are already working.
 

--- a/program-management/stakeholder-communication-templates.md
+++ b/program-management/stakeholder-communication-templates.md
@@ -2,7 +2,7 @@
 
 ## Leadership Context
 
-The highest-leverage thing a TPM or engineering leader does is give stakeholders accurate information at the right frequency. Bad program communication produces one of two failure modes: stakeholders who are constantly surprised because they did not know things were going wrong, or stakeholders who are overwhelmed and stop reading updates because the signal-to-noise ratio is too low. Both failure modes erode trust and slow decision-making. The templates in this playbook exist to remove the weekly cost of deciding how to communicate — so the work becomes choosing the right facts to surface, not structuring them from scratch each time.
+A TPM or engineering leader earns high leverage by giving stakeholders accurate information at the right frequency. Bad program communication produces one of two failure modes: stakeholders who are constantly surprised because they did not know things were going wrong, or stakeholders who are overwhelmed and stop reading updates because the signal-to-noise ratio is too low. Both failure modes erode trust and slow decision-making. The templates in this playbook exist to remove the weekly cost of deciding how to communicate — so the work becomes choosing which facts to surface, without structuring them from scratch each time.
 
 ## Background and Motivation
 
@@ -22,7 +22,7 @@ For shorter or single-team efforts, a brief Slack message or a comment on a tick
 
 ## The 3 Writing Principles for Upward Communication
 
-Before the templates: the underlying principles that determine whether a status update is actually useful.
+Before the templates: the underlying principles that determine whether a status update lands as useful.
 
 **1. Lead with status, not detail.**
 
@@ -218,7 +218,7 @@ Marcus Webb, Sarah Chen
 
 ## Common Failure Modes
 
-**Status updates that read as activity reports.** "This week the team completed X, Y, and Z" with no evaluation of whether that is good, bad, or concerning. The reader cannot tell if the program is healthy. Every update needs an explicit status judgment, not just a list of completed work.
+**Status updates that read as activity reports.** "This week the team completed X, Y, and Z" with no evaluation of whether that is good, bad, or concerning. The reader cannot tell if the program is healthy. Every update needs an explicit status judgment; a list of completed work alone does not produce one.
 
 **Buried blockers.** A blocker mentioned in the third paragraph of a workstream description that reads "the team is working through some challenges with the vendor timeline" is not surfaced — it is hidden. If something is blocking or at risk, it belongs in the summary and in the asks section. Nowhere else.
 


### PR DESCRIPTION
Folder 12 of 14 — `program-management/` (5 files, 1,351 lines). Continues the voice + FA sweep from #45 (folder 11, merged as `f33a4b7`). Branch cut fresh from `origin/main` at `f33a4b7`; `merge-base HEAD origin/main` == `rev-parse origin/main` verified.

Refs #12.

## Files

- `change-management-framework.md` (289L) — Raytheon Waterfall→SAFe + ActBlue LaunchDarkly/on-call openers
- `launch-readiness-checklist.md` (300L) — Stripe migration opener
- `program-planning-playbook.md` (285L) — PCI deprecation opener
- `raid-dependency-tracking.md` (248L) — PCI + payments dependency-tracking opener
- `stakeholder-communication-templates.md` (229L) — PCI stakeholder communication opener

## FA pass — 0 🚩 flags

All biographical openers anchor cleanly to `accomplishments.md`:

- [x] L88 (Raytheon Waterfall→Kanban→SAFe, 20+ personnel, working groups, JIRA migration tool) — `change-management` L11
- [x] L63 (LaunchDarkly 4-month mandate-to-first-trivial-flag + 7-month customer-facing) — `change-management` L13
- [x] L57 (on-call restructuring, redesigned cross-team handover) — `change-management` L13
- [x] L42 (Stripe migration: 2,600+ accounts, 7,000+ line codebase reduction, "led the program; defined scope and sequencing; my team executed") — `launch-readiness` L9
- [x] L41 (PCI deprecation: 2,600+ accounts to Stripe, 30% codebase reduction, 4–5 engineering teams, stakeholders in product/compliance/legal/finance/account ops) — `program-planning` L9, `raid-dependency` L9, `stakeholder-communication` L9

**Pending career-playbook follow-up** ("5-person SRE team", "~12 staff engineers") — `program-management/` did NOT surface those claims either. To triage in `strategy/` (folder 13).

## Voice pass — heavy density

Mandatory banned-construction fixes:
- 9 `rather than`
- 3 `actually`
- 12 unquoted `just` (mostly in "not just X" X-not-Y form)
- 0 `simply` / 0 `not only`
- **Total: ~24 mandatory removals**

~30 `, not [lowercase]` X-not-Y constructions (heavy in this folder; ~15 in prose, ~15 in checklist items eligible for structured-template carve-out).

~28 superlatives (`most`/`highest`/`largest`/`hardest`/etc.); ~10 in prose, ~18 in tables/checklists.

### 4 aphorism-class dispositions

- 🚩 **H-A1** (X-not-Y, ~30 instances; ~15 in prose): Default **B** recast prose X-not-Y to semicolon-contrast; preserve in checklist items where "X, not Y" is part of the template structure.
- 🚩 **H-A2** (superlatives, ~28 instances; ~10 in prose): Default **B** recast prose superlatives where non-superlative phrasing carries same load; preserve in tables/checklists.
- 🚩 **H-A3** (`rather than` + `actually` + unquoted `just`, ~24 mandatory): Default **B** remove all.
- 🚩 **H-A4** (carry-forward 12 `\bthat\b` triage + carry-forward 13 question-form `that` reintroduction): Default **B** apply at edit time, second-pass grep at review.

## Carry-forwards in effect (14)

- **Carry-forward 9** (pre-commit grep for `rather than|actually|not only|simply|just|, not`) — will fire heavily on the edit pass.
- **Carry-forward 12** (`\bthat\b` + superlative morphology grep with manual triage) — large surface area (~28 superlatives).
- **Carry-forward 13** (question-form `that` reintroduction) — `program-planning` and `change-management` have pedagogical question-form content.
- **Carry-forward 14** (NEW from folder 11): cleanup-pass grep must fire after every cleanup edit, not just main edit pass. Validated at `people/career-ladder` L109 (three attempts to land clean).
