### PR TITLE
fix: recast five-person key-person risk in ma-tdd opening example

### DIFF
--- a/strategy/ma-technical-due-diligence.md
+++ b/strategy/ma-technical-due-diligence.md
@@ -2,7 +2,7 @@
 
 ## Leadership Context
 
-Technical due diligence is among the moments when an engineering leader's judgment directly shapes a business transaction. The quality of the technical assessment shapes acquisition price negotiation, integration budget, and — decisively — the timeline at which the combined engineering org will be able to move as a single unit after close. A diligence process that misses a $2M infrastructure migration, a GPL licensing exposure, or a five-person key-person risk does not fail in diligence; it fails 18 months post-close, when the cost is paid under integration pressure, at premium.
+Technical due diligence is among the moments when an engineering leader's judgment directly shapes a business transaction. The quality of the technical assessment shapes acquisition price negotiation, integration budget, and — decisively — the timeline at which the combined engineering org will be able to move as a single unit after close. A diligence process that misses a $2M infrastructure migration, a GPL licensing exposure, or a key-person risk concentrated in a small acquired team does not fail in diligence; it fails 18 months post-close, when the cost is paid under integration pressure, at premium.
 
 The business outcome: thorough technical diligence reduces integration risk, produces defensible inputs to purchase price adjustments, and gives the post-close engineering leadership team a credible integration plan on day one instead of day 60.
 


### PR DESCRIPTION
## Summary

- Recasts the M&A due-diligence opening example from "a five-person key-person risk" to "a key-person risk concentrated in a small acquired team"
- Removes the numeric pattern that grep flags during future sweeps without losing the illustrative meaning
- The original was a generic hypothetical, not a biographical claim

## Context

Flagged during the #12 voice + FA sweep (explicitly out of scope at the time). Tracked in [career-playbook#283](https://github.com/brownm09/career-playbook/issues/283) Part 2. Disposition chosen: recast to eliminate future grep noise.

## Test plan

- [ ] Verify L5 of `strategy/ma-technical-due-diligence.md` reads cleanly without the numeric
- [ ] Confirm "five-person" no longer appears in the file

Closes [career-playbook#283](https://github.com/brownm09/career-playbook/issues/283) Part 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)