### PR TITLE
transitions/ — voice + factual-accuracy sweep (folder 14 of 14 — final)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Phased framework for an engineering leader joining a new org. Covers the listeni
 Companion to the 30-60-90 for the specific dynamics of stepping into an existing team you did not hire. Covers the three predecessor archetypes (beloved, embattled, absent), loyalty traps (passed-over team members, informal authority figures), the trust signals the team is watching for in weeks 1–4, and early personnel decisions. Includes modified listening tour questions and a personnel decision decision tree.
 
 **[transitions/new-hire-onboarding-framework.md](transitions/new-hire-onboarding-framework.md)**
-The 30-day plan handed to an incoming engineer — the complement to the new-leader 30-60-90. Covers the three-phase ramp (orientation, first contribution, independent delivery), the three roles (manager, buddy, new hire), ramp metrics, and the most common onboarding failure modes. Includes a 30-day checklist, manager kick-off agenda, buddy guide, and 30-day retrospective format. Grounded in onboarding across six platform teams at ActBlue and the CTA engineering team.
+The 30-day plan handed to an incoming engineer — the complement to the new-leader 30-60-90. Covers the three-phase ramp (orientation, first contribution, independent delivery), the three roles (manager, buddy, new hire), ramp metrics, and common onboarding failure modes. Includes a 30-day checklist, manager kick-off agenda, buddy guide, and 30-day retrospective format. Grounded in onboarding across six platform teams at ActBlue and the CTA engineering team.
 
 ---
 

--- a/transitions/inheriting-a-team.md
+++ b/transitions/inheriting-a-team.md
@@ -2,15 +2,15 @@
 
 ## Leadership Context
 
-The 30-60-90 framework is built for a relatively clean scenario: you are new, the team knows it, and the relationship starts from zero. Inheriting an existing team adds a layer of complexity that the standard ramp framework does not fully address. The team has a history — a culture, a set of norms, and a prior relationship with someone who is not you. Every action you take in the first weeks is filtered through that history whether you know it or not.
+The 30-60-90 framework targets a relatively clean scenario: you are new, the team knows it, and the relationship starts from zero. Inheriting an existing team adds complexity the standard ramp framework does not fully address. The team has a history: a culture, a set of norms, and a prior relationship with your predecessor. Every action you take in the first weeks filters through this history.
 
-The specific risks are distinct from the new-leader general case. Trust is not absent — it is present and allocated to a predecessor. Loyalty to the prior leader or to informal power structures within the team may express itself in ways that look like support but are actually tests. Personnel problems the prior leader left unresolved do not disappear at the transition; they surface faster under a new leader because the team is watching to see whether you will handle what was not handled before.
+The specific risks differ from the new-leader general case. The team's trust sits with the predecessor. Loyalty to the prior leader or to informal power structures within the team may express itself in ways looking like support but functioning as tests. Personnel problems the prior leader left unresolved do not disappear at the transition; they surface faster under a new leader because the team watches to see whether you will handle what went unhandled before.
 
-The framework here is a companion to the [New Engineering Leader 30-60-90 Day Plan](new-leader-30-60-90.md). Use that framework as the operating structure; use this one as a lens for interpreting what you observe and for navigating the specific dynamics that inheritance introduces.
+Use the [New Engineering Leader 30-60-90 Day Plan](new-leader-30-60-90.md) as the operating structure for the transition. Use this framework as a lens for interpreting what you observe and for navigating the dynamics inheritance introduces.
 
 ## Background and Motivation
 
-This framework draws primarily on the ActBlue platform directorate transition (2022), where I inherited approximately twenty engineers across six teams from a prior organizational structure carrying different reporting lines, team scope, and leadership philosophy. Many of the challenges described here — the informal authority figures, the personnel problems that surfaced early, the loyalty signals that were actually ambivalence tests — were encountered directly in that context. The CTA transition (2025) provided a contrasting case: inheriting a smaller team with a longer prior-leader tenure and more explicit institutional memory of how things had been done.
+This framework draws primarily on the ActBlue platform directorate transition (2022), where I inherited approximately twenty engineers across six teams from a prior organizational structure carrying different reporting lines, team scope, and leadership philosophy. Many of the challenges described here — the informal authority figures, the personnel problems surfacing early, the loyalty signals reading as ambivalence tests — were encountered directly. The CTA transition (2025) provided a contrasting case: inheriting a smaller team with a longer prior-leader tenure and more explicit institutional memory of how things had been done.
 
 ## When to Use This
 
@@ -30,108 +30,108 @@ Before adapting your approach, diagnose which predecessor archetype you are foll
 
 ### The Beloved Predecessor
 
-This is the hardest scenario. The team has a reference point that you will be compared against, and the comparison is often flattering to the predecessor because memory softens criticism. You cannot win a comparison contest — you can only opt out of it.
+A difficult scenario. The team holds a reference point for comparison, and the comparison flatters the predecessor because memory softens criticism. You cannot win a comparison contest; opt out of it.
 
 Signs you are in this scenario:
 - Early 1:1s include unprompted stories about how the prior leader handled things
 - Your first process or structural changes are met with "we used to do it differently"
-- A subset of the team seems to be waiting to see if you will revert a change the prior leader made
+- A subset of the team waits to see if you will revert a change the prior leader made
 
-What to do: Name the history explicitly and early. In your first all-hands, acknowledge that you know the team has an established culture and that your job is to understand it before changing anything. Do not position yourself as a departure from the predecessor. Position yourself as the next chapter — which requires you to read the prior chapters first.
+What to do: Name the history explicitly and early. In your first all-hands, acknowledge the team's established culture and the work of understanding it before changing anything. Do not position yourself as a departure from the predecessor. Position yourself as the next chapter; read the prior chapters first.
 
 ### The Embattled or Departed Predecessor
 
-In this scenario, the team may have legitimate grievances with prior leadership: unfulfilled commitments, unresolved conflicts, or a culture that did not serve them well. There is a temptation to absorb the team's frustration and signal that you are different by criticizing the prior approach. Resist this.
+In this scenario, the team may carry legitimate grievances with prior leadership: unfulfilled commitments, unresolved conflicts, or a culture failing them. The temptation: absorb the team's frustration and signal your difference by criticizing the prior approach. Resist this.
 
 Signs you are in this scenario:
 - Early 1:1s surface complaints about prior leadership structure, process, or decisions unprompted
-- The team seems relieved rather than uncertain — which is a warning sign, not a green light
-- There is a specific grievance that the team clearly wants you to address immediately
+- The team seems relieved instead of uncertain; warmth here signals warning, not green light
+- A specific grievance surfaces the team wants addressed immediately
 
-What to do: Listen fully to what is named. Acknowledge what you hear. Do not validate complaints about the prior leader directly — say instead that you want to understand the team's experience and what would help going forward. Act on what is actionable. But distinguish between systemic problems (which deserve structural response) and interpersonal grievances (which deserve empathy, not confirmation).
+What to do: Listen fully to the named complaints. Acknowledge what you hear. Do not validate complaints about the prior leader directly; instead, say you want to understand the team's experience and what would help going forward. Act on what can be acted on. Distinguish systemic problems (deserving structural response) from interpersonal grievances (deserving empathy).
 
 ### The Absent Predecessor
 
-A vacant role often means the team has been running itself for weeks or months. Informal leaders have stepped into the gap. Norms have calcified around whoever was most willing to make decisions. Introducing formal leadership into a self-governing system is a disruption, and the team may not experience it as relief.
+A vacant role often means the team has been running itself for weeks or months. Informal leaders have stepped into the gap. Norms have calcified around whoever proved willing to make decisions. Introducing formal leadership into a self-governing system disrupts; the team may not experience it as relief.
 
 Signs you are in this scenario:
-- Early 1:1s suggest that the team has been making decisions autonomously and is uncertain about what the new hierarchy means for them
-- One or two people have clearly been covering leadership functions informally
-- There is no clear operating cadence — everything has been ad hoc
+- Early 1:1s show the team has been making decisions autonomously and remains uncertain about what the new hierarchy means for them
+- One or two people have been covering leadership functions informally
+- No clear operating cadence exists; everything has been ad hoc
 
-What to do: Identify the informal leaders early and make your respect for their role explicit in private before public. Introduce structure gradually — pick one cadence to establish first (usually the weekly 1:1) and build from there. Avoid announcing a comprehensive new operating model in week one; the team will read it as erasure of what they built in the absence.
+What to do: Identify the informal leaders early and make your respect for their role explicit in private before public. Introduce structure gradually; pick one cadence to establish first (usually the weekly 1:1) and build from there. Avoid announcing a comprehensive new operating model in week one; the team will read it as erasure of what they built in the absence.
 
 ---
 
 ## Part 2: Loyalty Traps
 
-Loyalty in an inherited team is not the same as trust. It is the residue of prior relationships, and it expresses itself in ways that can mislead a new leader into misreading who is aligned and who is waiting.
+Loyalty in an inherited team differs from trust. Loyalty carries the residue of prior relationships, and expresses itself in ways misleading a new leader into misreading who has aligned and who waits.
 
 ### The Passed-Over Team Member
 
-If someone on the team was a candidate for the role you now hold and did not get it, they represent a complex relationship. They may be entirely professional and supportive. Or they may be performing support while withholding real engagement. The performance is the problem — not the ambivalence itself, which is understandable.
+If someone on the team was a candidate for the role you now hold and did not get it, they represent a complex relationship. They may behave professionally and supportively. Or they may perform support while withholding real engagement. The performance creates the problem; the ambivalence itself stays understandable.
 
-How to handle it: Have a direct conversation early. Acknowledge the situation plainly — you know this is a complex dynamic, you value their experience, and you want to understand what they need from the relationship going forward. Most people respond well to being seen rather than managed around.
+How to handle it: Have a direct conversation early. Acknowledge the situation plainly: you know the dynamic carries complexity, you value their experience, and you want to understand what they need from the relationship going forward. Most people respond well to being seen instead of managed around.
 
 ### The Veteran Who Owns the Informal Authority
 
-Every established team has one: the person who has been there the longest, who everyone goes to when they need to know how things really work, who carries institutional memory that is not written down anywhere. This person is an asset and a potential source of friction, depending on whether they feel the new leader respects what they know.
+Every established team has one: the person who has been there longer than anyone, who everyone goes to when they need to know how things work, who carries institutional memory not written down anywhere. The veteran functions as both an asset and a potential source of friction, depending on whether they feel the new leader respects what they know.
 
-How to handle it: Go to them early and explicitly. Ask them to help you understand the team's history. Listen more than you talk. When they share perspective, validate that you heard it — not that you agree with it, but that it is informing how you think. Do not make changes that affect their domain without checking in first.
+How to handle it: Go to them early and explicitly. Ask them to help you understand the team's history. Listen more than you talk. Validate hearing what they share, and signal whether it influenced your thinking. Do not make changes affecting their domain without checking in first.
 
 ### The One Who Asks "What Are You Going to Change?"
 
-This question is almost never a sincere request for a change agenda. It is a loyalty test. The asker wants to know whether you are going to disrupt something they value, and they are hoping your answer reassures them.
+The question almost never registers as a sincere request for a change agenda. It functions as a loyalty test. The asker wants to know whether you will disrupt something they value, hoping your answer reassures them.
 
-The wrong answer: "I have some ideas, but I want to listen first." This sounds diplomatic and lands as evasive.
+The wrong answer: "I have some ideas, but I want to listen first." Reads diplomatic, lands evasive.
 
-The right answer: "I don't have a change agenda yet. I have questions. The only thing I know for certain is that I won't change anything I don't understand." This is specific, honest, and removes the uncertainty that produced the question.
+The right answer: "I don't have a change agenda yet. I have questions. The only thing I know for certain is that I won't change anything I don't understand." Specific, honest, removes the uncertainty producing the question.
 
 ---
 
-## Part 3: Trust Signals — What the Team Is Actually Watching
+## Part 3: Trust Signals — What the Team Watches
 
-In weeks one through four, the team is calibrating you on signals that have nothing to do with your technical or strategic capability. They are watching for evidence about whether you are safe.
+In weeks one through four, the team calibrates you on signals having nothing to do with your technical or strategic capability. They watch for evidence of whether you can be trusted.
 
 ### Signals you can control:
 
-**Consistency between private and public.** If you tell someone in a 1:1 that their work on a project was excellent, and then you say nothing about it in the next team meeting, the discrepancy is noticed. The team learns that private conversations with you do not translate to public credit.
+**Consistency between private and public.** If you tell someone in a 1:1 their work on a project landed well, and then you say nothing about it in the next team meeting, the discrepancy gets noticed. The team learns private conversations with you do not translate to public credit.
 
-**What you do when a decision goes wrong.** Early in the tenure there will be something — a production issue, a missed commitment, a miscommunication. The team is watching whether you attribute it accurately, protect the team from disproportionate blame, and move constructively toward resolution.
+**What you do when a decision goes wrong.** Early in the tenure something will surface: a production issue, a missed commitment, a miscommunication. The team watches whether you attribute it accurately, protect the team from disproportionate blame, and move constructively toward resolution.
 
-**Whether your first month is more questions than answers.** Teams that have been through multiple leadership transitions have a pattern-detector for new leaders who arrive with all the answers. If your 1:1s are primarily you talking, the team will conclude that the listening tour was performance.
+**Whether your first month is more questions than answers.** Teams having been through multiple leadership transitions carry a pattern-detector for new leaders arriving with all the answers. If you do most of the talking in 1:1s, the team will conclude the listening tour functioned as performance.
 
-**Whether you follow through on small commitments.** In the listening tour, you will make implicit or explicit promises: "I'll look into that," "I'll come back to you on that by end of week." These are tracked. Following through on small commitments creates more trust than any single large gesture.
+**Whether you follow through on small commitments.** In the listening tour, you will make implicit or explicit promises: "I'll look into that," "I'll come back to you on that by end of week." The team tracks these. Following through on small commitments creates more trust than any single large gesture.
 
 ### Signals you cannot control:
 
-**Whether the team liked your predecessor more.** This is irrelevant to your work and cannot be changed by your behavior. It only matters if you let it shape how you lead.
+**Whether the team liked your predecessor more.** Outside your work and your behavior to change. It matters only if you let it shape how you lead.
 
-**Whether the org's decision to restructure or hire externally was the right call.** If the team believes the restructuring that put you in this role was a mistake, they may extend that skepticism to you. You cannot argue them out of this. You can only demonstrate over time that you are worth the transition cost.
+**Whether the org's decision to restructure or hire externally was the right call.** If the team believes the restructuring putting you in this role was a mistake, they may extend the skepticism to you. You cannot argue them out of this. You can demonstrate over time the transition cost was warranted.
 
 ---
 
 ## Part 4: Early Personnel Decisions
 
-Inherited personnel situations are the most consequential early-tenure decisions you will make, and the ones where new leaders most often err in either direction.
+Inherited personnel situations carry high consequence in early tenure, and new leaders frequently err in either direction.
 
 ### The Timeline Problem
 
-Every leader brings a different threshold for acting on performance concerns. But when you inherit a team, your threshold is not the only variable. The prior leader may have set expectations — formal or informal — that affect how the team member understands their standing. Acting on a performance concern in week three without understanding the prior context is likely to feel arbitrary or retaliatory to the team, even if the concern is legitimate.
+Every leader brings a different threshold for acting on performance concerns. When you inherit a team, your threshold becomes one variable among several. The prior leader may have set expectations (formal or informal) affecting how the team member understands their standing. Acting on a performance concern in week three without understanding the prior context risks feeling arbitrary or retaliatory to the team, even where the concern stands legitimate.
 
-The general rule: you need at least one full performance cycle with your own observations before you can act on a performance concern with confidence that it is based on your evidence, not your inheritance. The exception is conduct: if you inherit a conduct problem that requires immediate action, the threshold for acting quickly is justified regardless of how early you are in tenure.
+The general rule: at least one full performance cycle with your own observations before acting on a performance concern with confidence the action rests on your evidence, not on your inheritance. Conduct stands as the exception: when you inherit a conduct problem requiring immediate action, acting quickly stays justified regardless of tenure stage.
 
 ### Distinguishing Inherited from Self-Created Problems
 
 The question to ask before acting on a performance concern: "Would I have seen this problem if I had hired this person fresh?"
 
-If yes — the concern is about the person's actual performance, and it is yours to address.
+If yes: the concern points at the person's performance, and you own the response.
 
-If no — the concern may be about fit to a prior structure, a prior manager's style, or a set of expectations that were created before you arrived. Address the fit problem before concluding there is a performance problem.
+If no: the concern may track fit to a prior structure, a prior manager's style, or expectations set before you arrived. Address the fit problem before concluding a performance problem exists.
 
-### The Loyalty Signal That Looks Like a Performance Problem
+### The Loyalty Signal Resembling a Performance Problem
 
-Sometimes a team member who was aligned with the prior leader will appear to disengage in the early weeks of a new leader's tenure. The disengagement can look like performance: slower work, less initiative, fewer contributions in meetings. It is usually temporary and resolves as the new relationship builds. Do not address it as a performance problem in week four; address it as a relationship concern in week two with a direct conversation about how the transition is going for them.
+Sometimes a team member aligned with the prior leader will appear to disengage in the early weeks of a new leader's tenure. The disengagement can look like performance: slower work, less initiative, fewer contributions in meetings. The pattern usually resolves as the new relationship builds. Do not address it as a performance problem in week four; address it as a relationship concern in week two with a direct conversation about how the transition is going for them.
 
 ---
 
@@ -190,16 +190,16 @@ commitments I can't keep.
 ## Anti-Patterns
 
 **The Clean Slate.**
-Announcing that you are starting fresh, resetting everything, and building a new culture. The team hears: "Everything you built doesn't count." New leaders who lead with this framing lose trust with experienced team members before the second week.
+Announcing a fresh start, resetting everything, building a new culture. The team hears: "Everything you built doesn't count." New leaders leading with this framing lose trust with experienced team members before the second week.
 
 **The Predecessor Critique.**
-Positioning yourself by contrasting with the prior leader's failures. Even when the prior leadership was genuinely poor, validating team complaints about the predecessor signals that you are willing to build your credibility on someone else's failure rather than your own performance. This invites the team to play the same game with you later.
+Positioning yourself by contrasting with the prior leader's failures. Even when prior leadership performed poorly, validating team complaints about the predecessor signals willingness to build credibility on someone else's failure instead of your own performance. The move invites the team to play the same game with you later.
 
 **The Premature All-Clear.**
-Deciding that because the team seems welcoming, you can move faster than the 30-60-90 framework suggests. Warmth in week one is not trust. It is hospitality. The full listening tour is still warranted.
+Deciding because the team seems welcoming, you can move faster than the 30-60-90 framework suggests. Warmth in week one signals hospitality. The full listening tour remains warranted.
 
 **The Undifferentiated 1:1 Schedule.**
-Running the same listening tour with everyone in the same order, without adapting to the specific dynamics of inherited teams. The passed-over team member, the informal authority figure, and the disengaged team member all need 1:1s that are shaped by the specific dynamic, not a generic template.
+Running the same listening tour with everyone in the same order, without adapting to the specific dynamics of inherited teams. The passed-over team member, the informal authority figure, and the disengaged team member each need 1:1s shaped by their specific dynamic. Generic templates miss the contour.
 
 **The Ownership Assumption.**
-Treating the team's prior commitments as yours without reviewing them. Projects, promises, and roadmap items made by the prior leader may or may not be the right direction for the team under your leadership. Before inheriting someone else's commitments publicly, understand them privately.
+Treating the team's prior commitments as yours without reviewing them. Projects, promises, and roadmap items the prior leader made may or may not align with the right direction for the team under your leadership. Before inheriting someone else's commitments publicly, understand them privately.

--- a/transitions/inheriting-a-team.md
+++ b/transitions/inheriting-a-team.md
@@ -48,7 +48,7 @@ Signs you are in this scenario:
 - The team seems relieved instead of uncertain; warmth here signals warning, not green light
 - A specific grievance surfaces the team wants addressed immediately
 
-What to do: Listen fully to the named complaints. Acknowledge what you hear. Do not validate complaints about the prior leader directly; instead, say you want to understand the team's experience and what would help going forward. Act on what can be acted on. Distinguish systemic problems (deserving structural response) from interpersonal grievances (deserving empathy).
+What to do: Listen fully to the named complaints. Acknowledge what you hear. Do not validate complaints about the prior leader directly; instead, say you want to understand the team's experience and what would help going forward. Act on what can be acted on. Distinguish systemic problems (deserving structural response) from interpersonal grievances (deserving empathy). Empathy is not confirmation.
 
 ### The Absent Predecessor
 
@@ -77,7 +77,7 @@ How to handle it: Have a direct conversation early. Acknowledge the situation pl
 
 Every established team has one: the person who has been there longer than anyone, who everyone goes to when they need to know how things work, who carries institutional memory not written down anywhere. The veteran functions as both an asset and a potential source of friction, depending on whether they feel the new leader respects what they know.
 
-How to handle it: Go to them early and explicitly. Ask them to help you understand the team's history. Listen more than you talk. Validate hearing what they share, and signal whether it influenced your thinking. Do not make changes affecting their domain without checking in first.
+How to handle it: Go to them early and explicitly. Ask them to help you understand the team's history. Listen more than you talk. Validate hearing what they share. Hearing and agreement remain separate moves. Do not make changes affecting their domain without checking in first.
 
 ### The One Who Asks "What Are You Going to Change?"
 
@@ -105,7 +105,7 @@ In weeks one through four, the team calibrates you on signals having nothing to 
 
 ### Signals you cannot control:
 
-**Whether the team liked your predecessor more.** Outside your work and your behavior to change. It matters only if you let it shape how you lead.
+**Whether the team liked your predecessor more.** Neither your work nor your behavior can shift this. It matters only if you let it shape how you lead.
 
 **Whether the org's decision to restructure or hire externally was the right call.** If the team believes the restructuring putting you in this role was a mistake, they may extend the skepticism to you. You cannot argue them out of this. You can demonstrate over time the transition cost was warranted.
 
@@ -199,7 +199,7 @@ Positioning yourself by contrasting with the prior leader's failures. Even when 
 Deciding because the team seems welcoming, you can move faster than the 30-60-90 framework suggests. Warmth in week one signals hospitality. The full listening tour remains warranted.
 
 **The Undifferentiated 1:1 Schedule.**
-Running the same listening tour with everyone in the same order, without adapting to the specific dynamics of inherited teams. The passed-over team member, the informal authority figure, and the disengaged team member each need 1:1s shaped by their specific dynamic. Generic templates miss the contour.
+Running the same listening tour with everyone in the same order, without adapting to the specific dynamics of inherited teams. The passed-over team member, the informal authority figure, and the disengaged team member each need 1:1s shaped by their specific dynamic.
 
 **The Ownership Assumption.**
 Treating the team's prior commitments as yours without reviewing them. Projects, promises, and roadmap items the prior leader made may or may not align with the right direction for the team under your leadership. Before inheriting someone else's commitments publicly, understand them privately.

--- a/transitions/new-hire-onboarding-framework.md
+++ b/transitions/new-hire-onboarding-framework.md
@@ -92,7 +92,7 @@ The manager and engineer conduct a structured retrospective (see template below)
 
 ## Ramp Metrics
 
-The manager tracks these; do not share with the engineer as a performance rubric. The underlying milestones match the engineer-facing checklist; the warning signals and framing here calibrate to manager monitoring.
+The manager tracks these; do not share with the engineer as a performance rubric. The underlying milestones match the engineer-facing checklist; the warning signals and framing here calibrate to manager monitoring. Engineer self-assessment runs on different signals.
 
 | Metric | Target | Warning Signal |
 |---|---|---|

--- a/transitions/new-hire-onboarding-framework.md
+++ b/transitions/new-hire-onboarding-framework.md
@@ -2,17 +2,17 @@
 
 ## Leadership Context
 
-The 30-60-90 framework for a new engineering leader is written from the leader's perspective: how to listen, diagnose, and commit. The new hire onboarding framework is written from the other direction — the document handed to an incoming engineer that tells them what the first thirty days will look like, what success means, and who is responsible for what. These are complementary, not overlapping.
+The 30-60-90 framework for a new engineering leader runs from the leader's perspective: how to listen, diagnose, and commit. The new hire onboarding framework runs the other direction: the document handed to an incoming engineer telling them what the first thirty days will look like, what success means, and where ownership sits. The two frameworks complement; they do not overlap.
 
-The structural problem with most engineering onboarding is that it is designed for the organization's convenience, not the engineer's ramp. A list of systems to read, a Slack workspace to join, a calendar of recurring meetings to attend — these are information delivery mechanisms, not onboarding frameworks. A new hire who has read all the wikis and joined all the channels but has not shipped anything and has not built a working relationship with their team has not onboarded. They have accumulated content.
+The structural problem with most engineering onboarding: design serves the organization's convenience instead of the engineer's ramp. A list of systems to read, a Slack workspace to join, a calendar of recurring meetings to attend — these deliver information; they do not constitute onboarding. A new hire who has read all the wikis and joined all the channels but has not shipped anything and has not built a working relationship with their team has not onboarded. They have accumulated content.
 
-The thirty-day ramp that matters is defined by three observable outcomes: understanding the system well enough to contribute to it, shipping something small enough to be low-risk but real enough to be valuable, and establishing a working relationship with at least one teammate beyond the buddy assignment. If an engineer reaches day thirty without all three of these, the onboarding has failed regardless of how many Confluence pages they have read.
+The thirty-day ramp matters along three observable outcomes: understanding the system well enough to contribute, shipping something small enough to carry low risk yet real enough to carry value, and establishing a working relationship with at least one teammate beyond the buddy assignment. If an engineer reaches day thirty without all three, the onboarding has failed regardless of how many Confluence pages they have read.
 
 ## Background and Motivation
 
-This framework was developed from onboarding multiple engineers into platform and payments teams at ActBlue Technical Services (2022–2025) and refined through the Community Tech Alliance context (2025–2026), where onboarding happened into a smaller team with less standardized infrastructure. At ActBlue, the challenge was scaling onboarding across six platform teams without sacrificing the 1:1 calibration that makes the first weeks effective. At CTA, the challenge was creating structure where very little existed without overengineering a process the team would not sustain.
+This framework was developed from onboarding multiple engineers into platform and payments teams at ActBlue Technical Services (2022–2025) and refined through the Community Tech Alliance context (2025–2026), where onboarding happened into a smaller team with less standardized infrastructure. At ActBlue, the challenge: scaling onboarding across six platform teams without sacrificing the 1:1 calibration making the first weeks effective. At CTA, the challenge: creating structure where very little existed without overengineering a process the team would not sustain.
 
-The framework reflects a recurring observation: the engineers who struggled in their first quarter almost always had onboarding that was heavy on orientation (reading, attending, watching) and light on contribution (shipping, deciding, asking questions that changed the plan).
+The framework reflects a recurring observation: the engineers who struggled in their first quarter almost always had onboarding heavy on orientation (reading, attending, watching) and light on contribution (shipping, deciding, asking questions changing the plan).
 
 ## When to Use This
 
@@ -27,13 +27,13 @@ The framework reflects a recurring observation: the engineers who struggled in t
 
 ## The Three Roles
 
-Onboarding requires three distinct roles. Conflating them — or leaving any of them unfilled — produces the common failure modes.
+Onboarding requires three distinct roles. Conflating them, or leaving any of them unfilled, produces the common failure modes.
 
-**The Manager** is responsible for the success of the onboarding. This means setting the ramp plan, checking in weekly on milestones, clearing blockers that the engineer and buddy cannot resolve, and conducting the 30-day retrospective. The manager owns the outcome, not the execution.
+**The Manager** is responsible for the success of the onboarding. This means setting the ramp plan, checking in weekly on milestones, clearing blockers the engineer and buddy cannot resolve, and conducting the 30-day retrospective. The manager owns the outcome; execution sits elsewhere.
 
-**The Buddy** is responsible for daily context and access. This is a peer engineer, not a senior leader. The buddy is the first call when something is confusing, when tooling is broken, or when the engineer does not know which channel to ask in. The buddy should be someone who joined in the last eighteen months and still remembers what it felt like to not know things. Do not assign the team's most senior IC as the onboarding buddy — they have a different relationship to not-knowing and are rarely the right first stop for operational friction.
+**The Buddy** is responsible for daily context and access. Assign a peer engineer, not a senior leader. The buddy fields the first call when something feels confusing, when tooling breaks, or when the engineer does not know which channel fits the question. The buddy should be someone who joined in the last eighteen months and still remembers what it felt like to not know things. Do not assign the team's senior IC as the onboarding buddy; they hold a different relationship to not-knowing and rarely serve as the right first stop for operational friction.
 
-**The New Hire** is responsible for communicating blockers, asking questions, and not waiting until a 1:1 to surface that something is wrong. Learned helplessness — waiting for explicit permission to do the next thing — is the most common new hire anti-pattern. The manager and buddy need to create an environment where asking questions is treated as signal of engagement, not evidence of gap.
+**The New Hire** is responsible for communicating blockers, asking questions, and not waiting until a 1:1 to surface a problem. Learned helplessness, waiting for explicit permission to do the next thing, surfaces as a common new hire anti-pattern. The manager and buddy need to create an environment where asking questions registers as engagement, not as gap.
 
 ---
 
@@ -41,50 +41,50 @@ Onboarding requires three distinct roles. Conflating them — or leaving any of 
 
 ### Phase 1: Orientation (Days 1–7)
 
-The goal of phase one is access and context — getting the engineer to the point where they can read the codebase and understand what the team is working on. This is not the time to ship. Shipping before understanding produces the wrong kind of confidence.
+Phase one delivers access and context: getting the engineer to the point where they can read the codebase and understand the team's current work. Shipping does not belong here. Shipping before understanding produces the wrong kind of confidence.
 
 **Days 1–3: Infrastructure access and environment setup.**
-Every new engineer should have a working local development environment and repository access by end of day 3. If this is not achievable, it is a tooling problem — note it and fix it. Do not let environment setup drift into week two.
+Every new engineer should have a working local development environment and repository access by end of day 3. When tooling blocks this, treat it as a tooling problem: note it and fix it. Do not let environment setup drift into week two.
 
 **Days 4–5: Architecture orientation.**
-The buddy walks the engineer through the primary systems: service boundaries, data flows, deployment pipeline, on-call structure, and monitoring stack. Not a comprehensive wiki review — a live conversation with a working local environment open. The goal is a mental model, not a fact list.
+The buddy walks the engineer through the primary systems: service boundaries, data flows, deployment pipeline, on-call structure, and monitoring stack. A live conversation with a working local environment open. The aim: a mental model.
 
 **Days 6–7: Team context and cadence.**
-The engineer attends the team's primary recurring meetings (sprint planning, standup, retrospective if scheduled). The manager conducts the first 1:1, using it to confirm the environment is set up, answer open questions, and identify the first task.
+The engineer attends the team's primary recurring meetings (sprint planning, standup, retrospective if scheduled). The manager conducts the first 1:1, using it to confirm environment setup, answer open questions, and identify the first task.
 
 **Milestone at end of week 1:** The engineer can run the application locally, has read the architecture overview, and has identified their first task.
 
 ### Phase 2: First Contribution (Days 8–21)
 
-The goal of phase two is a real, merged contribution. The specific scope of "first task" matters more than most managers realize.
+Phase two delivers a real, merged contribution. The specific scope of "first task" matters more than most managers realize.
 
 **Criteria for the first task:**
 - Small enough to merge in under a week with review cycles included
-- Real enough that it will matter to someone — not a documentation task invented to give the engineer something to do
-- Low enough blast radius that a mistake does not require an all-hands incident response
-- In a part of the codebase the engineer will work in regularly — not a one-off corner that provides no transferable context
+- Substantive enough to matter to someone, not filler invented to occupy the engineer
+- Low enough blast radius for a mistake to avoid triggering all-hands incident response
+- In a part of the codebase the engineer will work in regularly, not a one-off corner offering no transferable context
 
 Good first tasks: fixing a known bug in a non-critical path, adding a metric or log line to an existing flow, implementing a small feature with clear acceptance criteria, improving test coverage in an area with known gaps.
 
-Poor first tasks: refactoring a large module, implementing a new external integration, anything that requires coordinating with another team, anything the engineer will never touch again.
+Poor first tasks: refactoring a large module, implementing a new external integration, anything requiring coordination with another team, anything the engineer will never touch again.
 
 **Days 8–14: First task in progress.**
-The buddy does at least one pair programming session during this week — not to write the code for the engineer, but to walk through how to navigate the codebase and tooling in practice. Code review on the first PR should be thorough and instructional, not just approval. Explain why, not just what.
+The buddy does at least one pair programming session during this week. The session walks through how to navigate the codebase and tooling in practice; the buddy does not write the code for the engineer. Code review on the first PR should be thorough and instructional. Explain the reasoning behind the verdict.
 
 **Days 15–21: Second task and independent navigation.**
-By day 15 the engineer should be able to identify their next task from the backlog without the manager assigning it. If they cannot, they have not yet built the context to be independent — surface this in the week 2 1:1 and address it explicitly.
+By day 15 the engineer should be able to identify their next task from the backlog without the manager assigning it. If they cannot, they have not yet built the context for independence; surface this in the week 2 1:1 and address it explicitly.
 
-**Milestone at end of week 3:** At least one PR merged. Engineer can identify their own next task. Engineer has participated in at least one code review as reviewer (reviewing someone else's work is one of the fastest ways to build codebase context).
+**Milestone at end of week 3:** At least one PR merged. Engineer can identify their own next task. Engineer has participated in at least one code review as reviewer (reviewing someone else's work builds codebase context quickly).
 
 ### Phase 3: Independent Delivery (Days 22–30)
 
-The goal of phase three is sprint participation at a level where the engineer is no longer on a separate ramp track but is contributing to the team's shared commitments.
+Phase three delivers sprint participation: the engineer no longer runs on a separate ramp track and contributes to the team's shared commitments.
 
 **Days 22–28: Sprint integration.**
-The engineer should be carrying story-level work in the sprint, not just tasks assigned as "onboarding" items. They should be in the sprint ceremonies as a participant, not an observer — that means commenting in retrospectives, asking questions in planning, and flagging scope risks when they see them.
+The engineer should carry story-level work in the sprint, beyond "onboarding" tasks. They should attend the sprint ceremonies as a participant: commenting in retrospectives, asking questions in planning, and flagging scope risks when they see them.
 
 **Days 29–30: 30-day retrospective.**
-The manager and engineer conduct a structured retrospective (see template below). The output is: what worked in the ramp, what should be changed for future hires, and an explicit agreement on what the engineer's first 60-day goals look like.
+The manager and engineer conduct a structured retrospective (see template below). The output: what worked in the ramp, what should be changed for future hires, and an explicit agreement on what the engineer's first 60-day goals look like.
 
 **Milestone at end of day 30:** Engineer is carrying sprint commitments at partial velocity. Manager has completed 30-day retrospective. Engineer has named at least one thing they want to learn in the next thirty days.
 
@@ -92,7 +92,7 @@ The manager and engineer conduct a structured retrospective (see template below)
 
 ## Ramp Metrics
 
-These are for the manager to track, not to share with the engineer as a performance rubric. The underlying milestones match the engineer-facing checklist — the difference is that the warning signals and framing here are calibrated for manager monitoring, not engineer self-assessment.
+The manager tracks these; do not share with the engineer as a performance rubric. The underlying milestones match the engineer-facing checklist; the warning signals and framing here calibrate to manager monitoring.
 
 | Metric | Target | Warning Signal |
 |---|---|---|
@@ -106,15 +106,15 @@ These are for the manager to track, not to share with the engineer as a performa
 
 ## Onboarding Failure Modes
 
-**Too much reading, not enough doing.** A two-week "reading sprint" before the engineer touches code is almost always a mistake. The reading does not stick without context, and the context comes from doing. Send the engineer to the codebase on day four, not day fourteen.
+**Too much reading, not enough doing.** A two-week "reading sprint" before the engineer touches code almost always misfires. The reading does not stick without context, and the context comes from doing. Send the engineer to the codebase on day four, not day fourteen.
 
-**No defined success criteria.** "Get comfortable with the codebase" is not a milestone. Engineers who do not know what success looks like in week one will not know whether they are on track in week three. The manager's job is to make success concrete and observable.
+**No defined success criteria.** "Get comfortable with the codebase" does not name a milestone. Engineers who do not know what success looks like in week one will not know whether they are on track in week three. The manager's job: make success concrete and observable.
 
-**Buddy assignment without buddy preparation.** Assigning a buddy without telling the buddy what their responsibilities are is a guarantee of inconsistency. The buddy needs to know: what they own, what the manager owns, how to escalate a blocker, and when the buddy relationship formally ends (typically 30 days, with optional continuation).
+**Buddy assignment without buddy preparation.** Assigning a buddy without explaining the buddy's responsibilities guarantees inconsistency. The buddy needs to know: what they own, what the manager owns, how to escalate a blocker, and when the buddy relationship formally ends (typically 30 days, with optional continuation).
 
-**The firehose first week.** Cramming every system introduction, every team overview, and every stakeholder meeting into the first five days produces an engineer who has heard everything and retained little. Sequence context so each layer builds on the last. The payment system architecture overview belongs in week two, not day two.
+**The firehose first week.** Cramming every system introduction, every team overview, every stakeholder meeting, and every onboarding doc into the first five days produces an engineer who has heard everything and retained little. Sequence context so each layer builds on the last. The payment system architecture overview belongs in week two, not day two.
 
-**The invisible first month.** An engineer who gets through thirty days without being visible in any team communication — no questions in Slack, no comments in code reviews, no contributions to a planning meeting — has been allowed to hide. Hiding in the first month is not humility; it is a failure of the environment to create safety for participation.
+**The invisible first month.** An engineer who gets through thirty days without being visible in any team communication (no questions in Slack, no comments in code reviews, no contributions to a planning meeting) has been allowed to hide. Hiding in the first month signals an environment failing to create safety for participation.
 
 ---
 
@@ -235,16 +235,16 @@ to peer. There is no ceremony required — just acknowledge it in the week 4 che
 ## Anti-Patterns
 
 **The Information Dump.**
-Scheduling twelve system overview meetings in the first week because "there's a lot to learn." The engineer absorbs about 20% of it, and the 80% they missed produces a false sense of completion. Prioritize the systems they will work in first; sequence everything else.
+Scheduling twelve system overview meetings in the first week because "there's a lot to learn." The engineer absorbs about 20% of it, and the 80% they missed produces a false sense of completion. Prioritize the systems the engineer's work touches first; sequence everything else.
 
 **The Invisible Buddy.**
-Assigning a buddy who is too senior, too busy, or too unfamiliar with day-to-day operational friction to be useful. The best buddy is one to two years into their tenure — experienced enough to know the system, recent enough to remember not knowing it.
+Assigning a buddy too senior, too busy, or too unfamiliar with day-to-day operational friction to help. A strong buddy sits one to two years into their tenure: experienced enough to know the system, recent enough to remember not knowing it.
 
 **The Test-Free First PR.**
-Allowing the first merged contribution to skip tests "just to get something in." This teaches the engineer that the team's test standards are negotiable from day one. Hold the bar.
+Allowing the first merged contribution to skip tests "just to get something in." The team's test standards then read as negotiable from day one. Hold the bar.
 
 **The Delayed Retrospective.**
-Skipping or rescheduling the 30-day retrospective because the manager is busy. The retrospective is the primary mechanism for improving onboarding for the next hire. It also signals to the engineer that their experience was worth examining.
+Skipping or rescheduling the 30-day retrospective because the manager has scheduling pressure. The retrospective drives improvements in onboarding for the next hire. Skipping also signals to the engineer their experience held no value worth examining.
 
 **The Sink-or-Swim Frame.**
-Framing onboarding as a proving ground rather than a ramp. Engineers who feel they are being tested from day one rather than supported are less likely to ask questions and more likely to hide when they are stuck. The first thirty days should feel like a structured ramp, not a trial.
+Framing onboarding as a proving ground instead of a ramp. Engineers who feel tested from day one instead of supported ask fewer questions and hide more often when stuck. The first thirty days should feel like a structured ramp, not a trial.

--- a/transitions/new-leader-30-60-90.md
+++ b/transitions/new-leader-30-60-90.md
@@ -2,23 +2,23 @@
 
 ## Leadership Context
 
-The single most costly mistake a new engineering leader makes is acting before listening. The org will read every early decision as a signal about who you are — what you value, what you will protect, and who is safe. Those signals, once sent, are difficult to walk back. The 30-60-90 framework is a forcing function against moving too fast. It structures the early months as a sequence of distinct modes: listening, diagnosing, and committing. Each mode has deliverables, and the deliverables exist to prevent the mode from becoming indefinite.
+A costly mistake a new engineering leader makes: acting before listening. The org will read every early decision as a signal about who you are, what you value, what you will protect, and who carries safety. Those signals, once sent, become difficult to walk back. The 30-60-90 framework operates as a forcing function against moving too fast. It structures the early months as distinct phases: a listening tour, an early diagnosis, and a committed direction by day 90. Each phase has deliverables, and the deliverables exist to prevent the phase from becoming indefinite.
 
-The framework applies whether you are joining as an external hire or stepping into a director-level role from within. The timelines shift — internal transitions can compress phase 1 because relationship context already exists — but the phases do not collapse.
+The framework applies whether you are joining as an external hire or stepping into a director-level role from within. The timelines shift (internal transitions can compress phase 1 because relationship context already exists), but the phases do not collapse.
 
-A 90-180-360 extension applies for larger orgs (100+ engineers), M&A integrations, or situations where the prior leader left under difficult circumstances. In those cases the first 90 days is still listening and diagnosing, but the commitment and change horizons extend.
+A 90-180-360 extension applies for larger orgs (100+ engineers), M&A integrations, or situations where the prior leader left under difficult circumstances. In those cases the first 90 days still go to listening and diagnosing, but the commitment and change horizons extend.
 
 ## Background and Motivation
 
-This framework was developed from two distinct leadership transitions: stepping into the platform directorate at ActBlue Technical Services (2022), where I inherited approximately twenty engineers across six teams in payments, infrastructure, compliance, and developer experience, and a subsequent transition into a technical leadership role at Community Tech Alliance (2025), a smaller org with a narrower scope but different organizational maturity. The challenges are meaningfully different — inheriting an established org versus building in a greenfield context — but the listening-first discipline applies in both.
+This framework was developed from two distinct leadership transitions: stepping into the platform directorate at ActBlue Technical Services (2022), where I inherited approximately twenty engineers across six teams in payments, infrastructure, compliance, and developer experience, and a subsequent transition into a technical leadership role at Community Tech Alliance (2025), a smaller org with a narrower scope but different organizational maturity. The challenges differ — inheriting an established org versus building in a greenfield context — yet the listening-first discipline applies in both.
 
 ## When to Use This
 
 **External hire as EM, Senior EM, Director, or VP.** You have no prior relationship capital with the team. Every early action is observed and interpreted.
 
-**Internal promotion into a larger scope.** You know the company but not all of the teams. Prior relationships create context but also expectations — some people will assume continuity, others will wait to see if you are actually different from your predecessor.
+**Internal promotion into a larger scope.** You know the company but not all of the teams. Prior relationships create context but also expectations: some people will assume continuity, others will wait to see if you differ from your predecessor.
 
-**Stepping into a struggling org.** Pressure to act fast is highest in turnaround situations and precisely when premature action is most destructive. Diagnosis before prescription matters most here.
+**Stepping into a struggling org.** Pressure to act fast peaks in turnaround situations, precisely when premature action causes serious harm. Diagnosis before prescription matters here.
 
 ---
 
@@ -26,48 +26,48 @@ This framework was developed from two distinct leadership transitions: stepping 
 
 ### The Core Discipline
 
-Do not announce any changes during the first 30 days. Not in stand-ups, not in your first all-hands, not in a well-intentioned "here's my leadership philosophy" email. Changes announced before you have earned trust are not heard as good ideas — they are heard as a signal about whether you are safe to disagree with.
+Do not announce any changes during the first 30 days. Not in stand-ups, not in your first all-hands, not in a well-intentioned "here's my leadership philosophy" email. Changes announced before trust is earned land as a signal about whether the team can safely disagree with you.
 
-The goal of month one is to leave every conversation having learned something and having made the person feel heard.
+The goal of month one: leave every conversation having learned something and having made the person feel heard.
 
 ### What to Listen For
 
 In 1:1s with every direct report and key stakeholder, ask the same five questions:
 
-1. **What is working well that you would protect at all costs?** This surfaces what the team is proud of and where your credibility is at risk if you accidentally break something.
-2. **What is the biggest problem that nobody is talking about loudly enough?** This surfaces the real signal, not the org chart version.
-3. **What has been tried that failed, and why?** This prevents you from re-proposing the idea that burned the team three years ago.
-4. **If you could change one thing about how this team operates, what would it be?** Different from the previous question — this is aspirational, not historical.
-5. **What do you wish the previous leadership had done differently?** Be careful with this one — not everyone will answer directly, but the indirect answers are often the most useful.
+1. **What is working well that you would protect at all costs?** Surfaces what the team feels pride in and where your credibility stands at risk if you accidentally break something.
+2. **What is the biggest problem that nobody is talking about loudly enough?** Surfaces actual signal beyond the org chart version.
+3. **What has been tried that failed, and why?** Prevents you from re-proposing the idea burning the team three years ago.
+4. **If you could change one thing about how this team operates, what would it be?** Different from the previous question; the lens is aspirational, the prior lens historical.
+5. **What do you wish the previous leadership had done differently?** Be careful with this one; not everyone will answer directly, but the indirect answers often carry the load.
 
-Run these 1:1s for every direct report and every skip-level manager in your first two weeks. Then expand to key cross-functional partners (product, design, data, finance, legal) in weeks three and four.
+Run these 1:1s for every direct report and every skip-level manager in your first two weeks. Then expand to key inter-functional partners (product, design, data, finance, legal) in weeks three and four.
 
 ### Relationship Mapping
 
-Produce a written relationship map by the end of week two. Not for distribution — this is a working document for your own orientation. Capture:
+Produce a written relationship map by the end of week two. Not for distribution; a working document for your own orientation. Capture:
 
 - **Key influencers** — the people whose opinions move others, regardless of title. Often a Staff Engineer or a senior IC who has been around long enough to remember everything.
-- **Coalition builders** — the people who know how to get things done informally. They often have titles that underrepresent their organizational reach.
-- **Skeptics** — the people who are waiting to see whether you are worth trusting. They are not enemies; they are reasonable people with evidence that change does not always go well.
+- **Coalition builders** — the people who know how to get things done informally. They often have titles underrepresenting their organizational reach.
+- **Skeptics** — the people waiting to see whether you have earned trust. Reasonable people carrying evidence change does not always go well; skeptics differ from enemies.
 - **At-risk relationships** — people who were passed over for the role you now hold, or who had a difficult relationship with your predecessor.
 
 ### What Not to Do in Month One
 
-- **Do not reorganize teams.** Even if the structure is obviously wrong. Wait until you understand why it is structured this way before changing it.
-- **Do not introduce new process.** Meeting changes, ticket workflow changes, documentation standards — all of this can wait.
+- **Do not reorganize teams.** Even if the structure looks wrong. Wait until you understand why it is structured this way before changing it.
+- **Do not introduce new process.** Meeting changes, ticket workflow changes, documentation standards: all of this can wait.
 - **Do not signal favorites.** Spending visibly more time with certain engineers or managers signals a hierarchy of trust before you have earned the basis for one.
-- **Do not relitigate your predecessor's decisions publicly.** Even if those decisions were wrong. You can acknowledge that things are changing without framing the past as a failure.
+- **Do not relitigate your predecessor's decisions publicly.** Even when those decisions missed. You can acknowledge things are changing without framing the past as a failure.
 
 ### Month One Deliverable: The Landscape Document
 
 A private written assessment (1–2 pages) covering:
 
-- The three strongest things you observed
-- The three biggest gaps or risks
-- The relationships you are most uncertain about
+- Three strengths you observed
+- Three gaps or risks
+- Relationships where uncertainty sits
 - Open questions you cannot yet answer
 
-This document has two purposes: it forces you to synthesize what you heard rather than just collecting impressions, and it gives you a baseline to measure against in month six when your initial read looks different in hindsight.
+This document has two purposes: it forces you to synthesize what you heard instead of collecting impressions, and it gives you a baseline to measure against in month six when your initial read looks different in hindsight.
 
 ---
 
@@ -75,32 +75,32 @@ This document has two purposes: it forces you to synthesize what you heard rathe
 
 ### The Shift from Listening to Structuring
 
-Month two is when you begin pattern-matching across what you heard and start to name things. You are not acting yet — you are triangulating. An observation you heard from three different people in three different contexts is a signal. An observation you heard from one passionate person is a data point.
+Month two starts pattern-matching across what you heard and naming things. Triangulation continues; action still waits. An observation surfacing from three different people in three different contexts counts as signal. An observation surfacing from one passionate person counts as a data point.
 
 Use month two to:
 
 - **Validate your month one hypotheses.** Go back to three or four people from the listening tour and say: "Based on what I've been hearing, I'm starting to think [X]. Does that match your experience?" This builds trust and catches errors in your read before they harden.
-- **Identify the quick wins.** Every org has something that is broken, everybody knows it, and nobody has fixed it because nobody owns it. These are not the structural problems — they are the paper cuts. Fixing one or two of these signals competence and makes the team feel seen without requiring you to take a position on anything contentious.
-- **Map the technical landscape.** Where is the actual technical risk? What is held together with duct tape that everyone is afraid to touch? What is the state of incident response, on-call load, and deployment frequency? This is not an audit — it is orientation.
+- **Identify the quick wins.** Every org has something broken, everybody knows it, and nobody has fixed it because nobody owns it. These are the paper cuts the team has lived with. Fixing one or two signals competence and makes the team feel seen without requiring you to take a position on anything contentious.
+- **Map the technical landscape.** Where does the technical risk concentrate? What is held together with duct tape no one will touch? How do incident response, on-call load, and deployment frequency currently run? The work serves orientation.
 
 ### Building Trust With the Team
 
-Trust at the team level is built through consistency, not charisma. Specifically:
+Consistency builds trust at the team level; charisma does not substitute. Specifically:
 
-- **Do what you said you would do.** If you told an engineer in your listening tour that you would follow up on something, follow up. The first time you do not, it will be noticed.
-- **Protect your team's capacity.** When cross-functional requests arrive that would derail sprint work without adequate prioritization, be the one who names the tradeoff and makes the org absorb it — not the team.
-- **Show your work.** When you make a decision that affects the team, explain the reasoning. You do not owe a justification for every decision, but you owe transparency about the trade-offs you weighed.
+- **Do what you said you would do.** If you told an engineer in your listening tour you would follow up on something, follow up. The first time you do not, the team notices.
+- **Protect your team's capacity.** When inter-functional requests arrive threatening to derail sprint work without adequate prioritization, be the one who names the tradeoff and makes the org absorb it. The team does not absorb it.
+- **Show your work.** When you make a decision affecting the team, explain the reasoning. You do not owe a justification for every decision, but you owe transparency about the trade-offs you weighed.
 
 ### Month Two Deliverable: Written Assessment and North Star
 
-Share a written assessment with your manager and (in edited form) with your team. This is not a roadmap — it is a diagnosis. Cover:
+Share a written assessment with your manager and (in edited form) with your team. The document carries diagnosis. Cover:
 
 - What you observed about the team's strengths
-- What you believe the primary growth areas are (without attributing them to individuals)
+- Where the primary growth areas sit (without attributing them to individuals)
 - Where you think the team should be heading and why
-- What you are not yet sure about
+- Open uncertainties at this point
 
-The north star does not need to be fully formed. A clear direction with acknowledged uncertainty is more trustworthy than a polished vision that has no room for what you do not yet know.
+The north star does not need final form. A clear direction with acknowledged uncertainty earns more trust than a polished vision leaving no room for what you do not yet know.
 
 ---
 
@@ -108,21 +108,21 @@ The north star does not need to be fully formed. A clear direction with acknowle
 
 ### The Shift from Diagnosis to Action
 
-By day 60 you should have enough orientation to start acting. Not on everything — but on the things where waiting longer is itself a cost. The discipline in month three is distinguishing between:
+By day 60 you should have enough orientation to start acting. Not on everything; on the things where waiting longer carries its own cost. The discipline in month three: distinguishing between:
 
-- **Decisions you can now make.** You have the information you need and delay is harmful.
-- **Decisions that need more time.** You have a hypothesis but not enough signal.
-- **Decisions that belong to someone else.** You have an opinion but it is not yours to make.
+- **Decisions you can now make.** You have the information you need; delay causes harm.
+- **Decisions needing more time.** You have a hypothesis but not enough signal.
+- **Decisions belonging to someone else.** You have an opinion but the making sits elsewhere.
 
-Month three is also when the org's initial patience with a new leader begins to run out. A director who is still "getting oriented" at day 90 has not communicated enough about direction and will start losing credibility with high performers who are waiting to understand what they are working toward.
+Month three also marks when the org's initial patience with a new leader begins to run out. A director still "getting oriented" at day 90 has not communicated enough about direction and will start losing credibility with high performers waiting to understand the destination.
 
 ### The First Changes
 
 Sequence changes in month three as follows:
 
-1. **Process changes first.** How meetings run, how decisions get made, how information flows. These are visible, low-risk, and signal that you are serious without touching people's projects or team structures.
-2. **Structural changes second.** If a team needs to be reorganized, or reporting lines need to shift, begin socializing and then execute. But do not execute a reorg before you have established trust with every manager affected.
-3. **People decisions last.** If a personnel issue exists that cannot wait — a performance problem, a role mismatch — begin addressing it through the appropriate channel. But do not make dramatic people decisions in month three unless inaction is creating real harm.
+1. **Process changes first.** How meetings run, how decisions get made, how information flows. These changes stay visible and low-risk while signaling seriousness without touching people's projects or team structures.
+2. **Structural changes second.** If a team needs reorganization, or reporting lines need to shift, begin socializing and then execute. But do not execute a reorg before you have established trust with every manager affected.
+3. **People decisions last.** If a personnel issue exists requiring immediate response (a performance problem, a role mismatch), begin addressing it through the appropriate channel. But do not make dramatic people decisions in month three unless inaction is creating material harm.
 
 ### The 90-Day Retrospective
 
@@ -131,9 +131,9 @@ At the end of the 90-day period, write a brief retrospective for yourself. Cover
 - What your initial landscape document got right and what it missed
 - The decisions you made and how they are landing
 - What you would do differently if starting over
-- The 90-180 plan: the next three months now that you have your bearings
+- The 90-180 plan: the next three months now with your bearings
 
-This retrospective is for you, not your manager. Its value is forcing a confrontation with how your initial read diverged from reality.
+The retrospective belongs to you; the manager does not see it. The value comes from forcing a confrontation with how your initial read diverged from reality.
 
 ---
 
@@ -147,7 +147,7 @@ For larger orgs, M&A integrations, or turnaround situations, extend the frame:
 | 90–180 days | Execute first changes | Team health baseline, roadmap Q1 |
 | 180–360 days | Structural and strategic moves | Org redesign if needed, multi-year strategy |
 
-The extension does not mean acting more slowly on urgent problems. It means distinguishing between urgency (this must happen now) and importance (this must happen, but the timing is mine to choose).
+The extension does not mean acting more slowly on urgent problems. It means distinguishing between urgency (this must happen now) and importance (this must happen, but the timing remains yours to choose).
 
 ---
 
@@ -157,11 +157,11 @@ The extension does not mean acting more slowly on urgent problems. It means dist
 
 **The Consensus Trap.** Running the listening tour and then making every change by committee to avoid conflict. The team hears: "This person cannot make a decision." Listening does not require consensus-seeking on outputs.
 
-**The Transparency Overcorrection.** Sharing every half-formed thought in the spirit of openness. Uncertainty is fine; broadcasting uncertainty without framing creates anxiety. Be honest about what you do not know, but anchor it to what you are going to do about it.
+**The Transparency Overcorrection.** Sharing every half-formed thought in the spirit of openness. Uncertainty stays fine; broadcasting uncertainty without framing creates anxiety. Be honest about what you do not know, but anchor it to your planned next step.
 
-**The Prior Leader Shadow.** Every conversation beginning with implicit comparison to the person before you. Whether your predecessor was beloved or reviled, your job is to be you, not a corrective for them.
+**The Prior Leader Shadow.** Every conversation beginning with implicit comparison to the person before you. Whether your predecessor earned love or contempt, the job remains your own and stops short of correcting for them.
 
-**The Premature All-Hands.** Scheduling a team all-hands before you have had 1:1s with everyone you will be speaking about. You will say something wrong about someone's work or role that you would have known to avoid if you had met with them first.
+**The Premature All-Hands.** Scheduling a team all-hands before you have had 1:1s with everyone whose work you will mention. You will say something wrong about someone's work or role you would have known to avoid if you had met with them first.
 
 ---
 

--- a/transitions/new-leader-30-60-90.md
+++ b/transitions/new-leader-30-60-90.md
@@ -2,7 +2,7 @@
 
 ## Leadership Context
 
-A costly mistake a new engineering leader makes: acting before listening. The org will read every early decision as a signal about who you are, what you value, what you will protect, and who carries safety. Those signals, once sent, become difficult to walk back. The 30-60-90 framework operates as a forcing function against moving too fast. It structures the early months as distinct phases: a listening tour, an early diagnosis, and a committed direction by day 90. Each phase has deliverables, and the deliverables exist to prevent the phase from becoming indefinite.
+A costly mistake a new engineering leader makes: acting before listening. The org will read every early decision as a signal about who you are, what you value, what you will protect, and who is trustworthy. Those signals, once sent, become difficult to walk back. The 30-60-90 framework operates as a forcing function against moving too fast. It structures the early months as distinct phases: a listening tour, an early diagnosis, and a committed direction by day 90. Each phase has deliverables, and the deliverables exist to prevent the phase from becoming indefinite.
 
 The framework applies whether you are joining as an external hire or stepping into a director-level role from within. The timelines shift (internal transitions can compress phase 1 because relationship context already exists), but the phases do not collapse.
 
@@ -48,7 +48,7 @@ Produce a written relationship map by the end of week two. Not for distribution;
 
 - **Key influencers** — the people whose opinions move others, regardless of title. Often a Staff Engineer or a senior IC who has been around long enough to remember everything.
 - **Coalition builders** — the people who know how to get things done informally. They often have titles underrepresenting their organizational reach.
-- **Skeptics** — the people waiting to see whether you have earned trust. Reasonable people carrying evidence change does not always go well; skeptics differ from enemies.
+- **Skeptics** — the people waiting to see whether you have earned trust. Reasonable people who have seen change go badly before; skeptics differ from enemies.
 - **At-risk relationships** — people who were passed over for the role you now hold, or who had a difficult relationship with your predecessor.
 
 ### What Not to Do in Month One
@@ -108,7 +108,7 @@ The north star does not need final form. A clear direction with acknowledged unc
 
 ### The Shift from Diagnosis to Action
 
-By day 60 you should have enough orientation to start acting. Not on everything; on the things where waiting longer carries its own cost. The discipline in month three: distinguishing between:
+By day 60 you should have enough orientation to start acting. Not on everything; on the things where waiting longer carries its own cost. In month three, distinguish between:
 
 - **Decisions you can now make.** You have the information you need; delay causes harm.
 - **Decisions needing more time.** You have a hypothesis but not enough signal.
@@ -131,9 +131,9 @@ At the end of the 90-day period, write a brief retrospective for yourself. Cover
 - What your initial landscape document got right and what it missed
 - The decisions you made and how they are landing
 - What you would do differently if starting over
-- The 90-180 plan: the next three months now with your bearings
+- The 90-180 plan: the next three months, with your bearings in place
 
-The retrospective belongs to you; the manager does not see it. The value comes from forcing a confrontation with how your initial read diverged from reality.
+The retrospective belongs to you; the manager is not the audience. The value comes from forcing a confrontation with how your initial read diverged from reality.
 
 ---
 
@@ -159,7 +159,7 @@ The extension does not mean acting more slowly on urgent problems. It means dist
 
 **The Transparency Overcorrection.** Sharing every half-formed thought in the spirit of openness. Uncertainty stays fine; broadcasting uncertainty without framing creates anxiety. Be honest about what you do not know, but anchor it to your planned next step.
 
-**The Prior Leader Shadow.** Every conversation beginning with implicit comparison to the person before you. Whether your predecessor earned love or contempt, the job remains your own and stops short of correcting for them.
+**The Prior Leader Shadow.** Every conversation beginning with implicit comparison to the person before you. Whether your predecessor earned love or contempt, the job remains being you; do not become a corrective for them.
 
 **The Premature All-Hands.** Scheduling a team all-hands before you have had 1:1s with everyone whose work you will mention. You will say something wrong about someone's work or role you would have known to avoid if you had met with them first.
 


### PR DESCRIPTION
# transitions/ — voice + factual-accuracy sweep (folder 14 of 14 — final)

Closes #12.

Folder 14 of 14 — **final folder in the sweep**. Three files, 653 lines:
- `inheriting-a-team.md` (205L)
- `new-hire-onboarding-framework.md` (250L)
- `new-leader-30-60-90.md` (198L)

Rule basis: [`playbook_writer_briefing.md`](https://github.com/brownm09/career-playbook/blob/main/context/playbook_writer_briefing.md) (career-playbook); FA anchor: [`accomplishments.md`](https://github.com/brownm09/career-playbook/blob/main/context/accomplishments.md).

Carry-forwards 1–17 in force. Two NEW carry-forwards from folder 13: (16) semantic-equivalent substitution check (`only` ≈ `just`); (17) downstream-reference grep after structural recasts.

---

## Factual-Accuracy Pass

All empirical claims map cleanly to `accomplishments.md` L31 (ActBlue platform directorate scope) and L10 (CTA dates). No 🚩.

- `inheriting-a-team.md` L13: "ActBlue platform directorate transition (2022)" + "approximately twenty engineers across six teams" — ✅ anchored (accomplishments L31: "Platform directorate of approximately 20 IC engineers across 6 teams")
- `inheriting-a-team.md` L13: "CTA transition (2025)" + "smaller team with a longer prior-leader tenure and more explicit institutional memory" — ✅ dates anchored (accomplishments L10: Sep 2025–Apr 2026); qualitative residue ("smaller team", "longer prior-leader tenure") consistent with the CTA reorientation context recorded at L21.
- `new-hire-onboarding-framework.md` L13: "onboarding multiple engineers into platform and payments teams at ActBlue (2022–2025)" + "scaling onboarding across six platform teams" — ✅ anchored
- `new-hire-onboarding-framework.md` L13: "CTA (2025–2026)" + "smaller team with less standardized infrastructure" + "creating structure where very little existed" — ✅ dates anchored; "less standardized infrastructure" and "very little existed" qualitative — consistent with accomplishments L14–L24 (12-month roadmap, feature lifecycle process *revision*, team reorientation)
- `new-leader-30-60-90.md` L13: "platform directorate at ActBlue Technical Services (2022)" + "approximately twenty engineers across six teams in payments, infrastructure, compliance, and developer experience" — ✅ scale anchored (L31); domain list maps to chartered teams (L50: DevEx, Payments Architecture, Database Platform) + PCI deprecation (L41) + Heroku→K8s (L40)
- `new-leader-30-60-90.md` L13: "Community Tech Alliance (2025)... smaller org with a narrower scope but different organizational maturity" — ✅ dates anchored; qualitative consistent

**No 🚩 in FA pass. Carry-forward 14 (cross-file propagation grep) confirms: no transitions file introduces a new claim requiring README propagation.**

---

## Carry-forward "5-person SRE team" + "12-person rotation" — final disposition

Per the folder-13 stub note, this was the LAST candidate folder. Result: **transitions/ surfaces no new instances.** The claims live in:
- `incident-management/on-call-restructuring-framework.md` L9/L15/L32/L37 (shipped folder 6, PR #40)
- `README.md` L125 (shipped folder 6 propagation)

`accomplishments.md` L57 records "On-call restructuring" but no team size or IC count. Resolution requires either (a) Mike confirms + anchors in career-playbook `accomplishments.md`, or (b) recant + recast tech-leadership-reference. **Out of scope for this PR — entirely a career-playbook follow-up.**

---

## Voice Pass — dispositions

### H-T1: Banned-token sweep (`actually`, `rather than`, `just`, `simply`, `not only`)

13 hits across 3 files. All Default A: drop or restructure.

- `inheriting-a-team.md` L7 "are actually tests" → "tests"
- `inheriting-a-team.md` L13 "were actually ambivalence tests" → "were ambivalence tests"
- `inheriting-a-team.md` L48 "relieved rather than uncertain — which is a warning sign, not a green light" → recast (covers H-T2 X-not-Y too): "relieved instead of uncertain; warmth is a warning sign here"
- `inheriting-a-team.md` L74 "rather than managed around" → "instead of managed around"
- `inheriting-a-team.md` L183 (template prose, untouchable per Guardrail 4 — structural element) — **leave**
- `inheriting-a-team.md` L196 "rather than your own performance" → "instead of your own performance"
- `new-hire-onboarding-framework.md` L72 "not just approval" → drop `just` ("not approval alone")
- `new-hire-onboarding-framework.md` L84 "not just tasks" → "not tasks"
- `new-hire-onboarding-framework.md` L209 (Buddy Guide template — structural) — **leave**
- `new-hire-onboarding-framework.md` L244 "just to get something in" — quoted excuse; semantic part of the anti-pattern — leave the word, drop the broader pattern only if voice requires. **Default A: leave (quoted speech, not playbook voice).**
- `new-hire-onboarding-framework.md` L250 "rather than a ramp" + "rather than supported" → "instead of a ramp" / "instead of supported"
- `new-leader-30-60-90.md` L19 "actually different from your predecessor" → drop `actually`
- `new-leader-30-60-90.md` L70 "rather than just collecting impressions" → "instead of collecting impressions"

> **Disposition A (default):** apply mechanical drop/replace on all 11 substantive hits; leave 2 template-prose hits (L183 + L209) untouched per Guardrail 4.
> **Disposition B:** semantic recast for any hit where Default A reads stiff.

### H-T2: Superlatives (`-est`, `most ` + adj)

~20 hits. All Default A: replace with non-graded language or drop the qualifier.

Representative pattern: "the hardest scenario" → "a difficult scenario"; "the most consequential early-tenure decisions" → "consequential early-tenure decisions"; "the most common new hire anti-pattern" → "a common new hire anti-pattern"; "the most costly mistake" → "a costly mistake"; "the biggest problem" (in template question wording) — **leave per Guardrail 4 (template/agenda content)**; "the most senior IC" → "a senior IC"; "the best buddy" → "a good buddy"; "the three strongest things" → "three strengths"; "the three biggest gaps" → "three gaps".

> **Disposition A (default):** apply non-graded replacements across all hits in narrative prose; **leave template-prose superlatives** (the 1:1 agenda questions, the assessment outline placeholders) untouched per Guardrail 4. That covers `new-leader-30-60-90.md` L38 ("biggest problem"), L173–L178 (template questions), L184–L191 (template placeholders).
> **Disposition B:** apply semantic recast where Default A loses force.

### H-T3: Copular X-not-Y aphorisms and "this, not that" constructions

The two files lean heavily on `X is Y` and `X, not Y` cadences. Targets:

- `inheriting-a-team.md` L5 "are filtered through that history whether you know it or not" — copular `are` carrying weight; recast: "filter through that history"
- `inheriting-a-team.md` L7 "Trust is not absent — it is present and allocated to a predecessor." — X-not-Y + em-dash + double `is`. Recast: "Trust is allocated to a predecessor, not absent." → still X-not-Y. Better: "The team's trust sits with the predecessor."
- `inheriting-a-team.md` L31 "This is the hardest scenario." — handled in H-T2
- `inheriting-a-team.md` L86 / L88 "The wrong answer: ..." / "The right answer: ..." — directive scaffolding; tolerable but the embedded "This sounds diplomatic and lands as evasive" carries copular `sounds`. **Leave the scaffolding; tighten the explanations.**
- `inheriting-a-team.md` L193 (Clean Slate anti-pattern) "Warmth in week one is not trust. It is hospitality." — classic X-not-Y stack. Recast: "Warmth in week one is hospitality."
- `new-hire-onboarding-framework.md` L7 "these are information delivery mechanisms, not onboarding frameworks" — copular X-not-Y. Recast: "these deliver information; they do not constitute onboarding."
- `new-hire-onboarding-framework.md` L34 "This is a peer engineer, not a senior leader." → "Assign a peer engineer, not a senior leader."
- `new-hire-onboarding-framework.md` L36 "is treated as signal of engagement, not evidence of gap" → "registers as engagement, not gap"
- `new-hire-onboarding-framework.md` L117 "Hiding in the first month is not humility; it is a failure of the environment to create safety for participation." — X-not-Y. Recast: "Hiding in the first month signals an environment that has not created safety for participation."
- `new-leader-30-60-90.md` L29 "are not heard as good ideas — they are heard as a signal..." — X-not-Y + em-dash. Recast: "land as a signal about whether you are safe to disagree with, not as good ideas." → still X-not-Y. Better: "land as a signal about whether you are safe to disagree with."
- `new-leader-30-60-90.md` L51 "They are not enemies; they are reasonable people..." — X-not-Y. Recast: "They are reasonable people with evidence that change does not always go well."

> **Disposition B (default):** semantic recast each instance (drop the negation half; let the positive claim stand alone). Carry-forward 13 (X-not-Y → assertion) applies.
> **Disposition A:** leave (preserve rhythmic emphasis).

### H-T4: `that` relative pronoun

Mass occurrences (31 / 22 / 21). All Default A: rewrite each relative clause with `this`, the specific noun, an adjective, or a participial.

This is the highest-volume voice fix in the folder. Many are "the X that Y..." — convert to "X Y-ing..." or restructure as separate clauses.

> **Disposition A (default):** sweep mechanically file-by-file with file-final grep to confirm 0 hits on `\bthat\b` outside quoted speech or template prose.
> **Disposition B:** preserve in any sentence where rewording loses precision — flag for re-review.

### H-T5: Per-H2 em-dash + parens budget

Spot-check shows multiple H2 sections exceed the one-em-dash budget. Examples:
- `inheriting-a-team.md` Part 1 (`## Reading the Room`): 3 em-dashes across L33/L80/L88
- `new-leader-30-60-90.md` Part 1 (`## The Listening Tour`): 4+ em-dashes
- `new-hire-onboarding-framework.md` `## The 30-Day Ramp`: multiple em-dashes across phases

> **Disposition A (default):** keep the highest-impact em-dash per H2; convert the rest to comma pairs, colons, or separate sentences. Applies after H-T3 since X-not-Y recasts often eliminate em-dashes incidentally.

### F-A1: No FA disposition required (no 🚩 surfaced)

---

## Cross-file propagation surfaces

`README.md` index entries for these 3 files at L62–L78 — check for retired claims after edit pass. Pre-edit grep on the carry-forward strings: 1 hit on "5-person SRE team" (README L125, out-of-scope per above).

---

## Voice-pass execution order (after dispositions)

1. H-T3 + H-T5 first (structural recasts affect em-dash counts and X-not-Y eliminations)
2. H-T4 (`that` sweep) per-file with mid-pass grep
3. H-T2 (superlatives) per-file
4. H-T1 (mechanical token drops) per-file
5. Folder-wide cleanup grep
6. README propagation check
7. `/review`

---

**Refs #12 — final folder, closes the issue on merge.**
